### PR TITLE
Convert MCP tools to plugin skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -60,6 +60,27 @@
         "simctl"
       ],
       "license": "MIT"
+    },
+    {
+      "name": "XcodeBuild",
+      "version": "0.1.0",
+      "description": "Build, test, and manage Xcode projects and workspaces - discover projects, list schemes, build for simulators and devices, run tests, and diagnose environment issues",
+      "source": "./XcodeBuild",
+      "author": {
+        "name": "Gustavo Ambrozio"
+      },
+      "keywords": [
+        "xcode",
+        "xcodebuild",
+        "ios",
+        "macos",
+        "swift",
+        "build",
+        "test",
+        "device",
+        "development"
+      ],
+      "license": "MIT"
     }
   ]
 }

--- a/XcodeBuild/.claude-plugin/plugin.json
+++ b/XcodeBuild/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "XcodeBuild",
+  "version": "0.1.0",
+  "description": "Build, test, and manage Xcode projects and workspaces - discover projects, list schemes, build for simulators and devices, run tests, and diagnose environment issues",
+  "author": {
+    "name": "Gustavo Ambrozio"
+  },
+  "keywords": [
+    "xcode",
+    "xcodebuild",
+    "ios",
+    "macos",
+    "swift",
+    "build",
+    "test",
+    "device",
+    "development"
+  ],
+  "license": "MIT"
+}

--- a/XcodeBuild/skills/xcode-build/SKILL.md
+++ b/XcodeBuild/skills/xcode-build/SKILL.md
@@ -1,0 +1,415 @@
+---
+name: xcode-build
+description: Build, test, and manage Xcode projects and workspaces. Use this skill whenever you need to discover projects, list schemes, build for simulators or devices, run tests, or diagnose environment issues. Works with xcodebuild command-line tool.
+---
+
+# Xcode Build Management
+
+Build, test, and manage Xcode projects and workspaces using command-line tools. This skill provides scripts for common Xcode operations without requiring an MCP server.
+
+## Prerequisites
+
+- macOS with Xcode installed
+- Xcode Command Line Tools (`xcode-select --install`)
+- Python 3 (pre-installed on macOS)
+
+## Running the Scripts
+
+- All scripts are executable with proper shebang - no need to prefix with `python3`
+- All scripts are in the `scripts/` directory
+- All scripts output JSON with a `success` boolean field
+- All scripts have proper docstrings explaining arguments
+
+## Quick Start Workflow
+
+```bash
+# 1. Diagnose your environment
+scripts/xc-doctor.py
+
+# 2. Find Xcode projects in current directory
+scripts/xc-discover.py
+
+# 3. List schemes in a workspace
+scripts/xc-schemes.py --workspace MyApp.xcworkspace
+
+# 4. Build for iOS Simulator
+scripts/xc-build.py --workspace MyApp.xcworkspace --scheme MyApp \
+    --destination 'platform=iOS Simulator,name=iPhone 15'
+
+# 5. Run tests
+scripts/xc-test.py --workspace MyApp.xcworkspace --scheme MyAppTests \
+    --destination 'platform=iOS Simulator,name=iPhone 15'
+```
+
+## Script Reference
+
+All scripts are in `scripts/` and output JSON.
+
+### Environment & Discovery
+
+#### xc-doctor.py
+Diagnose your Xcode development environment.
+
+```bash
+# Basic diagnostics
+scripts/xc-doctor.py
+
+# Verbose (includes CocoaPods, Homebrew)
+scripts/xc-doctor.py --verbose
+```
+
+**Checks:** Xcode version, Swift version, simulators, connected devices, DerivedData size.
+
+#### xc-discover.py
+Find Xcode projects and workspaces in a directory.
+
+```bash
+# Search current directory
+scripts/xc-discover.py
+
+# Search specific path
+scripts/xc-discover.py --path /path/to/code
+
+# Limit depth
+scripts/xc-discover.py --path ~/Projects --max-depth 3
+```
+
+#### xc-schemes.py
+List available schemes in a project or workspace.
+
+```bash
+# From workspace
+scripts/xc-schemes.py --workspace MyApp.xcworkspace
+
+# From project
+scripts/xc-schemes.py --project MyApp.xcodeproj
+```
+
+#### xc-settings.py
+Show build settings for a scheme.
+
+```bash
+# Key settings only
+scripts/xc-settings.py --workspace MyApp.xcworkspace --scheme MyApp
+
+# All settings as JSON
+scripts/xc-settings.py --workspace MyApp.xcworkspace --scheme MyApp --json
+
+# Filter by pattern
+scripts/xc-settings.py --workspace MyApp.xcworkspace --scheme MyApp --filter "BUNDLE"
+```
+
+### Building
+
+#### xc-build.py
+Build a project or workspace for any destination.
+
+```bash
+# Build for iOS Simulator
+scripts/xc-build.py --workspace MyApp.xcworkspace --scheme MyApp \
+    --destination 'platform=iOS Simulator,name=iPhone 15'
+
+# Build for specific simulator by UUID
+scripts/xc-build.py --workspace MyApp.xcworkspace --scheme MyApp \
+    --destination 'id=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'
+
+# Build for macOS
+scripts/xc-build.py --workspace MyApp.xcworkspace --scheme MyApp \
+    --destination 'platform=macOS'
+
+# Build for physical device
+scripts/xc-build.py --workspace MyApp.xcworkspace --scheme MyApp \
+    --destination 'platform=iOS,id=DEVICE-UDID'
+
+# Clean build with Release configuration
+scripts/xc-build.py --workspace MyApp.xcworkspace --scheme MyApp \
+    --destination 'platform=iOS Simulator,name=iPhone 15' \
+    --configuration Release --clean
+
+# Generic build (any simulator)
+scripts/xc-build.py --workspace MyApp.xcworkspace --scheme MyApp \
+    --destination 'generic/platform=iOS Simulator'
+```
+
+**Destination Formats:**
+| Target | Destination Format |
+|--------|-------------------|
+| Named Simulator | `platform=iOS Simulator,name=iPhone 15` |
+| Simulator by UUID | `id=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX` |
+| Physical Device | `platform=iOS,id=DEVICE-UDID` |
+| macOS | `platform=macOS` |
+| Any iOS Simulator | `generic/platform=iOS Simulator` |
+| Any iOS Device | `generic/platform=iOS` |
+
+### Testing
+
+#### xc-test.py
+Run tests for a project or workspace.
+
+```bash
+# Run all tests
+scripts/xc-test.py --workspace MyApp.xcworkspace --scheme MyAppTests \
+    --destination 'platform=iOS Simulator,name=iPhone 15'
+
+# Run specific test
+scripts/xc-test.py --workspace MyApp.xcworkspace --scheme MyAppTests \
+    --destination 'platform=iOS Simulator,name=iPhone 15' \
+    --only-testing 'MyAppTests/LoginTests/testLogin'
+
+# Skip specific tests
+scripts/xc-test.py --workspace MyApp.xcworkspace --scheme MyAppTests \
+    --destination 'platform=iOS Simulator,name=iPhone 15' \
+    --skip-testing 'MyAppTests/SlowTests'
+
+# Parallel tests with retry
+scripts/xc-test.py --workspace MyApp.xcworkspace --scheme MyAppTests \
+    --destination 'platform=iOS Simulator,name=iPhone 15' \
+    --parallel --retry-count 2
+```
+
+### Device Management
+
+#### xc-devices.py
+List connected physical Apple devices.
+
+```bash
+# List all devices
+scripts/xc-devices.py
+
+# List only available (paired) devices
+scripts/xc-devices.py --available
+
+# Raw JSON output
+scripts/xc-devices.py --json-raw
+```
+
+#### xc-device-install.py
+Install an app on a physical device.
+
+```bash
+scripts/xc-device-install.py --device DEVICE-UDID --app /path/to/MyApp.app
+```
+
+#### xc-device-launch.py
+Launch an app on a physical device.
+
+```bash
+scripts/xc-device-launch.py --device DEVICE-UDID --bundle-id com.example.MyApp
+```
+
+#### xc-device-stop.py
+Stop a running app on a physical device.
+
+```bash
+scripts/xc-device-stop.py --device DEVICE-UDID --bundle-id com.example.MyApp
+```
+
+### Cleaning
+
+#### xc-clean.py
+Clean build products and DerivedData.
+
+```bash
+# Clean a specific scheme
+scripts/xc-clean.py --workspace MyApp.xcworkspace --scheme MyApp
+
+# View DerivedData info
+scripts/xc-clean.py --derived-data
+
+# Clean ALL DerivedData
+scripts/xc-clean.py --derived-data --all
+```
+
+## Common Workflows
+
+### Build and Install on Simulator
+
+```bash
+# 1. Find a simulator
+# (Use iOSSimulator plugin's sim-list.py if available)
+xcrun simctl list devices available | grep iPhone
+
+# 2. Build for that simulator
+scripts/xc-build.py --workspace MyApp.xcworkspace --scheme MyApp \
+    --destination 'platform=iOS Simulator,name=iPhone 15'
+
+# 3. Install and launch
+# (Use iOSSimulator plugin's sim-install.py and sim-launch.py)
+```
+
+### Build and Deploy to Physical Device
+
+```bash
+# 1. List connected devices
+scripts/xc-devices.py
+
+# 2. Build for the device
+scripts/xc-build.py --workspace MyApp.xcworkspace --scheme MyApp \
+    --destination 'platform=iOS,id=DEVICE-UDID' \
+    --configuration Release
+
+# 3. Install the app
+scripts/xc-device-install.py --device DEVICE-UDID \
+    --app ~/Library/Developer/Xcode/DerivedData/MyApp-xxx/Build/Products/Release-iphoneos/MyApp.app
+
+# 4. Launch the app
+scripts/xc-device-launch.py --device DEVICE-UDID --bundle-id com.example.MyApp
+```
+
+### Continuous Integration Build
+
+```bash
+# Clean, build, and test in one flow
+scripts/xc-build.py --workspace MyApp.xcworkspace --scheme MyApp \
+    --destination 'generic/platform=iOS Simulator' \
+    --configuration Release --clean
+
+scripts/xc-test.py --workspace MyApp.xcworkspace --scheme MyAppTests \
+    --destination 'platform=iOS Simulator,name=iPhone 15' \
+    --parallel
+```
+
+## JSON Output Schemas
+
+All scripts output JSON to stdout. Every response includes a `success` boolean.
+
+### Standard Success Response
+```json
+{
+  "success": true,
+  "message": "Description of what was done"
+}
+```
+
+### Standard Error Response
+```json
+{
+  "success": false,
+  "error": "Description of what went wrong",
+  "hint": "Helpful suggestion if available"
+}
+```
+
+### xc-doctor.py
+```json
+{
+  "success": true,
+  "message": "Environment check complete: healthy",
+  "status": "healthy",
+  "diagnostics": {
+    "system": { "os": "macOS", "os_version": "14.0" },
+    "xcode": { "installed": true, "version": "15.0" },
+    "swift": { "installed": true, "version": "Swift version 5.9" },
+    "simulators": { "available": true, "count": 25 },
+    "devices": { "available": true, "connected_count": 1 }
+  }
+}
+```
+
+### xc-discover.py
+```json
+{
+  "success": true,
+  "message": "Found 1 workspace(s) and 2 project(s)",
+  "workspaces": ["/path/to/MyApp.xcworkspace"],
+  "projects": ["/path/to/MyApp.xcodeproj", "/path/to/MyFramework.xcodeproj"]
+}
+```
+
+### xc-build.py (success)
+```json
+{
+  "success": true,
+  "message": "Build succeeded",
+  "scheme": "MyApp",
+  "configuration": "Debug",
+  "warning_count": 0
+}
+```
+
+### xc-build.py (failure)
+```json
+{
+  "success": false,
+  "error": "Build failed",
+  "scheme": "MyApp",
+  "error_count": 2,
+  "errors": [
+    {
+      "file": "/path/to/File.swift",
+      "line": 42,
+      "column": 10,
+      "message": "Cannot find 'foo' in scope"
+    }
+  ]
+}
+```
+
+### xc-test.py (success)
+```json
+{
+  "success": true,
+  "message": "Tests passed: 42 passed, 0 failed, 0 skipped",
+  "passed_count": 42,
+  "failed_count": 0,
+  "skipped_count": 0,
+  "execution_time": 12.5
+}
+```
+
+### xc-devices.py
+```json
+{
+  "success": true,
+  "message": "Found 1 device(s)",
+  "devices": [
+    {
+      "name": "iPhone 15 Pro",
+      "udid": "00008120-XXXXXXXXXXXX",
+      "platform": "iOS",
+      "os_version": "17.0",
+      "model": "iPhone 15 Pro",
+      "connection": "USB"
+    }
+  ]
+}
+```
+
+## Troubleshooting
+
+### "xcodebuild: error: The scheme 'X' is not configured for building"
+- Run `xc-schemes.py` to list available schemes
+- Check that the scheme is shared (Manage Schemes in Xcode)
+
+### "Unable to find a destination matching the provided specification"
+- List simulators with `xcrun simctl list devices available`
+- Use exact device name or UUID in destination
+
+### Build signing errors
+- For simulator builds: Signing is usually not required
+- For device builds: Configure signing in Xcode, or use:
+  ```bash
+  --extra-args CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+  ```
+
+### Test timeout
+- Tests have a 30-minute timeout by default
+- Long-running tests may need configuration adjustment
+
+### DerivedData taking too much space
+```bash
+# Check size
+scripts/xc-clean.py --derived-data
+
+# Clean all
+scripts/xc-clean.py --derived-data --all
+```
+
+## Integration with Other Plugins
+
+This plugin works well with:
+
+- **iOSSimulator**: Use for simulator management (boot, screenshot, UI automation)
+- **SwiftDevelopment**: Use xcsift for filtered build output
+
+When building for simulator, use iOSSimulator's `sim-list.py` to find UUIDs, then pass to `xc-build.py`.

--- a/XcodeBuild/skills/xcode-build/scripts/xc-build.py
+++ b/XcodeBuild/skills/xcode-build/scripts/xc-build.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Build an Xcode project or workspace for a specific destination.
+
+Usage:
+    xc-build.py --project <path> --scheme <name> [options]
+    xc-build.py --workspace <path> --scheme <name> [options]
+
+Options:
+    --project <path>         Path to .xcodeproj
+    --workspace <path>       Path to .xcworkspace
+    --scheme <name>          Scheme name to build
+    --destination <dest>     Build destination (see examples below)
+    --configuration <cfg>    Build configuration (Debug/Release, default: Debug)
+    --derived-data <path>    Custom DerivedData path
+    --clean                  Clean before building
+    --quiet                  Less verbose output
+    --extra-args <args>      Additional xcodebuild arguments
+
+Destination Examples:
+    Simulator: 'platform=iOS Simulator,name=iPhone 15'
+    Simulator by ID: 'id=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'
+    Device: 'platform=iOS,id=DEVICE-UDID'
+    macOS: 'platform=macOS'
+    Any iOS Simulator: 'generic/platform=iOS Simulator'
+    Any iOS Device: 'generic/platform=iOS'
+
+Output:
+    JSON object with build results, errors, and warnings
+"""
+
+import json
+import sys
+import argparse
+import os
+
+from xc_utils import (
+    run_xcodebuild, parse_build_output, success_response, error_response
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Build Xcode project')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--project', help='Path to .xcodeproj')
+    group.add_argument('--workspace', help='Path to .xcworkspace')
+    parser.add_argument('--scheme', required=True, help='Scheme name')
+    parser.add_argument('--destination', help='Build destination')
+    parser.add_argument('--configuration', default='Debug', help='Build configuration')
+    parser.add_argument('--derived-data', help='Custom DerivedData path')
+    parser.add_argument('--clean', action='store_true', help='Clean before building')
+    parser.add_argument('--quiet', action='store_true', help='Less verbose output')
+    parser.add_argument('--extra-args', nargs='*', help='Additional xcodebuild arguments')
+    args = parser.parse_args()
+
+    # Build xcodebuild command
+    cmd_args = []
+
+    if args.project:
+        path = os.path.abspath(args.project)
+        if not os.path.exists(path):
+            print(json.dumps(error_response(f'Project not found: {path}')))
+            sys.exit(1)
+        cmd_args.extend(['-project', path])
+    else:
+        path = os.path.abspath(args.workspace)
+        if not os.path.exists(path):
+            print(json.dumps(error_response(f'Workspace not found: {path}')))
+            sys.exit(1)
+        cmd_args.extend(['-workspace', path])
+
+    cmd_args.extend(['-scheme', args.scheme])
+    cmd_args.extend(['-configuration', args.configuration])
+
+    if args.destination:
+        cmd_args.extend(['-destination', args.destination])
+
+    if args.derived_data:
+        cmd_args.extend(['-derivedDataPath', os.path.abspath(args.derived_data)])
+
+    # Add recommended flags to avoid common issues
+    cmd_args.extend(['-skipMacroValidation', '-skipPackagePluginValidation'])
+
+    if args.quiet:
+        cmd_args.append('-quiet')
+
+    if args.extra_args:
+        cmd_args.extend(args.extra_args)
+
+    # Determine action
+    if args.clean:
+        cmd_args.extend(['clean', 'build'])
+    else:
+        cmd_args.append('build')
+
+    # Run build
+    success, stdout, stderr = run_xcodebuild(*cmd_args)
+
+    # Parse output
+    parsed = parse_build_output(stdout, stderr)
+
+    if success and parsed['build_succeeded']:
+        response = success_response(
+            'Build succeeded',
+            scheme=args.scheme,
+            configuration=args.configuration,
+            destination=args.destination,
+            warnings=parsed['warnings'] if parsed['warnings'] else None,
+            warning_count=parsed['warning_count']
+        )
+
+        # Remove None values
+        response = {k: v for k, v in response.items() if v is not None}
+
+        print(json.dumps(response, indent=2))
+    else:
+        response = error_response(
+            'Build failed',
+            scheme=args.scheme,
+            configuration=args.configuration,
+            destination=args.destination,
+            errors=parsed['errors'],
+            warnings=parsed['warnings'] if parsed['warnings'] else None,
+            error_count=parsed['error_count'],
+            warning_count=parsed['warning_count']
+        )
+
+        # Add raw output if no structured errors found
+        if not parsed['errors']:
+            # Get last 50 lines of output for context
+            combined = stdout + '\n' + stderr
+            lines = combined.strip().split('\n')
+            response['output_tail'] = '\n'.join(lines[-50:])
+
+        # Remove None values
+        response = {k: v for k, v in response.items() if v is not None}
+
+        print(json.dumps(response, indent=2))
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/XcodeBuild/skills/xcode-build/scripts/xc-clean.py
+++ b/XcodeBuild/skills/xcode-build/scripts/xc-clean.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Clean Xcode build products and DerivedData.
+
+Usage:
+    xc-clean.py --project <path> --scheme <name>
+    xc-clean.py --workspace <path> --scheme <name>
+    xc-clean.py --derived-data [--all]
+
+Options:
+    --project <path>         Path to .xcodeproj
+    --workspace <path>       Path to .xcworkspace
+    --scheme <name>          Scheme name to clean
+    --derived-data           Clean DerivedData folder
+    --all                    Clean all DerivedData (use with --derived-data)
+    --path <path>            Specific DerivedData path to clean
+
+Output:
+    JSON object with clean operation results
+"""
+
+import json
+import sys
+import argparse
+import os
+import shutil
+
+from xc_utils import run_xcodebuild, get_derived_data_path, success_response, error_response
+
+
+def clean_derived_data(path: str = None, all_data: bool = False) -> dict:
+    """Clean DerivedData folder."""
+    derived_data_path = path or get_derived_data_path()
+
+    if not os.path.exists(derived_data_path):
+        return success_response(
+            'DerivedData folder does not exist',
+            path=derived_data_path
+        )
+
+    if all_data:
+        # Remove everything in DerivedData
+        try:
+            # Get size before cleaning
+            total_size = 0
+            for dirpath, dirnames, filenames in os.walk(derived_data_path):
+                for f in filenames:
+                    fp = os.path.join(dirpath, f)
+                    try:
+                        total_size += os.path.getsize(fp)
+                    except (OSError, IOError):
+                        pass
+
+            # Remove contents
+            for item in os.listdir(derived_data_path):
+                item_path = os.path.join(derived_data_path, item)
+                if os.path.isdir(item_path):
+                    shutil.rmtree(item_path)
+                else:
+                    os.remove(item_path)
+
+            size_mb = total_size / (1024 * 1024)
+            return success_response(
+                f'Cleaned all DerivedData ({size_mb:.1f} MB freed)',
+                path=derived_data_path,
+                bytes_freed=total_size
+            )
+        except Exception as e:
+            return error_response(f'Failed to clean DerivedData: {e}')
+    else:
+        # Just report what's there
+        items = []
+        total_size = 0
+        try:
+            for item in os.listdir(derived_data_path):
+                item_path = os.path.join(derived_data_path, item)
+                if os.path.isdir(item_path):
+                    # Get folder size
+                    size = 0
+                    for dirpath, dirnames, filenames in os.walk(item_path):
+                        for f in filenames:
+                            fp = os.path.join(dirpath, f)
+                            try:
+                                size += os.path.getsize(fp)
+                            except (OSError, IOError):
+                                pass
+                    total_size += size
+                    items.append({
+                        'name': item,
+                        'size_bytes': size,
+                        'size_mb': round(size / (1024 * 1024), 1)
+                    })
+        except Exception as e:
+            return error_response(f'Failed to scan DerivedData: {e}')
+
+        return success_response(
+            f'DerivedData contains {len(items)} items ({total_size / (1024 * 1024):.1f} MB)',
+            path=derived_data_path,
+            items=items,
+            total_size_bytes=total_size,
+            hint='Use --all to clean all DerivedData'
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Clean Xcode build products')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--project', help='Path to .xcodeproj')
+    group.add_argument('--workspace', help='Path to .xcworkspace')
+    group.add_argument('--derived-data', action='store_true', help='Clean DerivedData folder')
+    parser.add_argument('--scheme', help='Scheme name to clean')
+    parser.add_argument('--all', action='store_true', help='Clean all DerivedData')
+    parser.add_argument('--path', help='Specific DerivedData path')
+    args = parser.parse_args()
+
+    # Handle DerivedData cleaning
+    if args.derived_data:
+        result = clean_derived_data(args.path, args.all)
+        print(json.dumps(result, indent=2))
+        if not result.get('success'):
+            sys.exit(1)
+        return
+
+    # Handle project/workspace cleaning
+    if not args.project and not args.workspace:
+        print(json.dumps(error_response(
+            'Either --project, --workspace, or --derived-data is required'
+        )))
+        sys.exit(1)
+
+    if not args.scheme:
+        print(json.dumps(error_response('--scheme is required for project/workspace cleaning')))
+        sys.exit(1)
+
+    # Build xcodebuild command
+    cmd_args = []
+
+    if args.project:
+        path = os.path.abspath(args.project)
+        if not os.path.exists(path):
+            print(json.dumps(error_response(f'Project not found: {path}')))
+            sys.exit(1)
+        cmd_args.extend(['-project', path])
+    else:
+        path = os.path.abspath(args.workspace)
+        if not os.path.exists(path):
+            print(json.dumps(error_response(f'Workspace not found: {path}')))
+            sys.exit(1)
+        cmd_args.extend(['-workspace', path])
+
+    cmd_args.extend(['-scheme', args.scheme])
+    cmd_args.append('clean')
+
+    # Run clean
+    success, stdout, stderr = run_xcodebuild(*cmd_args)
+
+    if success:
+        print(json.dumps(success_response(
+            'Clean succeeded',
+            scheme=args.scheme
+        ), indent=2))
+    else:
+        print(json.dumps(error_response(
+            f'Clean failed: {stderr.strip()}',
+            scheme=args.scheme
+        ), indent=2))
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/XcodeBuild/skills/xcode-build/scripts/xc-device-install.py
+++ b/XcodeBuild/skills/xcode-build/scripts/xc-device-install.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Install an app on a connected physical device.
+
+Usage:
+    xc-device-install.py --device <udid> --app <path>
+
+Options:
+    --device <udid>    Device UDID (from xc-devices.py)
+    --app <path>       Path to .app bundle
+
+Output:
+    JSON object with installation result
+"""
+
+import json
+import sys
+import argparse
+import os
+import tempfile
+import plistlib
+
+from xc_utils import run_xcrun, success_response, error_response
+
+
+def get_bundle_id(app_path: str) -> str:
+    """Extract bundle ID from app's Info.plist."""
+    info_plist = os.path.join(app_path, 'Info.plist')
+    if not os.path.exists(info_plist):
+        return None
+
+    try:
+        with open(info_plist, 'rb') as f:
+            plist = plistlib.load(f)
+            return plist.get('CFBundleIdentifier')
+    except Exception:
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Install app on device')
+    parser.add_argument('--device', required=True, help='Device UDID')
+    parser.add_argument('--app', required=True, help='Path to .app bundle')
+    args = parser.parse_args()
+
+    app_path = os.path.abspath(args.app)
+
+    if not os.path.exists(app_path):
+        print(json.dumps(error_response(f'App not found: {app_path}')))
+        sys.exit(1)
+
+    if not app_path.endswith('.app'):
+        print(json.dumps(error_response('Path must be a .app bundle')))
+        sys.exit(1)
+
+    # Get bundle ID for reference
+    bundle_id = get_bundle_id(app_path)
+
+    # Try devicectl first (Xcode 15+)
+    success, stdout, stderr = run_xcrun(
+        'devicectl', 'device', 'install', 'app',
+        '--device', args.device,
+        app_path
+    )
+
+    if success:
+        response = success_response(
+            'App installed successfully',
+            device_udid=args.device,
+            app_path=app_path,
+            bundle_id=bundle_id
+        )
+        if bundle_id:
+            response['next_steps'] = [
+                f'Launch with: xc-device-launch.py --device {args.device} --bundle-id {bundle_id}'
+            ]
+        print(json.dumps(response, indent=2))
+        return
+
+    # Check for specific errors
+    if 'unable to locate device' in stderr.lower() or 'device not found' in stderr.lower():
+        print(json.dumps(error_response(
+            f'Device not found: {args.device}',
+            hint='Use xc-devices.py to list connected devices'
+        )))
+        sys.exit(1)
+
+    if 'signing' in stderr.lower() or 'codesign' in stderr.lower():
+        print(json.dumps(error_response(
+            'Code signing error',
+            details=stderr.strip(),
+            hint='Ensure the app is signed for development and device is registered'
+        )))
+        sys.exit(1)
+
+    print(json.dumps(error_response(
+        f'Failed to install app: {stderr.strip()}',
+        device_udid=args.device,
+        app_path=app_path
+    )))
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/XcodeBuild/skills/xcode-build/scripts/xc-device-launch.py
+++ b/XcodeBuild/skills/xcode-build/scripts/xc-device-launch.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Launch an app on a connected physical device.
+
+Usage:
+    xc-device-launch.py --device <udid> --bundle-id <id>
+
+Options:
+    --device <udid>       Device UDID (from xc-devices.py)
+    --bundle-id <id>      App bundle identifier
+
+Output:
+    JSON object with launch result
+"""
+
+import json
+import sys
+import argparse
+import tempfile
+import os
+
+from xc_utils import run_xcrun, success_response, error_response
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Launch app on device')
+    parser.add_argument('--device', required=True, help='Device UDID')
+    parser.add_argument('--bundle-id', required=True, help='App bundle identifier')
+    args = parser.parse_args()
+
+    # Create temp file for JSON output
+    with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+        json_path = f.name
+
+    try:
+        # Use devicectl to launch with terminate-existing
+        success, stdout, stderr = run_xcrun(
+            'devicectl', 'device', 'process', 'launch',
+            '--device', args.device,
+            '--terminate-existing',
+            '--json-output', json_path,
+            args.bundle_id
+        )
+
+        if success:
+            # Try to get process ID from JSON output
+            pid = None
+            if os.path.exists(json_path):
+                try:
+                    with open(json_path, 'r') as f:
+                        data = json.load(f)
+                        result = data.get('result', {})
+                        pid = result.get('processID') or result.get('process', {}).get('processIdentifier')
+                except (json.JSONDecodeError, KeyError):
+                    pass
+
+            response = success_response(
+                'App launched successfully',
+                device_udid=args.device,
+                bundle_id=args.bundle_id,
+                process_id=pid
+            )
+
+            response['next_steps'] = [
+                f'Stop with: xc-device-stop.py --device {args.device} --bundle-id {args.bundle_id}'
+            ]
+
+            print(json.dumps(response, indent=2))
+            return
+
+        # Check for specific errors
+        if 'unable to locate device' in stderr.lower():
+            print(json.dumps(error_response(
+                f'Device not found: {args.device}',
+                hint='Use xc-devices.py to list connected devices'
+            )))
+            sys.exit(1)
+
+        if 'app not installed' in stderr.lower() or 'no installed app' in stderr.lower():
+            print(json.dumps(error_response(
+                f'App not installed: {args.bundle_id}',
+                hint='Use xc-device-install.py to install the app first'
+            )))
+            sys.exit(1)
+
+        print(json.dumps(error_response(
+            f'Failed to launch app: {stderr.strip()}',
+            device_udid=args.device,
+            bundle_id=args.bundle_id
+        )))
+        sys.exit(1)
+
+    finally:
+        if os.path.exists(json_path):
+            os.unlink(json_path)
+
+
+if __name__ == '__main__':
+    main()

--- a/XcodeBuild/skills/xcode-build/scripts/xc-device-stop.py
+++ b/XcodeBuild/skills/xcode-build/scripts/xc-device-stop.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Stop a running app on a connected physical device.
+
+Usage:
+    xc-device-stop.py --device <udid> --bundle-id <id>
+
+Options:
+    --device <udid>       Device UDID (from xc-devices.py)
+    --bundle-id <id>      App bundle identifier
+
+Output:
+    JSON object with stop result
+"""
+
+import json
+import sys
+import argparse
+
+from xc_utils import run_xcrun, success_response, error_response
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Stop app on device')
+    parser.add_argument('--device', required=True, help='Device UDID')
+    parser.add_argument('--bundle-id', required=True, help='App bundle identifier')
+    args = parser.parse_args()
+
+    # Use devicectl to terminate
+    success, stdout, stderr = run_xcrun(
+        'devicectl', 'device', 'process', 'terminate',
+        '--device', args.device,
+        args.bundle_id
+    )
+
+    if success:
+        print(json.dumps(success_response(
+            'App stopped successfully',
+            device_udid=args.device,
+            bundle_id=args.bundle_id
+        ), indent=2))
+        return
+
+    # Check if app was not running (treat as success)
+    if 'not running' in stderr.lower() or 'no such process' in stderr.lower():
+        print(json.dumps(success_response(
+            'App was not running',
+            device_udid=args.device,
+            bundle_id=args.bundle_id
+        ), indent=2))
+        return
+
+    # Check for device errors
+    if 'unable to locate device' in stderr.lower():
+        print(json.dumps(error_response(
+            f'Device not found: {args.device}',
+            hint='Use xc-devices.py to list connected devices'
+        )))
+        sys.exit(1)
+
+    print(json.dumps(error_response(
+        f'Failed to stop app: {stderr.strip()}',
+        device_udid=args.device,
+        bundle_id=args.bundle_id
+    )))
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/XcodeBuild/skills/xcode-build/scripts/xc-devices.py
+++ b/XcodeBuild/skills/xcode-build/scripts/xc-devices.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+List connected Apple devices (iPhone, iPad, Apple Watch, etc.).
+
+Usage:
+    xc-devices.py [--available] [--json-raw]
+
+Options:
+    --available    Show only available (paired) devices
+    --json-raw     Output raw devicectl JSON
+
+Output:
+    JSON object with list of connected devices
+"""
+
+import json
+import sys
+import argparse
+import tempfile
+import os
+
+from xc_utils import run_xcrun, run_command, success_response, error_response
+
+
+def parse_device_info(device: dict) -> dict:
+    """Extract relevant device information from devicectl output."""
+    hardware = device.get('hardwareProperties', {})
+    device_props = device.get('deviceProperties', {})
+    connection = device.get('connectionProperties', {})
+
+    # Determine platform
+    platform_id = hardware.get('platform', '').lower()
+    platform_map = {
+        'iphoneos': 'iOS',
+        'ipados': 'iPadOS',
+        'watchos': 'watchOS',
+        'tvos': 'tvOS',
+        'xros': 'visionOS',
+    }
+    platform = platform_map.get(platform_id, platform_id.upper() if platform_id else 'Unknown')
+
+    # Determine connection type
+    transport = connection.get('transportType', '').lower()
+    is_wifi = 'wifi' in transport or 'network' in transport
+
+    # Check pairing/availability
+    is_paired = device_props.get('developerModeStatus', '') == 'enabled' or \
+                connection.get('pairingState', '') == 'paired'
+
+    return {
+        'name': device_props.get('name', 'Unknown'),
+        'udid': device.get('identifier', ''),
+        'platform': platform,
+        'os_version': device_props.get('osVersionNumber', ''),
+        'model': hardware.get('marketingName', hardware.get('deviceType', 'Unknown')),
+        'model_id': hardware.get('productType', ''),
+        'architecture': hardware.get('cpuType', {}).get('name', ''),
+        'connection': 'WiFi' if is_wifi else 'USB',
+        'is_paired': is_paired,
+        'available': is_paired,
+    }
+
+
+def list_devices_devicectl() -> tuple:
+    """List devices using xcrun devicectl (modern method, Xcode 15+)."""
+    with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+        json_path = f.name
+
+    try:
+        success, stdout, stderr = run_xcrun(
+            'devicectl', 'list', 'devices', '--json-output', json_path
+        )
+
+        if not success:
+            return None, f'devicectl failed: {stderr}'
+
+        if not os.path.exists(json_path):
+            return None, 'devicectl did not produce output'
+
+        with open(json_path, 'r') as f:
+            data = json.load(f)
+
+        return data, None
+    except json.JSONDecodeError as e:
+        return None, f'Failed to parse devicectl output: {e}'
+    finally:
+        if os.path.exists(json_path):
+            os.unlink(json_path)
+
+
+def list_devices_xctrace() -> tuple:
+    """List devices using xcrun xctrace (fallback method)."""
+    success, stdout, stderr = run_xcrun('xctrace', 'list', 'devices')
+
+    if not success:
+        return None, f'xctrace failed: {stderr}'
+
+    devices = []
+    lines = stdout.strip().split('\n')
+
+    for line in lines:
+        line = line.strip()
+        # Skip headers and simulators
+        if not line or line.startswith('==') or 'Simulator' in line:
+            continue
+
+        # Parse device line: "Name (OS Version) (UDID)"
+        # Example: "iPhone 15 Pro (17.0) (00008120-000000000000000E)"
+        import re
+        match = re.match(r'^(.+?)\s+\(([^)]+)\)\s+\(([A-F0-9-]+)\)$', line)
+        if match:
+            devices.append({
+                'name': match.group(1).strip(),
+                'os_version': match.group(2),
+                'udid': match.group(3),
+                'platform': 'iOS',  # xctrace doesn't distinguish
+                'connection': 'Unknown',
+                'available': True,
+            })
+
+    return {'devices': devices}, None
+
+
+def main():
+    parser = argparse.ArgumentParser(description='List connected Apple devices')
+    parser.add_argument('--available', action='store_true', help='Show only available devices')
+    parser.add_argument('--json-raw', action='store_true', help='Output raw JSON from devicectl')
+    args = parser.parse_args()
+
+    # Try modern devicectl first
+    data, error = list_devices_devicectl()
+
+    # Fall back to xctrace if devicectl fails
+    if data is None:
+        data, error = list_devices_xctrace()
+
+        if data is None:
+            print(json.dumps(error_response(
+                f'Failed to list devices: {error}',
+                hint='Ensure Xcode is installed and a device is connected'
+            )))
+            sys.exit(1)
+
+        # xctrace returns simpler format
+        devices = data.get('devices', [])
+        if args.available:
+            devices = [d for d in devices if d.get('available', True)]
+
+        print(json.dumps(success_response(
+            f'Found {len(devices)} device(s) (via xctrace)',
+            method='xctrace',
+            devices=devices,
+            count=len(devices)
+        ), indent=2))
+        return
+
+    if args.json_raw:
+        print(json.dumps(data, indent=2))
+        return
+
+    # Parse devicectl output
+    result = data.get('result', {})
+    raw_devices = result.get('devices', [])
+
+    devices = []
+    for raw_device in raw_devices:
+        # Skip simulators
+        hardware = raw_device.get('hardwareProperties', {})
+        if hardware.get('deviceType', '').lower() == 'simulator':
+            continue
+
+        device = parse_device_info(raw_device)
+        devices.append(device)
+
+    if args.available:
+        devices = [d for d in devices if d.get('available', False)]
+
+    # Group by connection type
+    usb_devices = [d for d in devices if d.get('connection') == 'USB']
+    wifi_devices = [d for d in devices if d.get('connection') == 'WiFi']
+
+    response = success_response(
+        f'Found {len(devices)} device(s)',
+        method='devicectl',
+        devices=devices,
+        count=len(devices),
+        by_connection={
+            'usb': len(usb_devices),
+            'wifi': len(wifi_devices)
+        }
+    )
+
+    if not devices:
+        response['hint'] = 'Connect a device via USB or enable WiFi debugging'
+
+    print(json.dumps(response, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/XcodeBuild/skills/xcode-build/scripts/xc-discover.py
+++ b/XcodeBuild/skills/xcode-build/scripts/xc-discover.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+Discover Xcode projects and workspaces in a directory.
+
+Usage:
+    xc-discover.py [--path <path>] [--max-depth <n>]
+
+Options:
+    --path <path>      Directory to search (default: current directory)
+    --max-depth <n>    Maximum search depth (default: 5)
+
+Output:
+    JSON object with lists of discovered projects and workspaces
+"""
+
+import json
+import sys
+import argparse
+import os
+
+from xc_utils import find_projects, success_response, error_response
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Discover Xcode projects and workspaces')
+    parser.add_argument('--path', default='.', help='Directory to search (default: current)')
+    parser.add_argument('--max-depth', type=int, default=5, help='Maximum search depth (default: 5)')
+    args = parser.parse_args()
+
+    search_path = os.path.abspath(args.path)
+
+    if not os.path.isdir(search_path):
+        print(json.dumps(error_response(f'Directory not found: {search_path}')))
+        sys.exit(1)
+
+    result = find_projects(search_path, args.max_depth)
+
+    total = len(result['projects']) + len(result['workspaces'])
+
+    if total == 0:
+        print(json.dumps(success_response(
+            'No Xcode projects or workspaces found',
+            search_path=search_path,
+            projects=[],
+            workspaces=[]
+        )))
+        return
+
+    response = success_response(
+        f'Found {len(result["workspaces"])} workspace(s) and {len(result["projects"])} project(s)',
+        search_path=search_path,
+        workspaces=result['workspaces'],
+        projects=result['projects'],
+        total_count=total
+    )
+
+    # Add recommendation
+    if result['workspaces']:
+        response['recommendation'] = 'Use a workspace (-workspace) when available, as it includes all dependencies'
+
+    print(json.dumps(response, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/XcodeBuild/skills/xcode-build/scripts/xc-doctor.py
+++ b/XcodeBuild/skills/xcode-build/scripts/xc-doctor.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""
+Diagnose Xcode development environment and report issues.
+
+Usage:
+    xc-doctor.py [--verbose]
+
+Options:
+    --verbose    Show detailed information
+
+Output:
+    JSON object with environment diagnostics
+"""
+
+import json
+import sys
+import argparse
+import os
+import platform
+
+from xc_utils import (
+    run_command, run_xcrun, get_xcode_path, get_xcode_version,
+    get_macos_version, get_available_platforms, get_derived_data_path,
+    success_response, error_response
+)
+
+
+def check_xcode_cli_tools() -> dict:
+    """Check if Xcode Command Line Tools are installed."""
+    success, stdout, stderr = run_command(['xcode-select', '-p'])
+    if success:
+        return {
+            'installed': True,
+            'path': stdout.strip()
+        }
+    return {
+        'installed': False,
+        'hint': 'Install with: xcode-select --install'
+    }
+
+
+def check_xcode() -> dict:
+    """Check Xcode installation."""
+    version_info = get_xcode_version()
+    if version_info:
+        xcode_path = get_xcode_path()
+        return {
+            'installed': True,
+            'version': version_info.get('xcode'),
+            'build': version_info.get('build'),
+            'path': xcode_path
+        }
+    return {
+        'installed': False,
+        'hint': 'Install Xcode from the App Store'
+    }
+
+
+def check_simulators() -> dict:
+    """Check available simulators."""
+    success, stdout, stderr = run_xcrun('simctl', 'list', 'devices', '-j')
+    if not success:
+        return {
+            'available': False,
+            'error': stderr.strip()
+        }
+
+    try:
+        data = json.loads(stdout)
+        devices = data.get('devices', {})
+
+        available_count = 0
+        booted_count = 0
+        runtimes = set()
+
+        for runtime, device_list in devices.items():
+            for device in device_list:
+                if device.get('isAvailable', True):
+                    available_count += 1
+                    # Extract runtime name
+                    runtime_name = runtime.split('.')[-1].replace('-', ' ')
+                    runtimes.add(runtime_name)
+                    if device.get('state') == 'Booted':
+                        booted_count += 1
+
+        return {
+            'available': True,
+            'count': available_count,
+            'booted': booted_count,
+            'runtimes': sorted(runtimes)
+        }
+    except json.JSONDecodeError:
+        return {
+            'available': False,
+            'error': 'Failed to parse simulator list'
+        }
+
+
+def check_devices() -> dict:
+    """Check connected devices."""
+    success, stdout, stderr = run_xcrun('xctrace', 'list', 'devices')
+    if not success:
+        return {
+            'available': False,
+            'error': stderr.strip()
+        }
+
+    # Count devices (excluding simulators)
+    device_count = 0
+    for line in stdout.split('\n'):
+        line = line.strip()
+        if line and not line.startswith('==') and 'Simulator' not in line:
+            # Check if it looks like a device entry
+            if '(' in line and ')' in line:
+                device_count += 1
+
+    return {
+        'available': True,
+        'connected_count': device_count
+    }
+
+
+def check_swift() -> dict:
+    """Check Swift installation."""
+    success, stdout, stderr = run_command(['swift', '--version'])
+    if success:
+        # Parse version from output
+        version = None
+        for line in stdout.split('\n'):
+            if 'Swift version' in line:
+                version = line.strip()
+                break
+        return {
+            'installed': True,
+            'version': version
+        }
+    return {
+        'installed': False,
+        'hint': 'Swift is included with Xcode'
+    }
+
+
+def check_cocoapods() -> dict:
+    """Check CocoaPods installation."""
+    success, stdout, stderr = run_command(['pod', '--version'])
+    if success:
+        return {
+            'installed': True,
+            'version': stdout.strip()
+        }
+    return {
+        'installed': False,
+        'hint': 'Install with: sudo gem install cocoapods'
+    }
+
+
+def check_homebrew() -> dict:
+    """Check Homebrew installation."""
+    success, stdout, stderr = run_command(['brew', '--version'])
+    if success:
+        version = stdout.split('\n')[0].strip()
+        return {
+            'installed': True,
+            'version': version
+        }
+    return {
+        'installed': False,
+        'hint': 'Install from: https://brew.sh'
+    }
+
+
+def check_derived_data() -> dict:
+    """Check DerivedData folder."""
+    path = get_derived_data_path()
+    if os.path.exists(path):
+        # Calculate size
+        total_size = 0
+        item_count = 0
+        for dirpath, dirnames, filenames in os.walk(path):
+            for f in filenames:
+                fp = os.path.join(dirpath, f)
+                try:
+                    total_size += os.path.getsize(fp)
+                except (OSError, IOError):
+                    pass
+            item_count += len(dirnames) + len(filenames)
+
+        return {
+            'exists': True,
+            'path': path,
+            'size_bytes': total_size,
+            'size_mb': round(total_size / (1024 * 1024), 1),
+            'item_count': item_count
+        }
+    return {
+        'exists': False,
+        'path': path
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Diagnose Xcode environment')
+    parser.add_argument('--verbose', action='store_true', help='Show detailed information')
+    args = parser.parse_args()
+
+    # Gather diagnostics
+    diagnostics = {
+        'system': {
+            'os': 'macOS',
+            'os_version': platform.mac_ver()[0],
+            'architecture': platform.machine(),
+            **get_macos_version()
+        },
+        'xcode_cli_tools': check_xcode_cli_tools(),
+        'xcode': check_xcode(),
+        'swift': check_swift(),
+        'simulators': check_simulators(),
+        'devices': check_devices(),
+        'derived_data': check_derived_data(),
+    }
+
+    if args.verbose:
+        diagnostics['platforms'] = get_available_platforms()
+        diagnostics['cocoapods'] = check_cocoapods()
+        diagnostics['homebrew'] = check_homebrew()
+
+    # Determine overall status
+    issues = []
+
+    if not diagnostics['xcode_cli_tools'].get('installed'):
+        issues.append('Xcode Command Line Tools not installed')
+
+    if not diagnostics['xcode'].get('installed'):
+        issues.append('Xcode not installed')
+
+    if not diagnostics['swift'].get('installed'):
+        issues.append('Swift not available')
+
+    if diagnostics['simulators'].get('count', 0) == 0:
+        issues.append('No simulators available')
+
+    # Build response
+    status = 'healthy' if not issues else 'issues_found'
+
+    response = success_response(
+        f'Environment check complete: {status}',
+        status=status,
+        issues=issues if issues else None,
+        diagnostics=diagnostics
+    )
+
+    # Remove None values
+    response = {k: v for k, v in response.items() if v is not None}
+
+    print(json.dumps(response, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/XcodeBuild/skills/xcode-build/scripts/xc-schemes.py
+++ b/XcodeBuild/skills/xcode-build/scripts/xc-schemes.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+List available schemes in an Xcode project or workspace.
+
+Usage:
+    xc-schemes.py --project <path>
+    xc-schemes.py --workspace <path>
+
+Options:
+    --project <path>     Path to .xcodeproj
+    --workspace <path>   Path to .xcworkspace
+
+Output:
+    JSON object with list of available schemes
+"""
+
+import json
+import sys
+import argparse
+import os
+
+from xc_utils import run_xcodebuild, parse_schemes_output, success_response, error_response
+
+
+def main():
+    parser = argparse.ArgumentParser(description='List Xcode schemes')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--project', help='Path to .xcodeproj')
+    group.add_argument('--workspace', help='Path to .xcworkspace')
+    args = parser.parse_args()
+
+    # Build xcodebuild command
+    cmd_args = ['-list']
+
+    if args.project:
+        path = os.path.abspath(args.project)
+        if not os.path.exists(path):
+            print(json.dumps(error_response(f'Project not found: {path}')))
+            sys.exit(1)
+        cmd_args.extend(['-project', path])
+        target_type = 'project'
+        target_path = path
+    else:
+        path = os.path.abspath(args.workspace)
+        if not os.path.exists(path):
+            print(json.dumps(error_response(f'Workspace not found: {path}')))
+            sys.exit(1)
+        cmd_args.extend(['-workspace', path])
+        target_type = 'workspace'
+        target_path = path
+
+    success, stdout, stderr = run_xcodebuild(*cmd_args)
+
+    if not success:
+        print(json.dumps(error_response(
+            f'Failed to list schemes: {stderr.strip()}',
+            command=f'xcodebuild {" ".join(cmd_args)}'
+        )))
+        sys.exit(1)
+
+    schemes = parse_schemes_output(stdout)
+
+    if not schemes:
+        print(json.dumps(success_response(
+            'No schemes found',
+            target_type=target_type,
+            path=target_path,
+            schemes=[],
+            raw_output=stdout
+        )))
+        return
+
+    response = success_response(
+        f'Found {len(schemes)} scheme(s)',
+        target_type=target_type,
+        path=target_path,
+        schemes=schemes
+    )
+
+    print(json.dumps(response, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/XcodeBuild/skills/xcode-build/scripts/xc-settings.py
+++ b/XcodeBuild/skills/xcode-build/scripts/xc-settings.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Show build settings for an Xcode scheme.
+
+Usage:
+    xc-settings.py --project <path> --scheme <name> [--filter <pattern>]
+    xc-settings.py --workspace <path> --scheme <name> [--filter <pattern>]
+
+Options:
+    --project <path>     Path to .xcodeproj
+    --workspace <path>   Path to .xcworkspace
+    --scheme <name>      Scheme name
+    --filter <pattern>   Filter settings by pattern (case-insensitive)
+    --json               Output raw settings as JSON (default: formatted)
+
+Output:
+    JSON object with build settings
+"""
+
+import json
+import sys
+import argparse
+import os
+import re
+
+from xc_utils import run_xcodebuild, parse_build_settings, success_response, error_response
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Show Xcode build settings')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--project', help='Path to .xcodeproj')
+    group.add_argument('--workspace', help='Path to .xcworkspace')
+    parser.add_argument('--scheme', required=True, help='Scheme name')
+    parser.add_argument('--filter', help='Filter settings by pattern')
+    parser.add_argument('--json', action='store_true', help='Output as JSON')
+    args = parser.parse_args()
+
+    # Build xcodebuild command
+    cmd_args = ['-showBuildSettings']
+
+    if args.project:
+        path = os.path.abspath(args.project)
+        if not os.path.exists(path):
+            print(json.dumps(error_response(f'Project not found: {path}')))
+            sys.exit(1)
+        cmd_args.extend(['-project', path])
+    else:
+        path = os.path.abspath(args.workspace)
+        if not os.path.exists(path):
+            print(json.dumps(error_response(f'Workspace not found: {path}')))
+            sys.exit(1)
+        cmd_args.extend(['-workspace', path])
+
+    cmd_args.extend(['-scheme', args.scheme])
+
+    success, stdout, stderr = run_xcodebuild(*cmd_args)
+
+    if not success:
+        print(json.dumps(error_response(
+            f'Failed to get build settings: {stderr.strip()}',
+            hint='Check that the scheme name is correct. Use xc-schemes.py to list available schemes.'
+        )))
+        sys.exit(1)
+
+    settings = parse_build_settings(stdout)
+
+    if not settings:
+        print(json.dumps(error_response('No build settings found')))
+        sys.exit(1)
+
+    # Filter if requested
+    if args.filter:
+        pattern = re.compile(args.filter, re.IGNORECASE)
+        settings = {k: v for k, v in settings.items() if pattern.search(k)}
+
+    # Extract key settings for summary
+    key_settings = {
+        'PRODUCT_NAME': settings.get('PRODUCT_NAME'),
+        'PRODUCT_BUNDLE_IDENTIFIER': settings.get('PRODUCT_BUNDLE_IDENTIFIER'),
+        'INFOPLIST_FILE': settings.get('INFOPLIST_FILE'),
+        'SWIFT_VERSION': settings.get('SWIFT_VERSION'),
+        'IPHONEOS_DEPLOYMENT_TARGET': settings.get('IPHONEOS_DEPLOYMENT_TARGET'),
+        'MACOSX_DEPLOYMENT_TARGET': settings.get('MACOSX_DEPLOYMENT_TARGET'),
+        'SDKROOT': settings.get('SDKROOT'),
+        'BUILD_DIR': settings.get('BUILD_DIR'),
+        'DERIVED_DATA_DIR': settings.get('DERIVED_DATA_DIR'),
+        'CODE_SIGN_IDENTITY': settings.get('CODE_SIGN_IDENTITY'),
+        'DEVELOPMENT_TEAM': settings.get('DEVELOPMENT_TEAM'),
+    }
+
+    # Remove None values
+    key_settings = {k: v for k, v in key_settings.items() if v is not None}
+
+    response = success_response(
+        f'Retrieved {len(settings)} build settings',
+        scheme=args.scheme,
+        key_settings=key_settings,
+        all_settings=settings if args.json or args.filter else None,
+        settings_count=len(settings)
+    )
+
+    # Remove None values from response
+    response = {k: v for k, v in response.items() if v is not None}
+
+    print(json.dumps(response, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/XcodeBuild/skills/xcode-build/scripts/xc-test.py
+++ b/XcodeBuild/skills/xcode-build/scripts/xc-test.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+Run tests for an Xcode project or workspace.
+
+Usage:
+    xc-test.py --project <path> --scheme <name> [options]
+    xc-test.py --workspace <path> --scheme <name> [options]
+
+Options:
+    --project <path>         Path to .xcodeproj
+    --workspace <path>       Path to .xcworkspace
+    --scheme <name>          Scheme name with tests
+    --destination <dest>     Test destination
+    --configuration <cfg>    Build configuration (Debug/Release, default: Debug)
+    --only-testing <spec>    Run only specific tests (e.g., 'MyTests/TestClass/testMethod')
+    --skip-testing <spec>    Skip specific tests
+    --parallel               Run tests in parallel
+    --retry-count <n>        Number of test retries on failure
+    --result-bundle <path>   Path to save result bundle
+    --quiet                  Less verbose output
+
+Output:
+    JSON object with test results, pass/fail counts, errors
+"""
+
+import json
+import sys
+import argparse
+import os
+import re
+
+from xc_utils import run_xcodebuild, parse_build_output, success_response, error_response
+
+
+def parse_test_output(stdout: str, stderr: str) -> dict:
+    """Parse xcodebuild test output to extract test results."""
+    combined = stdout + '\n' + stderr
+
+    # Parse test results
+    test_results = {
+        'passed': [],
+        'failed': [],
+        'skipped': [],
+    }
+
+    # Test case patterns
+    # Test Case '-[MyTests testExample]' passed (0.001 seconds).
+    # Test Case '-[MyTests testExample]' failed (0.001 seconds).
+    passed_pattern = re.compile(r"Test Case '([^']+)' passed")
+    failed_pattern = re.compile(r"Test Case '([^']+)' failed")
+    skipped_pattern = re.compile(r"Test Case '([^']+)' skipped")
+
+    for match in passed_pattern.finditer(combined):
+        test_results['passed'].append(match.group(1))
+
+    for match in failed_pattern.finditer(combined):
+        test_results['failed'].append(match.group(1))
+
+    for match in skipped_pattern.finditer(combined):
+        test_results['skipped'].append(match.group(1))
+
+    # Extract failure details
+    failure_details = []
+    failure_pattern = re.compile(
+        r'(.+?):(\d+): error: ([^\n]+)',
+        re.MULTILINE
+    )
+    for match in failure_pattern.finditer(combined):
+        failure_details.append({
+            'file': match.group(1),
+            'line': int(match.group(2)),
+            'message': match.group(3)
+        })
+
+    # Check for test summary
+    test_succeeded = '** TEST SUCCEEDED **' in combined
+    test_failed = '** TEST FAILED **' in combined
+
+    # Extract execution time if available
+    time_match = re.search(r'Test session results: (.+?) passed in (\d+\.\d+)', combined)
+    execution_time = float(time_match.group(2)) if time_match else None
+
+    return {
+        'test_succeeded': test_succeeded,
+        'test_failed': test_failed,
+        'passed': test_results['passed'],
+        'failed': test_results['failed'],
+        'skipped': test_results['skipped'],
+        'passed_count': len(test_results['passed']),
+        'failed_count': len(test_results['failed']),
+        'skipped_count': len(test_results['skipped']),
+        'failure_details': failure_details,
+        'execution_time': execution_time
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Run Xcode tests')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--project', help='Path to .xcodeproj')
+    group.add_argument('--workspace', help='Path to .xcworkspace')
+    parser.add_argument('--scheme', required=True, help='Scheme name')
+    parser.add_argument('--destination', help='Test destination')
+    parser.add_argument('--configuration', default='Debug', help='Build configuration')
+    parser.add_argument('--only-testing', action='append', help='Run only specific tests')
+    parser.add_argument('--skip-testing', action='append', help='Skip specific tests')
+    parser.add_argument('--parallel', action='store_true', help='Run tests in parallel')
+    parser.add_argument('--retry-count', type=int, help='Number of test retries')
+    parser.add_argument('--result-bundle', help='Path to save result bundle')
+    parser.add_argument('--quiet', action='store_true', help='Less verbose output')
+    args = parser.parse_args()
+
+    # Build xcodebuild command
+    cmd_args = []
+
+    if args.project:
+        path = os.path.abspath(args.project)
+        if not os.path.exists(path):
+            print(json.dumps(error_response(f'Project not found: {path}')))
+            sys.exit(1)
+        cmd_args.extend(['-project', path])
+    else:
+        path = os.path.abspath(args.workspace)
+        if not os.path.exists(path):
+            print(json.dumps(error_response(f'Workspace not found: {path}')))
+            sys.exit(1)
+        cmd_args.extend(['-workspace', path])
+
+    cmd_args.extend(['-scheme', args.scheme])
+    cmd_args.extend(['-configuration', args.configuration])
+
+    if args.destination:
+        cmd_args.extend(['-destination', args.destination])
+
+    # Add recommended flags
+    cmd_args.extend(['-skipMacroValidation', '-skipPackagePluginValidation'])
+
+    if args.only_testing:
+        for test in args.only_testing:
+            cmd_args.extend(['-only-testing', test])
+
+    if args.skip_testing:
+        for test in args.skip_testing:
+            cmd_args.extend(['-skip-testing', test])
+
+    if args.parallel:
+        cmd_args.append('-parallel-testing-enabled')
+        cmd_args.append('YES')
+
+    if args.retry_count:
+        cmd_args.extend(['-retry-tests-on-failure', '-test-iterations', str(args.retry_count)])
+
+    if args.result_bundle:
+        cmd_args.extend(['-resultBundlePath', os.path.abspath(args.result_bundle)])
+
+    if args.quiet:
+        cmd_args.append('-quiet')
+
+    cmd_args.append('test')
+
+    # Run tests
+    success, stdout, stderr = run_xcodebuild(*cmd_args, timeout=1800)  # 30 min timeout
+
+    # Parse results
+    test_results = parse_test_output(stdout, stderr)
+    build_results = parse_build_output(stdout, stderr)
+
+    if test_results['test_succeeded']:
+        response = success_response(
+            f"Tests passed: {test_results['passed_count']} passed, {test_results['failed_count']} failed, {test_results['skipped_count']} skipped",
+            scheme=args.scheme,
+            passed_count=test_results['passed_count'],
+            failed_count=test_results['failed_count'],
+            skipped_count=test_results['skipped_count'],
+            execution_time=test_results['execution_time'],
+            passed=test_results['passed'] if len(test_results['passed']) <= 20 else None,
+            skipped=test_results['skipped'] if test_results['skipped'] else None,
+        )
+
+        # Remove None values
+        response = {k: v for k, v in response.items() if v is not None}
+
+        print(json.dumps(response, indent=2))
+    else:
+        response = error_response(
+            f"Tests failed: {test_results['passed_count']} passed, {test_results['failed_count']} failed",
+            scheme=args.scheme,
+            passed_count=test_results['passed_count'],
+            failed_count=test_results['failed_count'],
+            skipped_count=test_results['skipped_count'],
+            failed=test_results['failed'],
+            failure_details=test_results['failure_details'] if test_results['failure_details'] else None,
+            build_errors=build_results['errors'] if build_results['errors'] else None
+        )
+
+        # Remove None values
+        response = {k: v for k, v in response.items() if v is not None}
+
+        # Add output tail if no structured results
+        if not test_results['failed'] and not test_results['failure_details']:
+            combined = stdout + '\n' + stderr
+            lines = combined.strip().split('\n')
+            response['output_tail'] = '\n'.join(lines[-50:])
+
+        print(json.dumps(response, indent=2))
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/XcodeBuild/skills/xcode-build/scripts/xc_utils.py
+++ b/XcodeBuild/skills/xcode-build/scripts/xc_utils.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""
+Shared utilities for Xcode build scripts.
+
+This module contains common functions used across multiple xc-*.py scripts
+to reduce code duplication and ensure consistent behavior.
+"""
+
+import subprocess
+import json
+import os
+import re
+from pathlib import Path
+from typing import Optional, Tuple, List, Dict, Any
+
+
+def run_command(cmd: List[str], cwd: Optional[str] = None,
+                timeout: Optional[int] = None) -> Tuple[bool, str, str]:
+    """
+    Run a command and return result.
+
+    Args:
+        cmd: Command and arguments as a list
+        cwd: Working directory for the command
+        timeout: Timeout in seconds
+
+    Returns:
+        Tuple of (success: bool, stdout: str, stderr: str)
+    """
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=timeout
+        )
+        return result.returncode == 0, result.stdout, result.stderr
+    except subprocess.TimeoutExpired:
+        return False, '', f'Command timed out after {timeout} seconds'
+    except FileNotFoundError:
+        return False, '', f'Command not found: {cmd[0]}'
+    except Exception as e:
+        return False, '', str(e)
+
+
+def run_xcodebuild(*args, cwd: Optional[str] = None,
+                   timeout: Optional[int] = 600) -> Tuple[bool, str, str]:
+    """
+    Run xcodebuild command and return result.
+
+    Args:
+        *args: Arguments to pass to xcodebuild
+        cwd: Working directory
+        timeout: Timeout in seconds (default 10 minutes)
+
+    Returns:
+        Tuple of (success: bool, stdout: str, stderr: str)
+    """
+    cmd = ['xcodebuild'] + list(args)
+    return run_command(cmd, cwd=cwd, timeout=timeout)
+
+
+def run_xcrun(*args, cwd: Optional[str] = None) -> Tuple[bool, str, str]:
+    """
+    Run xcrun command and return result.
+
+    Args:
+        *args: Arguments to pass to xcrun
+        cwd: Working directory
+
+    Returns:
+        Tuple of (success: bool, stdout: str, stderr: str)
+    """
+    cmd = ['xcrun'] + list(args)
+    return run_command(cmd, cwd=cwd)
+
+
+def get_xcode_path() -> Optional[str]:
+    """Get the path to the active Xcode installation."""
+    success, stdout, _ = run_command(['xcode-select', '-p'])
+    if success:
+        return stdout.strip()
+    return None
+
+
+def get_xcode_version() -> Optional[Dict[str, str]]:
+    """Get Xcode version information."""
+    success, stdout, _ = run_command(['xcodebuild', '-version'])
+    if not success:
+        return None
+
+    lines = stdout.strip().split('\n')
+    version_info = {}
+
+    for line in lines:
+        if line.startswith('Xcode'):
+            version_info['xcode'] = line.replace('Xcode ', '').strip()
+        elif line.startswith('Build version'):
+            version_info['build'] = line.replace('Build version ', '').strip()
+
+    return version_info if version_info else None
+
+
+def get_macos_version() -> Dict[str, str]:
+    """Get macOS version information."""
+    success, stdout, _ = run_command(['sw_vers'])
+    if not success:
+        return {}
+
+    version_info = {}
+    for line in stdout.strip().split('\n'):
+        if ':' in line:
+            key, value = line.split(':', 1)
+            version_info[key.strip().lower().replace(' ', '_')] = value.strip()
+
+    return version_info
+
+
+def find_projects(root_path: str, max_depth: int = 5) -> Dict[str, List[str]]:
+    """
+    Find Xcode projects and workspaces in a directory.
+
+    Args:
+        root_path: Root directory to search
+        max_depth: Maximum directory depth to search
+
+    Returns:
+        Dict with 'projects' and 'workspaces' lists
+    """
+    projects = []
+    workspaces = []
+
+    root = Path(root_path).resolve()
+
+    # Directories to skip
+    skip_dirs = {
+        'build', 'DerivedData', 'Pods', '.git', 'node_modules',
+        'Carthage', '.build', '.swiftpm', 'xcuserdata'
+    }
+
+    def search(path: Path, depth: int):
+        if depth > max_depth:
+            return
+
+        try:
+            for entry in path.iterdir():
+                if entry.is_symlink():
+                    continue
+
+                if entry.is_dir():
+                    name = entry.name
+
+                    if name in skip_dirs:
+                        continue
+
+                    if name.endswith('.xcodeproj'):
+                        projects.append(str(entry))
+                    elif name.endswith('.xcworkspace'):
+                        # Skip workspace inside xcodeproj
+                        if not str(entry.parent).endswith('.xcodeproj'):
+                            workspaces.append(str(entry))
+                    else:
+                        search(entry, depth + 1)
+        except PermissionError:
+            pass
+
+    search(root, 0)
+
+    return {
+        'projects': sorted(projects),
+        'workspaces': sorted(workspaces)
+    }
+
+
+def parse_schemes_output(stdout: str) -> List[str]:
+    """
+    Parse xcodebuild -list output to extract schemes.
+
+    Args:
+        stdout: Output from xcodebuild -list
+
+    Returns:
+        List of scheme names
+    """
+    schemes = []
+    in_schemes_section = False
+
+    for line in stdout.split('\n'):
+        line = line.strip()
+
+        if line == 'Schemes:':
+            in_schemes_section = True
+            continue
+
+        if in_schemes_section:
+            if not line or line.endswith(':'):
+                break
+            schemes.append(line)
+
+    return schemes
+
+
+def parse_build_settings(stdout: str) -> Dict[str, str]:
+    """
+    Parse xcodebuild -showBuildSettings output.
+
+    Args:
+        stdout: Output from xcodebuild -showBuildSettings
+
+    Returns:
+        Dict of build settings
+    """
+    settings = {}
+
+    for line in stdout.split('\n'):
+        line = line.strip()
+        if ' = ' in line:
+            key, value = line.split(' = ', 1)
+            settings[key.strip()] = value.strip()
+
+    return settings
+
+
+def parse_build_output(stdout: str, stderr: str) -> Dict[str, Any]:
+    """
+    Parse xcodebuild output to extract errors, warnings, and results.
+
+    Args:
+        stdout: Standard output from xcodebuild
+        stderr: Standard error from xcodebuild
+
+    Returns:
+        Dict with parsed build information
+    """
+    combined = stdout + '\n' + stderr
+
+    errors = []
+    warnings = []
+
+    # Error patterns
+    error_pattern = re.compile(r'^(.+?):(\d+):(\d+): error: (.+)$', re.MULTILINE)
+    warning_pattern = re.compile(r'^(.+?):(\d+):(\d+): warning: (.+)$', re.MULTILINE)
+
+    for match in error_pattern.finditer(combined):
+        errors.append({
+            'file': match.group(1),
+            'line': int(match.group(2)),
+            'column': int(match.group(3)),
+            'message': match.group(4)
+        })
+
+    for match in warning_pattern.finditer(combined):
+        warnings.append({
+            'file': match.group(1),
+            'line': int(match.group(2)),
+            'column': int(match.group(3)),
+            'message': match.group(4)
+        })
+
+    # Check for build succeeded/failed
+    build_succeeded = '** BUILD SUCCEEDED **' in combined
+    build_failed = '** BUILD FAILED **' in combined
+    test_succeeded = '** TEST SUCCEEDED **' in combined
+    test_failed = '** TEST FAILED **' in combined
+
+    return {
+        'errors': errors,
+        'warnings': warnings,
+        'error_count': len(errors),
+        'warning_count': len(warnings),
+        'build_succeeded': build_succeeded,
+        'build_failed': build_failed,
+        'test_succeeded': test_succeeded,
+        'test_failed': test_failed
+    }
+
+
+def get_derived_data_path() -> str:
+    """Get the default DerivedData path."""
+    return os.path.expanduser('~/Library/Developer/Xcode/DerivedData')
+
+
+def get_available_platforms() -> List[str]:
+    """Get list of available SDK platforms."""
+    success, stdout, _ = run_xcodebuild('-showsdks')
+    if not success:
+        return []
+
+    platforms = set()
+    for line in stdout.split('\n'):
+        # Look for SDK names like "iOS 17.0", "macOS 14.0", etc.
+        for platform in ['iOS', 'macOS', 'watchOS', 'tvOS', 'visionOS']:
+            if platform.lower() in line.lower():
+                platforms.add(platform)
+
+    return sorted(platforms)
+
+
+# Common error messages and hints
+BUILD_ERROR_HINTS = {
+    'Signing for': 'Configure code signing in Xcode or add CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO',
+    'No account for team': 'Sign in to your Apple Developer account in Xcode',
+    'No profiles for': 'Create a provisioning profile in Apple Developer portal',
+    'module not found': 'Run pod install or swift package resolve',
+    'No such module': 'Missing dependency - check Package.swift or Podfile',
+    'Command PhaseScriptExecution failed': 'A build phase script failed - check the build logs',
+    'Unable to find a destination': 'Specify a valid destination with -destination',
+}
+
+
+def get_error_hint(error_message: str) -> Optional[str]:
+    """Get a helpful hint for a known error message."""
+    for pattern, hint in BUILD_ERROR_HINTS.items():
+        if pattern.lower() in error_message.lower():
+            return hint
+    return None
+
+
+def json_output(data: Dict[str, Any], indent: int = 2) -> str:
+    """Format data as JSON string."""
+    return json.dumps(data, indent=indent)
+
+
+def success_response(message: str, **kwargs) -> Dict[str, Any]:
+    """Create a standard success response."""
+    return {'success': True, 'message': message, **kwargs}
+
+
+def error_response(error: str, **kwargs) -> Dict[str, Any]:
+    """Create a standard error response."""
+    hint = get_error_hint(error)
+    response = {'success': False, 'error': error, **kwargs}
+    if hint:
+        response['hint'] = hint
+    return response


### PR DESCRIPTION
New plugin that reimplements XcodeBuildMCP functionality as skills:

- xc-discover.py: Find Xcode projects and workspaces
- xc-schemes.py: List available build schemes
- xc-settings.py: Show build settings for a scheme
- xc-build.py: Build for simulator, device, or macOS
- xc-test.py: Run tests with filtering and parallel support
- xc-devices.py: List connected physical devices
- xc-device-install.py: Install apps on devices
- xc-device-launch.py: Launch apps on devices
- xc-device-stop.py: Stop running apps on devices
- xc-clean.py: Clean build products and DerivedData
- xc-doctor.py: Diagnose development environment

All scripts output JSON and are executable without python prefix.