### PR TITLE
Convert MCP tools to plugin skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,6 +77,26 @@
         "templates"
       ],
       "license": "MIT"
+    },
+    {
+      "name": "XcodeBuildTools",
+      "version": "0.1.0",
+      "description": "Xcode build tools for iOS, macOS, and Swift development - build, test, run, and manage simulators and devices",
+      "source": "./XcodeBuildTools",
+      "author": {
+        "name": "Gustavo Ambrozio"
+      },
+      "keywords": [
+        "xcode",
+        "ios",
+        "macos",
+        "swift",
+        "build",
+        "simulator",
+        "device",
+        "testing"
+      ],
+      "license": "MIT"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ Adds Marvin the Paranoid Android personality from *The Hitchhiker's Guide to the
 
 [View Plugin Documentation →](./MarvinOutputStyle/README.md)
 
+### XcodeBuildTools
+
+A comprehensive set of skills for Xcode development, reimplementing [XcodeBuildMCP](https://github.com/cameroncooke/XcodeBuildMCP) functionality as Claude Code skills. Build, test, and manage iOS/macOS apps and Swift packages without requiring an MCP server.
+
+**Includes skills for:**
+- Environment diagnostics (`xcode-doctor`)
+- Device builds (`device-build`)
+- Simulator builds (`simulator-build`)
+- Simulator management (`simulator-management`)
+- macOS builds (`macos-build`)
+- Project discovery (`project-discovery`)
+- Swift packages (`swift-package`)
+- Build cleanup (`xcode-clean`)
+
+[View Plugin Documentation →](./XcodeBuildTools/README.md)
+
 ## Contributing a Plugin
 
 Want to add your plugin to this marketplace?

--- a/XcodeBuildTools/.claude-plugin/plugin.json
+++ b/XcodeBuildTools/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "XcodeBuildTools",
+  "version": "0.1.0",
+  "description": "Xcode build tools for iOS, macOS, and Swift development - build, test, run, and manage simulators and devices",
+  "author": {"name": "Gustavo Ambrozio"},
+  "keywords": [
+    "xcode",
+    "ios",
+    "macos",
+    "swift",
+    "build",
+    "simulator",
+    "device",
+    "testing"
+  ],
+  "license": "MIT"
+}

--- a/XcodeBuildTools/README.md
+++ b/XcodeBuildTools/README.md
@@ -1,0 +1,72 @@
+# XcodeBuildTools Plugin
+
+A comprehensive set of skills for Xcode development, providing build, test, and automation capabilities for iOS, macOS, and Swift projects.
+
+## Overview
+
+This plugin reimplements the functionality of [XcodeBuildMCP](https://github.com/cameroncooke/XcodeBuildMCP) as Claude Code skills, allowing you to build, test, and manage Xcode projects without requiring an MCP server.
+
+## Prerequisites
+
+- macOS with Xcode installed
+- Xcode Command Line Tools (`xcode-select --install`)
+- Python 3 (pre-installed on macOS)
+
+## Available Skills
+
+### xcode-doctor
+Diagnose and validate your Xcode development environment.
+
+### device-build
+Build, test, and deploy apps to physical iOS devices.
+
+### simulator-build
+Build, test, and run apps on iOS simulators.
+
+### simulator-management
+Manage iOS simulators - boot, shutdown, configure location, appearance, and status bar.
+
+### macos-build
+Build, test, and run macOS applications.
+
+### project-discovery
+Discover Xcode projects, list schemes, and show build settings.
+
+### project-scaffolding
+Create new iOS and macOS project templates.
+
+### swift-package
+Build, test, run, and manage Swift packages.
+
+### ui-automation
+Automate UI interactions - tap, swipe, type, and take screenshots.
+
+### logging
+Capture and manage device and simulator logs.
+
+### xcode-clean
+Clean build products and derived data.
+
+## Installation
+
+```bash
+# Add the marketplace
+/plugin marketplace add gpambrozio/ClaudeCodePlugins
+
+# Install the plugin
+/plugin install XcodeBuildTools@ClaudeCodePlugins
+```
+
+## Usage
+
+Once installed, the skills are automatically available. Claude will use them when you ask for Xcode-related tasks like:
+
+- "Build my iOS app for the simulator"
+- "Run tests on my project"
+- "Create a new iOS project"
+- "List available simulators"
+- "Take a screenshot of the simulator"
+
+## Credits
+
+Based on [XcodeBuildMCP](https://github.com/cameroncooke/XcodeBuildMCP) by Cameron Cooke.

--- a/XcodeBuildTools/skills/device-build/SKILL.md
+++ b/XcodeBuildTools/skills/device-build/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: device-build
+description: Build, install, launch, and test iOS apps on physical Apple devices (iPhone, iPad, Apple Watch, Apple TV, Vision Pro). Use this skill when working with physical devices connected via USB or network.
+---
+
+# Device Build
+
+Build, install, and manage iOS apps on physical Apple devices.
+
+## Prerequisites
+
+- macOS with Xcode 15+ installed
+- Physical device connected via USB or paired over network
+- Valid code signing (development certificate and provisioning profile)
+
+## Scripts
+
+All scripts are in the `scripts/` directory and output JSON.
+
+### list-devices.py
+
+List connected physical Apple devices.
+
+```bash
+scripts/list-devices.py
+```
+
+Output:
+```json
+{
+  "success": true,
+  "devices": [
+    {
+      "name": "iPhone 15 Pro",
+      "udid": "00008030-001234567890",
+      "model": "iPhone 15 Pro",
+      "os_version": "17.0",
+      "connection": "USB",
+      "paired": true
+    }
+  ]
+}
+```
+
+### build-device.py
+
+Build an Xcode project/workspace for a physical device.
+
+```bash
+# Build with workspace
+scripts/build-device.py --workspace MyApp.xcworkspace --scheme MyApp --device-id <UDID>
+
+# Build with project
+scripts/build-device.py --project MyApp.xcodeproj --scheme MyApp --device-id <UDID>
+
+# Specify configuration
+scripts/build-device.py --workspace MyApp.xcworkspace --scheme MyApp --device-id <UDID> --configuration Release
+```
+
+**Parameters:**
+- `--workspace` or `--project`: Path to .xcworkspace or .xcodeproj (mutually exclusive)
+- `--scheme`: Build scheme name (required)
+- `--device-id`: Device UDID from list-devices.py (required)
+- `--configuration`: Build configuration (default: Debug)
+- `--derived-data`: Custom derived data path
+- `--extra-args`: Additional xcodebuild arguments
+
+### install-app-device.py
+
+Install an app on a connected device.
+
+```bash
+scripts/install-app-device.py --device-id <UDID> --app /path/to/MyApp.app
+```
+
+**Parameters:**
+- `--device-id`: Device UDID (required)
+- `--app`: Path to .app bundle (required)
+
+### launch-app-device.py
+
+Launch an installed app on a device.
+
+```bash
+scripts/launch-app-device.py --device-id <UDID> --bundle-id com.example.myapp
+
+# Wait for debugger
+scripts/launch-app-device.py --device-id <UDID> --bundle-id com.example.myapp --wait-for-debugger
+```
+
+**Parameters:**
+- `--device-id`: Device UDID (required)
+- `--bundle-id`: App bundle identifier (required)
+- `--wait-for-debugger`: Pause app startup waiting for debugger
+
+### stop-app-device.py
+
+Terminate a running app on a device.
+
+```bash
+scripts/stop-app-device.py --device-id <UDID> --bundle-id com.example.myapp
+```
+
+### test-device.py
+
+Run tests on a physical device.
+
+```bash
+scripts/test-device.py --workspace MyApp.xcworkspace --scheme MyAppTests --device-id <UDID>
+
+# Run specific test
+scripts/test-device.py --workspace MyApp.xcworkspace --scheme MyAppTests --device-id <UDID> --only-testing "MyAppTests/LoginTests/testSuccessfulLogin"
+```
+
+**Parameters:**
+- `--workspace` or `--project`: Path to .xcworkspace or .xcodeproj
+- `--scheme`: Test scheme name (required)
+- `--device-id`: Device UDID (required)
+- `--only-testing`: Run only specific test(s)
+- `--skip-testing`: Skip specific test(s)
+- `--configuration`: Build configuration (default: Debug)
+
+## Typical Workflow
+
+```bash
+# 1. List connected devices
+scripts/list-devices.py
+
+# 2. Build for the device
+scripts/build-device.py --workspace MyApp.xcworkspace --scheme MyApp --device-id <UDID>
+
+# 3. Install the app (if not using build-and-run)
+scripts/install-app-device.py --device-id <UDID> --app ~/Library/Developer/Xcode/DerivedData/.../MyApp.app
+
+# 4. Launch the app
+scripts/launch-app-device.py --device-id <UDID> --bundle-id com.example.myapp
+
+# 5. Run tests
+scripts/test-device.py --workspace MyApp.xcworkspace --scheme MyAppTests --device-id <UDID>
+```
+
+## Notes
+
+- Building for devices requires valid code signing
+- Use `security find-identity -v -p codesigning` to list available signing identities
+- Device UDID can be found in Finder or using `list-devices.py`
+- The `devicectl` tool (Xcode 15+) is preferred over older methods

--- a/XcodeBuildTools/skills/device-build/scripts/build-device.py
+++ b/XcodeBuildTools/skills/device-build/scripts/build-device.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Build an Xcode project/workspace for a physical iOS device.
+
+Usage:
+    ./build-device.py --workspace MyApp.xcworkspace --scheme MyApp --device-id <UDID>
+    ./build-device.py --project MyApp.xcodeproj --scheme MyApp --device-id <UDID>
+
+Options:
+    --workspace PATH     Path to .xcworkspace file
+    --project PATH       Path to .xcodeproj file
+    --scheme NAME        Build scheme name (required)
+    --device-id UDID     Device UDID (required)
+    --configuration CFG  Build configuration (default: Debug)
+    --derived-data PATH  Custom derived data path
+    --extra-args ARGS    Additional xcodebuild arguments (comma-separated)
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+
+
+def run_xcodebuild(args, timeout=600):
+    """Run xcodebuild and return parsed result."""
+    try:
+        result = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout
+        )
+
+        # Parse output for errors and warnings
+        errors = []
+        warnings = []
+
+        for line in result.stdout.split("\n") + result.stderr.split("\n"):
+            if ": error:" in line:
+                errors.append(line.strip())
+            elif ": warning:" in line:
+                warnings.append(line.strip())
+
+        return {
+            "success": result.returncode == 0,
+            "return_code": result.returncode,
+            "errors": errors[:20],  # Limit to first 20
+            "warnings": warnings[:20],
+            "error_count": len(errors),
+            "warning_count": len(warnings)
+        }
+
+    except subprocess.TimeoutExpired:
+        return {
+            "success": False,
+            "error": "Build timed out after 10 minutes"
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "error": str(e)
+        }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build for iOS device")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to .xcworkspace")
+    group.add_argument("--project", help="Path to .xcodeproj")
+    parser.add_argument("--scheme", required=True, help="Build scheme")
+    parser.add_argument("--device-id", required=True, help="Device UDID")
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--derived-data", help="Derived data path")
+    parser.add_argument("--extra-args", help="Extra xcodebuild args (comma-separated)")
+
+    args = parser.parse_args()
+
+    # Validate paths
+    if args.workspace and not os.path.exists(args.workspace):
+        print(json.dumps({"success": False, "error": f"Workspace not found: {args.workspace}"}))
+        return 1
+
+    if args.project and not os.path.exists(args.project):
+        print(json.dumps({"success": False, "error": f"Project not found: {args.project}"}))
+        return 1
+
+    # Build xcodebuild command
+    cmd = ["xcodebuild"]
+
+    if args.workspace:
+        cmd.extend(["-workspace", args.workspace])
+    else:
+        cmd.extend(["-project", args.project])
+
+    cmd.extend([
+        "-scheme", args.scheme,
+        "-configuration", args.configuration,
+        "-destination", f"id={args.device_id}",
+        "-skipMacroValidation",
+        "-skipPackagePluginValidation",
+        "build"
+    ])
+
+    if args.derived_data:
+        cmd.extend(["-derivedDataPath", args.derived_data])
+
+    if args.extra_args:
+        cmd.extend(args.extra_args.split(","))
+
+    # Run build
+    result = run_xcodebuild(cmd)
+
+    if result["success"]:
+        result["message"] = f"Build succeeded for device {args.device_id}"
+        result["scheme"] = args.scheme
+        result["configuration"] = args.configuration
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/device-build/scripts/install-app-device.py
+++ b/XcodeBuildTools/skills/device-build/scripts/install-app-device.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Install an app on a physical iOS device.
+
+Usage:
+    ./install-app-device.py --device-id <UDID> --app /path/to/MyApp.app
+
+Options:
+    --device-id UDID    Device UDID (required)
+    --app PATH          Path to .app bundle (required)
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+
+
+def run_command(cmd, timeout=120):
+    """Run a command and return result."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout
+        )
+        return result.returncode == 0, result.stdout, result.stderr
+    except subprocess.TimeoutExpired:
+        return False, "", "Command timed out"
+    except Exception as e:
+        return False, "", str(e)
+
+
+def install_with_devicectl(device_id, app_path):
+    """Install using devicectl (Xcode 15+)."""
+    success, stdout, stderr = run_command([
+        "xcrun", "devicectl", "device", "install", "app",
+        "--device", device_id,
+        app_path
+    ])
+
+    if success:
+        return {"success": True, "message": f"App installed on device {device_id}"}
+    else:
+        return {"success": False, "error": stderr or stdout or "Installation failed"}
+
+
+def install_with_ios_deploy(device_id, app_path):
+    """Fallback: Install using ios-deploy if available."""
+    success, stdout, stderr = run_command([
+        "ios-deploy", "--id", device_id, "--bundle", app_path
+    ])
+
+    if success:
+        return {"success": True, "message": f"App installed on device {device_id}"}
+    else:
+        return {"success": False, "error": stderr or stdout or "Installation failed"}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Install app on iOS device")
+    parser.add_argument("--device-id", required=True, help="Device UDID")
+    parser.add_argument("--app", required=True, help="Path to .app bundle")
+
+    args = parser.parse_args()
+
+    # Validate app path
+    if not os.path.exists(args.app):
+        print(json.dumps({"success": False, "error": f"App bundle not found: {args.app}"}))
+        return 1
+
+    if not args.app.endswith(".app"):
+        print(json.dumps({"success": False, "error": "Path must point to a .app bundle"}))
+        return 1
+
+    # Try devicectl first
+    result = install_with_devicectl(args.device_id, args.app)
+
+    # Fallback to ios-deploy
+    if not result["success"] and "not found" in result.get("error", "").lower():
+        result = install_with_ios_deploy(args.device_id, args.app)
+
+    result["device_id"] = args.device_id
+    result["app_path"] = args.app
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/device-build/scripts/launch-app-device.py
+++ b/XcodeBuildTools/skills/device-build/scripts/launch-app-device.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Launch an app on a physical iOS device.
+
+Usage:
+    ./launch-app-device.py --device-id <UDID> --bundle-id com.example.myapp
+    ./launch-app-device.py --device-id <UDID> --bundle-id com.example.myapp --wait-for-debugger
+
+Options:
+    --device-id UDID       Device UDID (required)
+    --bundle-id ID         App bundle identifier (required)
+    --wait-for-debugger    Wait for debugger to attach before running
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def run_command(cmd, timeout=60):
+    """Run a command and return result."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout
+        )
+        return result.returncode == 0, result.stdout, result.stderr
+    except subprocess.TimeoutExpired:
+        return False, "", "Command timed out"
+    except Exception as e:
+        return False, "", str(e)
+
+
+def launch_with_devicectl(device_id, bundle_id, wait_for_debugger=False):
+    """Launch app using devicectl (Xcode 15+)."""
+    cmd = [
+        "xcrun", "devicectl", "device", "process", "launch",
+        "--device", device_id,
+        bundle_id
+    ]
+
+    if wait_for_debugger:
+        cmd.insert(5, "--wait-for-debugger")
+
+    success, stdout, stderr = run_command(cmd)
+
+    if success:
+        # Try to extract PID from output
+        pid = None
+        for line in stdout.split("\n"):
+            if "pid:" in line.lower() or "process" in line.lower():
+                import re
+                match = re.search(r"\d+", line)
+                if match:
+                    pid = int(match.group())
+                    break
+
+        result = {
+            "success": True,
+            "message": f"Launched {bundle_id} on device",
+            "bundle_id": bundle_id,
+            "device_id": device_id
+        }
+        if pid:
+            result["pid"] = pid
+        return result
+    else:
+        return {"success": False, "error": stderr or stdout or "Launch failed"}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Launch app on iOS device")
+    parser.add_argument("--device-id", required=True, help="Device UDID")
+    parser.add_argument("--bundle-id", required=True, help="App bundle identifier")
+    parser.add_argument("--wait-for-debugger", action="store_true", help="Wait for debugger")
+
+    args = parser.parse_args()
+
+    result = launch_with_devicectl(args.device_id, args.bundle_id, args.wait_for_debugger)
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/device-build/scripts/list-devices.py
+++ b/XcodeBuildTools/skills/device-build/scripts/list-devices.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+List connected physical Apple devices.
+
+Usage:
+    ./list-devices.py [--json-pretty]
+
+Output: JSON with device list
+"""
+
+import json
+import subprocess
+import sys
+import os
+import tempfile
+import re
+
+
+def run_command(cmd, timeout=30):
+    """Run a command and return (success, stdout, stderr)."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout
+        )
+        return result.returncode == 0, result.stdout, result.stderr
+    except subprocess.TimeoutExpired:
+        return False, "", "Command timed out"
+    except FileNotFoundError:
+        return False, "", f"Command not found: {cmd[0]}"
+
+
+def list_devices_devicectl():
+    """List devices using devicectl (Xcode 15+/iOS 17+)."""
+    devices = []
+
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+        temp_path = f.name
+
+    try:
+        success, stdout, stderr = run_command([
+            "xcrun", "devicectl", "list", "devices", "--json-output", temp_path
+        ])
+
+        if success and os.path.exists(temp_path):
+            with open(temp_path, 'r') as f:
+                data = json.load(f)
+
+            for device in data.get("result", {}).get("devices", []):
+                hw = device.get("hardwareProperties", {})
+                dp = device.get("deviceProperties", {})
+                conn = device.get("connectionProperties", {})
+
+                # Skip simulators
+                if hw.get("deviceType") == "simulator":
+                    continue
+
+                devices.append({
+                    "name": dp.get("name", "Unknown"),
+                    "udid": hw.get("udid", "Unknown"),
+                    "model": hw.get("marketingName", hw.get("productType", "Unknown")),
+                    "os_version": dp.get("osVersionNumber", "Unknown"),
+                    "connection": conn.get("transportType", "Unknown"),
+                    "paired": conn.get("pairingState") == "paired"
+                })
+
+            return devices, None
+
+    except Exception as e:
+        return None, str(e)
+    finally:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+
+    return None, "devicectl failed"
+
+
+def list_devices_xctrace():
+    """Fallback: List devices using xctrace."""
+    devices = []
+
+    success, stdout, stderr = run_command(["xcrun", "xctrace", "list", "devices"])
+    if not success:
+        return None, stderr
+
+    # Parse output - format: "Device Name (UDID)"
+    for line in stdout.split("\n"):
+        line = line.strip()
+        if not line or "Simulator" in line or "==" in line:
+            continue
+
+        # Match pattern: Name (UUID)
+        match = re.match(r"^(.+?)\s+\(([A-Fa-f0-9-]+)\)$", line)
+        if match:
+            devices.append({
+                "name": match.group(1).strip(),
+                "udid": match.group(2),
+                "model": "Unknown",
+                "os_version": "Unknown",
+                "connection": "Unknown",
+                "paired": True
+            })
+
+    return devices, None
+
+
+def main():
+    # Try devicectl first (modern method)
+    devices, error = list_devices_devicectl()
+
+    # Fallback to xctrace
+    if devices is None:
+        devices, error = list_devices_xctrace()
+
+    if devices is None:
+        result = {
+            "success": False,
+            "error": error or "Failed to list devices",
+            "devices": []
+        }
+    else:
+        result = {
+            "success": True,
+            "count": len(devices),
+            "devices": devices
+        }
+        if len(devices) == 0:
+            result["message"] = "No physical devices connected. Connect a device via USB or ensure it's paired over network."
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/device-build/scripts/stop-app-device.py
+++ b/XcodeBuildTools/skills/device-build/scripts/stop-app-device.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Stop/terminate an app on a physical iOS device.
+
+Usage:
+    ./stop-app-device.py --device-id <UDID> --bundle-id com.example.myapp
+
+Options:
+    --device-id UDID    Device UDID (required)
+    --bundle-id ID      App bundle identifier (required)
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def run_command(cmd, timeout=30):
+    """Run a command and return result."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout
+        )
+        return result.returncode == 0, result.stdout, result.stderr
+    except subprocess.TimeoutExpired:
+        return False, "", "Command timed out"
+    except Exception as e:
+        return False, "", str(e)
+
+
+def stop_with_devicectl(device_id, bundle_id):
+    """Stop app using devicectl (Xcode 15+)."""
+    # First, we need to find the PID of the running app
+    success, stdout, stderr = run_command([
+        "xcrun", "devicectl", "device", "info", "processes",
+        "--device", device_id
+    ])
+
+    if not success:
+        return {"success": False, "error": f"Failed to get process list: {stderr}"}
+
+    # Find PID for bundle ID (this is a simplification - actual parsing may vary)
+    pid = None
+    for line in stdout.split("\n"):
+        if bundle_id in line:
+            import re
+            match = re.search(r"^\s*(\d+)", line)
+            if match:
+                pid = match.group(1)
+                break
+
+    if pid:
+        # Terminate the process
+        success, stdout, stderr = run_command([
+            "xcrun", "devicectl", "device", "process", "terminate",
+            "--device", device_id,
+            "--pid", pid
+        ])
+
+        if success:
+            return {
+                "success": True,
+                "message": f"Terminated {bundle_id} (PID: {pid})",
+                "bundle_id": bundle_id,
+                "pid": int(pid)
+            }
+        else:
+            return {"success": False, "error": stderr or "Failed to terminate"}
+    else:
+        # App might not be running - consider this success
+        return {
+            "success": True,
+            "message": f"App {bundle_id} was not running",
+            "bundle_id": bundle_id
+        }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Stop app on iOS device")
+    parser.add_argument("--device-id", required=True, help="Device UDID")
+    parser.add_argument("--bundle-id", required=True, help="App bundle identifier")
+
+    args = parser.parse_args()
+
+    result = stop_with_devicectl(args.device_id, args.bundle_id)
+    result["device_id"] = args.device_id
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/device-build/scripts/test-device.py
+++ b/XcodeBuildTools/skills/device-build/scripts/test-device.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+Run tests on a physical iOS device.
+
+Usage:
+    ./test-device.py --workspace MyApp.xcworkspace --scheme MyAppTests --device-id <UDID>
+    ./test-device.py --project MyApp.xcodeproj --scheme MyAppTests --device-id <UDID>
+
+Options:
+    --workspace PATH       Path to .xcworkspace file
+    --project PATH         Path to .xcodeproj file
+    --scheme NAME          Test scheme name (required)
+    --device-id UDID       Device UDID (required)
+    --configuration CFG    Build configuration (default: Debug)
+    --only-testing TESTS   Run only specific tests (comma-separated)
+    --skip-testing TESTS   Skip specific tests (comma-separated)
+    --derived-data PATH    Custom derived data path
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+import re
+
+
+def run_xcodebuild(args, timeout=1200):
+    """Run xcodebuild test and return parsed result."""
+    try:
+        result = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout
+        )
+
+        output = result.stdout + result.stderr
+
+        # Parse test results
+        tests_passed = []
+        tests_failed = []
+        errors = []
+
+        for line in output.split("\n"):
+            # Match test results
+            if "Test Case" in line:
+                if "passed" in line.lower():
+                    match = re.search(r"Test Case '-\[(\S+) (\S+)\]' passed", line)
+                    if match:
+                        tests_passed.append(f"{match.group(1)}/{match.group(2)}")
+                elif "failed" in line.lower():
+                    match = re.search(r"Test Case '-\[(\S+) (\S+)\]' failed", line)
+                    if match:
+                        tests_failed.append(f"{match.group(1)}/{match.group(2)}")
+
+            if ": error:" in line:
+                errors.append(line.strip())
+
+        # Check for test success patterns
+        test_succeeded = "** TEST SUCCEEDED **" in output or result.returncode == 0
+
+        return {
+            "success": test_succeeded and len(tests_failed) == 0,
+            "return_code": result.returncode,
+            "tests_passed": len(tests_passed),
+            "tests_failed": len(tests_failed),
+            "passed_tests": tests_passed[:50],  # Limit output
+            "failed_tests": tests_failed,
+            "errors": errors[:10]
+        }
+
+    except subprocess.TimeoutExpired:
+        return {
+            "success": False,
+            "error": "Tests timed out after 20 minutes"
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "error": str(e)
+        }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run tests on iOS device")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to .xcworkspace")
+    group.add_argument("--project", help="Path to .xcodeproj")
+    parser.add_argument("--scheme", required=True, help="Test scheme")
+    parser.add_argument("--device-id", required=True, help="Device UDID")
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--only-testing", help="Run only these tests (comma-separated)")
+    parser.add_argument("--skip-testing", help="Skip these tests (comma-separated)")
+    parser.add_argument("--derived-data", help="Derived data path")
+
+    args = parser.parse_args()
+
+    # Validate paths
+    if args.workspace and not os.path.exists(args.workspace):
+        print(json.dumps({"success": False, "error": f"Workspace not found: {args.workspace}"}))
+        return 1
+
+    if args.project and not os.path.exists(args.project):
+        print(json.dumps({"success": False, "error": f"Project not found: {args.project}"}))
+        return 1
+
+    # Build xcodebuild command
+    cmd = ["xcodebuild"]
+
+    if args.workspace:
+        cmd.extend(["-workspace", args.workspace])
+    else:
+        cmd.extend(["-project", args.project])
+
+    cmd.extend([
+        "-scheme", args.scheme,
+        "-configuration", args.configuration,
+        "-destination", f"id={args.device_id}",
+        "-skipMacroValidation",
+        "-skipPackagePluginValidation",
+        "test"
+    ])
+
+    if args.derived_data:
+        cmd.extend(["-derivedDataPath", args.derived_data])
+
+    if args.only_testing:
+        for test in args.only_testing.split(","):
+            cmd.extend(["-only-testing", test.strip()])
+
+    if args.skip_testing:
+        for test in args.skip_testing.split(","):
+            cmd.extend(["-skip-testing", test.strip()])
+
+    # Run tests
+    result = run_xcodebuild(cmd)
+
+    result["scheme"] = args.scheme
+    result["device_id"] = args.device_id
+
+    if result["success"]:
+        result["message"] = f"All {result['tests_passed']} tests passed"
+    elif result.get("tests_failed", 0) > 0:
+        result["message"] = f"{result['tests_failed']} test(s) failed"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/macos-build/SKILL.md
+++ b/XcodeBuildTools/skills/macos-build/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: macos-build
+description: Build, run, and test macOS applications using Xcode. Use this skill when working with macOS app projects.
+---
+
+# macOS Build
+
+Build, run, and test macOS applications.
+
+## Prerequisites
+
+- macOS with Xcode installed
+- A macOS Xcode project or workspace
+
+## Scripts
+
+All scripts are in the `scripts/` directory and output JSON.
+
+### build-macos.py
+
+Build a macOS application.
+
+```bash
+# Build with workspace
+scripts/build-macos.py --workspace MyApp.xcworkspace --scheme MyApp
+
+# Build with project
+scripts/build-macos.py --project MyApp.xcodeproj --scheme MyApp
+
+# Release configuration
+scripts/build-macos.py --workspace MyApp.xcworkspace --scheme MyApp --configuration Release
+
+# Specific architecture
+scripts/build-macos.py --workspace MyApp.xcworkspace --scheme MyApp --arch arm64
+```
+
+**Parameters:**
+- `--workspace` or `--project`: Path to .xcworkspace or .xcodeproj (mutually exclusive)
+- `--scheme`: Build scheme name (required)
+- `--configuration`: Build configuration (default: Debug)
+- `--arch`: Architecture (arm64 or x86_64)
+- `--derived-data`: Custom derived data path
+- `--extra-args`: Additional xcodebuild arguments
+
+### build-run-macos.py
+
+Build and run a macOS application.
+
+```bash
+scripts/build-run-macos.py --workspace MyApp.xcworkspace --scheme MyApp
+```
+
+### test-macos.py
+
+Run tests for a macOS application.
+
+```bash
+# Run all tests
+scripts/test-macos.py --workspace MyApp.xcworkspace --scheme MyAppTests
+
+# Run specific tests
+scripts/test-macos.py --workspace MyApp.xcworkspace --scheme MyAppTests --only-testing "MyAppTests/LoginTests"
+```
+
+### launch-app.py
+
+Launch a built macOS application.
+
+```bash
+scripts/launch-app.py --app /path/to/MyApp.app
+
+# Launch by bundle ID
+scripts/launch-app.py --bundle-id com.example.myapp
+```
+
+### stop-app.py
+
+Terminate a running macOS application.
+
+```bash
+scripts/stop-app.py --bundle-id com.example.myapp
+
+# Force quit
+scripts/stop-app.py --bundle-id com.example.myapp --force
+```
+
+## Typical Workflow
+
+```bash
+# 1. Build the app
+scripts/build-macos.py --workspace MyApp.xcworkspace --scheme MyApp
+
+# 2. Run tests
+scripts/test-macos.py --workspace MyApp.xcworkspace --scheme MyAppTests
+
+# 3. Build and run
+scripts/build-run-macos.py --workspace MyApp.xcworkspace --scheme MyApp
+
+# 4. Stop the app when done
+scripts/stop-app.py --bundle-id com.example.myapp
+```

--- a/XcodeBuildTools/skills/macos-build/scripts/build-macos.py
+++ b/XcodeBuildTools/skills/macos-build/scripts/build-macos.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Build a macOS application.
+
+Usage:
+    ./build-macos.py --workspace MyApp.xcworkspace --scheme MyApp
+    ./build-macos.py --project MyApp.xcodeproj --scheme MyApp
+
+Options:
+    --workspace PATH       Path to .xcworkspace file
+    --project PATH         Path to .xcodeproj file
+    --scheme NAME          Build scheme name (required)
+    --configuration CFG    Build configuration (default: Debug)
+    --arch ARCH            Architecture (arm64 or x86_64)
+    --derived-data PATH    Custom derived data path
+    --extra-args ARGS      Additional xcodebuild arguments
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+
+
+def run_xcodebuild(args, timeout=600):
+    """Run xcodebuild and return parsed result."""
+    try:
+        result = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout
+        )
+
+        errors = []
+        warnings = []
+
+        for line in result.stdout.split("\n") + result.stderr.split("\n"):
+            if ": error:" in line:
+                errors.append(line.strip())
+            elif ": warning:" in line:
+                warnings.append(line.strip())
+
+        return {
+            "success": result.returncode == 0,
+            "return_code": result.returncode,
+            "errors": errors[:20],
+            "warnings": warnings[:20],
+            "error_count": len(errors),
+            "warning_count": len(warnings)
+        }
+
+    except subprocess.TimeoutExpired:
+        return {"success": False, "error": "Build timed out after 10 minutes"}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build macOS app")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to .xcworkspace")
+    group.add_argument("--project", help="Path to .xcodeproj")
+    parser.add_argument("--scheme", required=True, help="Build scheme")
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--arch", choices=["arm64", "x86_64"], help="Architecture")
+    parser.add_argument("--derived-data", help="Derived data path")
+    parser.add_argument("--extra-args", help="Extra xcodebuild args")
+
+    args = parser.parse_args()
+
+    # Validate paths
+    if args.workspace and not os.path.exists(args.workspace):
+        print(json.dumps({"success": False, "error": f"Workspace not found: {args.workspace}"}))
+        return 1
+
+    if args.project and not os.path.exists(args.project):
+        print(json.dumps({"success": False, "error": f"Project not found: {args.project}"}))
+        return 1
+
+    # Build xcodebuild command
+    cmd = ["xcodebuild"]
+
+    if args.workspace:
+        cmd.extend(["-workspace", args.workspace])
+    else:
+        cmd.extend(["-project", args.project])
+
+    cmd.extend([
+        "-scheme", args.scheme,
+        "-configuration", args.configuration,
+        "-destination", "platform=macOS",
+        "-skipMacroValidation",
+        "-skipPackagePluginValidation",
+        "build"
+    ])
+
+    if args.arch:
+        cmd.extend(["-arch", args.arch])
+
+    if args.derived_data:
+        cmd.extend(["-derivedDataPath", args.derived_data])
+
+    if args.extra_args:
+        cmd.extend(args.extra_args.split(","))
+
+    # Run build
+    result = run_xcodebuild(cmd)
+
+    if result["success"]:
+        result["message"] = f"Build succeeded"
+        result["scheme"] = args.scheme
+        result["configuration"] = args.configuration
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/macos-build/scripts/build-run-macos.py
+++ b/XcodeBuildTools/skills/macos-build/scripts/build-run-macos.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Build and run a macOS application.
+
+Usage:
+    ./build-run-macos.py --workspace MyApp.xcworkspace --scheme MyApp
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+
+
+def get_app_path(workspace=None, project=None, scheme=None, configuration="Debug", derived_data=None):
+    """Get the built app path from build settings."""
+    cmd = ["xcodebuild", "-showBuildSettings"]
+
+    if workspace:
+        cmd.extend(["-workspace", workspace])
+    else:
+        cmd.extend(["-project", project])
+
+    cmd.extend(["-scheme", scheme, "-configuration", configuration])
+
+    if derived_data:
+        cmd.extend(["-derivedDataPath", derived_data])
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+
+        built_products_dir = None
+        product_name = None
+
+        for line in result.stdout.split("\n"):
+            if "BUILT_PRODUCTS_DIR = " in line:
+                built_products_dir = line.split("=")[1].strip()
+            elif "PRODUCT_NAME = " in line:
+                product_name = line.split("=")[1].strip()
+
+        if built_products_dir and product_name:
+            return os.path.join(built_products_dir, f"{product_name}.app"), None
+
+        return None, "Could not determine app path from build settings"
+
+    except Exception as e:
+        return None, str(e)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build and run macOS app")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to .xcworkspace")
+    group.add_argument("--project", help="Path to .xcodeproj")
+    parser.add_argument("--scheme", required=True, help="Build scheme")
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--arch", choices=["arm64", "x86_64"], help="Architecture")
+    parser.add_argument("--derived-data", help="Derived data path")
+
+    args = parser.parse_args()
+
+    # Validate paths
+    if args.workspace and not os.path.exists(args.workspace):
+        print(json.dumps({"success": False, "error": f"Workspace not found: {args.workspace}"}))
+        return 1
+
+    if args.project and not os.path.exists(args.project):
+        print(json.dumps({"success": False, "error": f"Project not found: {args.project}"}))
+        return 1
+
+    # Build
+    cmd = ["xcodebuild"]
+
+    if args.workspace:
+        cmd.extend(["-workspace", args.workspace])
+    else:
+        cmd.extend(["-project", args.project])
+
+    cmd.extend([
+        "-scheme", args.scheme,
+        "-configuration", args.configuration,
+        "-destination", "platform=macOS",
+        "-skipMacroValidation",
+        "-skipPackagePluginValidation",
+        "build"
+    ])
+
+    if args.arch:
+        cmd.extend(["-arch", args.arch])
+
+    if args.derived_data:
+        cmd.extend(["-derivedDataPath", args.derived_data])
+
+    try:
+        build_result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+
+        if build_result.returncode != 0:
+            errors = [l for l in build_result.stdout.split("\n") if ": error:" in l][:10]
+            print(json.dumps({
+                "success": False,
+                "error": "Build failed",
+                "errors": errors
+            }))
+            return 1
+
+    except subprocess.TimeoutExpired:
+        print(json.dumps({"success": False, "error": "Build timed out"}))
+        return 1
+
+    # Get app path
+    app_path, error = get_app_path(
+        workspace=args.workspace,
+        project=args.project,
+        scheme=args.scheme,
+        configuration=args.configuration,
+        derived_data=args.derived_data
+    )
+
+    if error:
+        print(json.dumps({"success": False, "error": f"Build succeeded but could not find app: {error}"}))
+        return 1
+
+    # Launch
+    try:
+        subprocess.run(["open", app_path], capture_output=True, timeout=10)
+
+        print(json.dumps({
+            "success": True,
+            "message": f"Built and launched {args.scheme}",
+            "app_path": app_path
+        }, indent=2))
+        return 0
+
+    except Exception as e:
+        print(json.dumps({
+            "success": False,
+            "error": f"Build succeeded but launch failed: {e}"
+        }))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/macos-build/scripts/launch-app.py
+++ b/XcodeBuildTools/skills/macos-build/scripts/launch-app.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Launch a macOS application.
+
+Usage:
+    ./launch-app.py --app /path/to/MyApp.app
+    ./launch-app.py --bundle-id com.example.myapp
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Launch macOS app")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--app", help="Path to .app bundle")
+    group.add_argument("--bundle-id", help="App bundle identifier")
+
+    args = parser.parse_args()
+
+    try:
+        if args.app:
+            if not os.path.exists(args.app):
+                print(json.dumps({"success": False, "error": f"App not found: {args.app}"}))
+                return 1
+
+            result = subprocess.run(
+                ["open", args.app],
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+
+            if result.returncode == 0:
+                print(json.dumps({
+                    "success": True,
+                    "message": f"Launched {os.path.basename(args.app)}",
+                    "app_path": args.app
+                }, indent=2))
+                return 0
+            else:
+                print(json.dumps({
+                    "success": False,
+                    "error": result.stderr or "Failed to launch app"
+                }))
+                return 1
+
+        else:
+            result = subprocess.run(
+                ["open", "-b", args.bundle_id],
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+
+            if result.returncode == 0:
+                print(json.dumps({
+                    "success": True,
+                    "message": f"Launched {args.bundle_id}",
+                    "bundle_id": args.bundle_id
+                }, indent=2))
+                return 0
+            else:
+                print(json.dumps({
+                    "success": False,
+                    "error": result.stderr or f"Failed to launch {args.bundle_id}"
+                }))
+                return 1
+
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/macos-build/scripts/stop-app.py
+++ b/XcodeBuildTools/skills/macos-build/scripts/stop-app.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+Stop/terminate a running macOS application.
+
+Usage:
+    ./stop-app.py --bundle-id com.example.myapp
+    ./stop-app.py --bundle-id com.example.myapp --force
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Stop macOS app")
+    parser.add_argument("--bundle-id", required=True, help="App bundle identifier")
+    parser.add_argument("--force", action="store_true", help="Force quit (kill)")
+
+    args = parser.parse_args()
+
+    try:
+        # First try AppleScript for graceful quit
+        if not args.force:
+            script = f'tell application id "{args.bundle_id}" to quit'
+            result = subprocess.run(
+                ["osascript", "-e", script],
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+
+            if result.returncode == 0:
+                print(json.dumps({
+                    "success": True,
+                    "message": f"Quit {args.bundle_id}",
+                    "bundle_id": args.bundle_id
+                }, indent=2))
+                return 0
+
+        # Force kill using pkill
+        result = subprocess.run(
+            ["pkill", "-f", args.bundle_id],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+
+        # pkill returns 1 if no processes matched, which is OK
+        print(json.dumps({
+            "success": True,
+            "message": f"Terminated {args.bundle_id}",
+            "bundle_id": args.bundle_id,
+            "forced": args.force or result.returncode != 0
+        }, indent=2))
+        return 0
+
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/macos-build/scripts/test-macos.py
+++ b/XcodeBuildTools/skills/macos-build/scripts/test-macos.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+Run tests for a macOS application.
+
+Usage:
+    ./test-macos.py --workspace MyApp.xcworkspace --scheme MyAppTests
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+import re
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run macOS tests")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to .xcworkspace")
+    group.add_argument("--project", help="Path to .xcodeproj")
+    parser.add_argument("--scheme", required=True, help="Test scheme")
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--only-testing", help="Run only these tests (comma-separated)")
+    parser.add_argument("--skip-testing", help="Skip these tests (comma-separated)")
+    parser.add_argument("--derived-data", help="Derived data path")
+
+    args = parser.parse_args()
+
+    # Validate paths
+    if args.workspace and not os.path.exists(args.workspace):
+        print(json.dumps({"success": False, "error": f"Workspace not found: {args.workspace}"}))
+        return 1
+
+    if args.project and not os.path.exists(args.project):
+        print(json.dumps({"success": False, "error": f"Project not found: {args.project}"}))
+        return 1
+
+    # Build xcodebuild command
+    cmd = ["xcodebuild"]
+
+    if args.workspace:
+        cmd.extend(["-workspace", args.workspace])
+    else:
+        cmd.extend(["-project", args.project])
+
+    cmd.extend([
+        "-scheme", args.scheme,
+        "-configuration", args.configuration,
+        "-destination", "platform=macOS",
+        "-skipMacroValidation",
+        "-skipPackagePluginValidation",
+        "test"
+    ])
+
+    if args.derived_data:
+        cmd.extend(["-derivedDataPath", args.derived_data])
+
+    if args.only_testing:
+        for test in args.only_testing.split(","):
+            cmd.extend(["-only-testing", test.strip()])
+
+    if args.skip_testing:
+        for test in args.skip_testing.split(","):
+            cmd.extend(["-skip-testing", test.strip()])
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=1200)
+
+        output = result.stdout + result.stderr
+
+        tests_passed = []
+        tests_failed = []
+        errors = []
+
+        for line in output.split("\n"):
+            if "Test Case" in line:
+                if "passed" in line.lower():
+                    match = re.search(r"Test Case '-\[(\S+) (\S+)\]' passed", line)
+                    if match:
+                        tests_passed.append(f"{match.group(1)}/{match.group(2)}")
+                elif "failed" in line.lower():
+                    match = re.search(r"Test Case '-\[(\S+) (\S+)\]' failed", line)
+                    if match:
+                        tests_failed.append(f"{match.group(1)}/{match.group(2)}")
+
+            if ": error:" in line:
+                errors.append(line.strip())
+
+        test_succeeded = "** TEST SUCCEEDED **" in output or result.returncode == 0
+
+        response = {
+            "success": test_succeeded and len(tests_failed) == 0,
+            "return_code": result.returncode,
+            "tests_passed": len(tests_passed),
+            "tests_failed": len(tests_failed),
+            "passed_tests": tests_passed[:50],
+            "failed_tests": tests_failed,
+            "errors": errors[:10],
+            "scheme": args.scheme
+        }
+
+        if response["success"]:
+            response["message"] = f"All {response['tests_passed']} tests passed"
+        elif tests_failed:
+            response["message"] = f"{len(tests_failed)} test(s) failed"
+
+        print(json.dumps(response, indent=2))
+        return 0 if response["success"] else 1
+
+    except subprocess.TimeoutExpired:
+        print(json.dumps({"success": False, "error": "Tests timed out after 20 minutes"}))
+        return 1
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/project-discovery/SKILL.md
+++ b/XcodeBuildTools/skills/project-discovery/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: project-discovery
+description: Discover Xcode projects, list available schemes, show build settings, and get bundle identifiers. Use this skill when you need to explore or understand an Xcode project structure.
+---
+
+# Project Discovery
+
+Discover and analyze Xcode projects and workspaces.
+
+## Prerequisites
+
+- macOS with Xcode installed
+- An Xcode project or workspace
+
+## Scripts
+
+All scripts are in the `scripts/` directory and output JSON.
+
+### discover-projects.py
+
+Find Xcode projects and workspaces in a directory.
+
+```bash
+# Search current directory
+scripts/discover-projects.py
+
+# Search specific directory
+scripts/discover-projects.py --path /path/to/code
+
+# Recursive search
+scripts/discover-projects.py --path /path/to/code --recursive
+```
+
+Output:
+```json
+{
+  "success": true,
+  "projects": [
+    {
+      "type": "workspace",
+      "name": "MyApp.xcworkspace",
+      "path": "/path/to/MyApp.xcworkspace"
+    },
+    {
+      "type": "project",
+      "name": "MyApp.xcodeproj",
+      "path": "/path/to/MyApp.xcodeproj"
+    }
+  ]
+}
+```
+
+### list-schemes.py
+
+List available build schemes.
+
+```bash
+# List schemes for workspace
+scripts/list-schemes.py --workspace MyApp.xcworkspace
+
+# List schemes for project
+scripts/list-schemes.py --project MyApp.xcodeproj
+```
+
+Output:
+```json
+{
+  "success": true,
+  "schemes": [
+    "MyApp",
+    "MyAppTests",
+    "MyAppUITests"
+  ]
+}
+```
+
+### show-build-settings.py
+
+Show build settings for a scheme.
+
+```bash
+# Show all build settings
+scripts/show-build-settings.py --workspace MyApp.xcworkspace --scheme MyApp
+
+# Show specific setting
+scripts/show-build-settings.py --workspace MyApp.xcworkspace --scheme MyApp --setting PRODUCT_BUNDLE_IDENTIFIER
+```
+
+### get-bundle-id.py
+
+Get the bundle identifier for an app.
+
+```bash
+# From workspace/scheme
+scripts/get-bundle-id.py --workspace MyApp.xcworkspace --scheme MyApp
+
+# From built app
+scripts/get-bundle-id.py --app /path/to/MyApp.app
+```
+
+## Typical Workflow
+
+```bash
+# 1. Find projects in directory
+scripts/discover-projects.py --path /path/to/repo
+
+# 2. List schemes
+scripts/list-schemes.py --workspace /path/to/MyApp.xcworkspace
+
+# 3. Get bundle ID for a scheme
+scripts/get-bundle-id.py --workspace /path/to/MyApp.xcworkspace --scheme MyApp
+
+# 4. View build settings
+scripts/show-build-settings.py --workspace /path/to/MyApp.xcworkspace --scheme MyApp
+```

--- a/XcodeBuildTools/skills/project-discovery/scripts/discover-projects.py
+++ b/XcodeBuildTools/skills/project-discovery/scripts/discover-projects.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Discover Xcode projects and workspaces in a directory.
+
+Usage:
+    ./discover-projects.py [--path PATH] [--recursive]
+
+Options:
+    --path PATH     Directory to search (default: current directory)
+    --recursive     Search subdirectories
+"""
+
+import argparse
+import json
+import os
+import sys
+
+
+def find_xcode_items(path, recursive=False):
+    """Find .xcworkspace and .xcodeproj items."""
+    items = []
+
+    if recursive:
+        for root, dirs, files in os.walk(path):
+            # Skip hidden directories and common non-project dirs
+            dirs[:] = [d for d in dirs if not d.startswith('.') and d not in ['Pods', 'Carthage', 'node_modules']]
+
+            for d in list(dirs):
+                if d.endswith('.xcworkspace'):
+                    items.append({
+                        "type": "workspace",
+                        "name": d,
+                        "path": os.path.join(root, d)
+                    })
+                    # Don't descend into workspace
+                    dirs.remove(d)
+                elif d.endswith('.xcodeproj'):
+                    items.append({
+                        "type": "project",
+                        "name": d,
+                        "path": os.path.join(root, d)
+                    })
+                    # Don't descend into project
+                    dirs.remove(d)
+    else:
+        try:
+            for item in os.listdir(path):
+                full_path = os.path.join(path, item)
+                if os.path.isdir(full_path):
+                    if item.endswith('.xcworkspace'):
+                        items.append({
+                            "type": "workspace",
+                            "name": item,
+                            "path": full_path
+                        })
+                    elif item.endswith('.xcodeproj'):
+                        items.append({
+                            "type": "project",
+                            "name": item,
+                            "path": full_path
+                        })
+        except PermissionError:
+            pass
+
+    # Sort: workspaces first, then by name
+    items.sort(key=lambda x: (0 if x["type"] == "workspace" else 1, x["name"]))
+
+    return items
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Discover Xcode projects")
+    parser.add_argument("--path", default=".", help="Directory to search")
+    parser.add_argument("--recursive", action="store_true", help="Search subdirectories")
+
+    args = parser.parse_args()
+
+    # Resolve path
+    search_path = os.path.abspath(args.path)
+
+    if not os.path.exists(search_path):
+        print(json.dumps({"success": False, "error": f"Path not found: {search_path}"}))
+        return 1
+
+    if not os.path.isdir(search_path):
+        print(json.dumps({"success": False, "error": f"Not a directory: {search_path}"}))
+        return 1
+
+    items = find_xcode_items(search_path, args.recursive)
+
+    result = {
+        "success": True,
+        "search_path": search_path,
+        "recursive": args.recursive,
+        "count": len(items),
+        "projects": items
+    }
+
+    if len(items) == 0:
+        result["message"] = "No Xcode projects or workspaces found"
+
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/project-discovery/scripts/get-bundle-id.py
+++ b/XcodeBuildTools/skills/project-discovery/scripts/get-bundle-id.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Get bundle identifier for an app.
+
+Usage:
+    ./get-bundle-id.py --workspace MyApp.xcworkspace --scheme MyApp
+    ./get-bundle-id.py --app /path/to/MyApp.app
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+
+
+def get_bundle_id_from_app(app_path):
+    """Get bundle ID from an app's Info.plist."""
+    plist_path = os.path.join(app_path, "Info.plist")
+
+    if not os.path.exists(plist_path):
+        return None, f"Info.plist not found in {app_path}"
+
+    try:
+        result = subprocess.run(
+            ["defaults", "read", plist_path, "CFBundleIdentifier"],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+
+        if result.returncode == 0:
+            return result.stdout.strip(), None
+        else:
+            return None, "Could not read CFBundleIdentifier"
+
+    except Exception as e:
+        return None, str(e)
+
+
+def get_bundle_id_from_build_settings(workspace=None, project=None, scheme=None, configuration="Debug"):
+    """Get bundle ID from build settings."""
+    cmd = ["xcodebuild", "-showBuildSettings"]
+
+    if workspace:
+        cmd.extend(["-workspace", workspace])
+    else:
+        cmd.extend(["-project", project])
+
+    cmd.extend(["-scheme", scheme, "-configuration", configuration])
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+
+        for line in result.stdout.split("\n"):
+            if "PRODUCT_BUNDLE_IDENTIFIER = " in line:
+                return line.split("=")[1].strip(), None
+
+        return None, "PRODUCT_BUNDLE_IDENTIFIER not found in build settings"
+
+    except Exception as e:
+        return None, str(e)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get app bundle identifier")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to .xcworkspace")
+    group.add_argument("--project", help="Path to .xcodeproj")
+    group.add_argument("--app", help="Path to .app bundle")
+    parser.add_argument("--scheme", help="Scheme name (required with --workspace/--project)")
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+
+    args = parser.parse_args()
+
+    if args.app:
+        if not os.path.exists(args.app):
+            print(json.dumps({"success": False, "error": f"App not found: {args.app}"}))
+            return 1
+
+        bundle_id, error = get_bundle_id_from_app(args.app)
+
+        if error:
+            print(json.dumps({"success": False, "error": error}))
+            return 1
+
+        print(json.dumps({
+            "success": True,
+            "bundle_id": bundle_id,
+            "source": "app",
+            "app_path": args.app
+        }, indent=2))
+        return 0
+
+    else:
+        if not args.scheme:
+            print(json.dumps({"success": False, "error": "--scheme is required with --workspace/--project"}))
+            return 1
+
+        path = args.workspace or args.project
+        if not os.path.exists(path):
+            print(json.dumps({"success": False, "error": f"Not found: {path}"}))
+            return 1
+
+        bundle_id, error = get_bundle_id_from_build_settings(
+            workspace=args.workspace,
+            project=args.project,
+            scheme=args.scheme,
+            configuration=args.configuration
+        )
+
+        if error:
+            print(json.dumps({"success": False, "error": error}))
+            return 1
+
+        print(json.dumps({
+            "success": True,
+            "bundle_id": bundle_id,
+            "source": "build_settings",
+            "scheme": args.scheme
+        }, indent=2))
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/project-discovery/scripts/list-schemes.py
+++ b/XcodeBuildTools/skills/project-discovery/scripts/list-schemes.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+List available build schemes for an Xcode project/workspace.
+
+Usage:
+    ./list-schemes.py --workspace MyApp.xcworkspace
+    ./list-schemes.py --project MyApp.xcodeproj
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Xcode schemes")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to .xcworkspace")
+    group.add_argument("--project", help="Path to .xcodeproj")
+
+    args = parser.parse_args()
+
+    # Validate path
+    path = args.workspace or args.project
+    if not os.path.exists(path):
+        print(json.dumps({"success": False, "error": f"Not found: {path}"}))
+        return 1
+
+    # Build command
+    cmd = ["xcodebuild", "-list", "-json"]
+
+    if args.workspace:
+        cmd.extend(["-workspace", args.workspace])
+    else:
+        cmd.extend(["-project", args.project])
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=60
+        )
+
+        if result.returncode != 0:
+            print(json.dumps({
+                "success": False,
+                "error": result.stderr or "Failed to list schemes"
+            }))
+            return 1
+
+        data = json.loads(result.stdout)
+
+        # Extract schemes from workspace or project structure
+        if "workspace" in data:
+            schemes = data["workspace"].get("schemes", [])
+            name = data["workspace"].get("name", "")
+        elif "project" in data:
+            schemes = data["project"].get("schemes", [])
+            name = data["project"].get("name", "")
+        else:
+            schemes = []
+            name = ""
+
+        print(json.dumps({
+            "success": True,
+            "name": name,
+            "count": len(schemes),
+            "schemes": schemes
+        }, indent=2))
+        return 0
+
+    except json.JSONDecodeError:
+        # Fallback: parse text output
+        try:
+            result = subprocess.run(
+                cmd[:-1],  # Remove -json flag
+                capture_output=True,
+                text=True,
+                timeout=60
+            )
+
+            schemes = []
+            in_schemes = False
+            for line in result.stdout.split("\n"):
+                line = line.strip()
+                if line == "Schemes:":
+                    in_schemes = True
+                elif in_schemes and line:
+                    if line.startswith("If no"):
+                        break
+                    schemes.append(line)
+
+            print(json.dumps({
+                "success": True,
+                "count": len(schemes),
+                "schemes": schemes
+            }, indent=2))
+            return 0
+
+        except Exception as e:
+            print(json.dumps({"success": False, "error": str(e)}))
+            return 1
+
+    except subprocess.TimeoutExpired:
+        print(json.dumps({"success": False, "error": "Command timed out"}))
+        return 1
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/project-discovery/scripts/show-build-settings.py
+++ b/XcodeBuildTools/skills/project-discovery/scripts/show-build-settings.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Show build settings for an Xcode scheme.
+
+Usage:
+    ./show-build-settings.py --workspace MyApp.xcworkspace --scheme MyApp
+    ./show-build-settings.py --project MyApp.xcodeproj --scheme MyApp --setting PRODUCT_BUNDLE_IDENTIFIER
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Show Xcode build settings")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to .xcworkspace")
+    group.add_argument("--project", help="Path to .xcodeproj")
+    parser.add_argument("--scheme", required=True, help="Scheme name")
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--setting", help="Specific setting to show")
+
+    args = parser.parse_args()
+
+    # Validate path
+    path = args.workspace or args.project
+    if not os.path.exists(path):
+        print(json.dumps({"success": False, "error": f"Not found: {path}"}))
+        return 1
+
+    # Build command
+    cmd = ["xcodebuild", "-showBuildSettings"]
+
+    if args.workspace:
+        cmd.extend(["-workspace", args.workspace])
+    else:
+        cmd.extend(["-project", args.project])
+
+    cmd.extend(["-scheme", args.scheme, "-configuration", args.configuration])
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=60
+        )
+
+        if result.returncode != 0:
+            print(json.dumps({
+                "success": False,
+                "error": result.stderr or "Failed to get build settings"
+            }))
+            return 1
+
+        # Parse build settings
+        settings = {}
+        for line in result.stdout.split("\n"):
+            line = line.strip()
+            if " = " in line:
+                key, value = line.split(" = ", 1)
+                key = key.strip()
+                value = value.strip()
+                settings[key] = value
+
+        # Filter to specific setting if requested
+        if args.setting:
+            if args.setting in settings:
+                print(json.dumps({
+                    "success": True,
+                    "setting": args.setting,
+                    "value": settings[args.setting]
+                }, indent=2))
+            else:
+                print(json.dumps({
+                    "success": False,
+                    "error": f"Setting '{args.setting}' not found"
+                }))
+                return 1
+        else:
+            # Return common useful settings
+            common_settings = [
+                "PRODUCT_NAME",
+                "PRODUCT_BUNDLE_IDENTIFIER",
+                "PRODUCT_MODULE_NAME",
+                "BUILT_PRODUCTS_DIR",
+                "TARGET_BUILD_DIR",
+                "INFOPLIST_FILE",
+                "SWIFT_VERSION",
+                "IPHONEOS_DEPLOYMENT_TARGET",
+                "MACOSX_DEPLOYMENT_TARGET",
+                "SDKROOT",
+                "CONFIGURATION",
+                "PLATFORM_NAME"
+            ]
+
+            filtered = {k: settings.get(k) for k in common_settings if k in settings}
+
+            print(json.dumps({
+                "success": True,
+                "scheme": args.scheme,
+                "configuration": args.configuration,
+                "settings": filtered,
+                "all_settings_count": len(settings)
+            }, indent=2))
+
+        return 0
+
+    except subprocess.TimeoutExpired:
+        print(json.dumps({"success": False, "error": "Command timed out"}))
+        return 1
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/simulator-build/SKILL.md
+++ b/XcodeBuildTools/skills/simulator-build/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: simulator-build
+description: Build, run, install, and test iOS apps on iOS Simulators. Use this skill when building for simulator, running tests, or deploying to a simulator.
+---
+
+# Simulator Build
+
+Build, run, and test iOS apps on iOS Simulators.
+
+## Prerequisites
+
+- macOS with Xcode installed
+- At least one iOS Simulator runtime installed
+
+## Scripts
+
+All scripts are in the `scripts/` directory and output JSON.
+
+### list-simulators.py
+
+List available iOS simulators.
+
+```bash
+# List all simulators
+scripts/list-simulators.py
+
+# List only booted simulators
+scripts/list-simulators.py --booted
+
+# Filter by runtime
+scripts/list-simulators.py --runtime "iOS 17"
+```
+
+Output:
+```json
+{
+  "success": true,
+  "simulators": [
+    {
+      "name": "iPhone 15 Pro",
+      "udid": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+      "state": "Booted",
+      "runtime": "iOS 17.0",
+      "is_available": true
+    }
+  ]
+}
+```
+
+### build-simulator.py
+
+Build an Xcode project/workspace for the iOS Simulator.
+
+```bash
+# Build with workspace
+scripts/build-simulator.py --workspace MyApp.xcworkspace --scheme MyApp --simulator-name "iPhone 15"
+
+# Build with project and specific simulator UDID
+scripts/build-simulator.py --project MyApp.xcodeproj --scheme MyApp --simulator-id <UDID>
+
+# Use latest OS version
+scripts/build-simulator.py --workspace MyApp.xcworkspace --scheme MyApp --simulator-name "iPhone 15" --use-latest-os
+
+# Release configuration
+scripts/build-simulator.py --workspace MyApp.xcworkspace --scheme MyApp --simulator-name "iPhone 15" --configuration Release
+```
+
+**Parameters:**
+- `--workspace` or `--project`: Path to .xcworkspace or .xcodeproj (mutually exclusive, required)
+- `--scheme`: Build scheme name (required)
+- `--simulator-name` or `--simulator-id`: Simulator name or UDID (one required)
+- `--configuration`: Build configuration (default: Debug)
+- `--use-latest-os`: Use latest OS version for simulator name
+- `--derived-data`: Custom derived data path
+- `--extra-args`: Additional xcodebuild arguments
+
+### build-run-simulator.py
+
+Build and immediately run an app on a simulator.
+
+```bash
+scripts/build-run-simulator.py --workspace MyApp.xcworkspace --scheme MyApp --simulator-name "iPhone 15"
+```
+
+This combines building, installing, and launching in one step.
+
+### install-app-simulator.py
+
+Install an app on a simulator.
+
+```bash
+scripts/install-app-simulator.py --simulator-id <UDID> --app /path/to/MyApp.app
+```
+
+### launch-app-simulator.py
+
+Launch an installed app on a simulator.
+
+```bash
+scripts/launch-app-simulator.py --simulator-id <UDID> --bundle-id com.example.myapp
+
+# Launch with console output
+scripts/launch-app-simulator.py --simulator-id <UDID> --bundle-id com.example.myapp --console
+```
+
+### stop-app-simulator.py
+
+Terminate a running app on a simulator.
+
+```bash
+scripts/stop-app-simulator.py --simulator-id <UDID> --bundle-id com.example.myapp
+```
+
+### test-simulator.py
+
+Run tests on a simulator.
+
+```bash
+# Run all tests
+scripts/test-simulator.py --workspace MyApp.xcworkspace --scheme MyAppTests --simulator-name "iPhone 15"
+
+# Run specific tests
+scripts/test-simulator.py --workspace MyApp.xcworkspace --scheme MyAppTests --simulator-name "iPhone 15" --only-testing "MyAppTests/LoginTests"
+```
+
+### screenshot.py
+
+Take a screenshot of a simulator.
+
+```bash
+scripts/screenshot.py --simulator-id <UDID> --output /tmp/screenshot.png
+
+# Auto-generated filename
+scripts/screenshot.py --simulator-id <UDID>
+```
+
+### record-video.py
+
+Record video of a simulator.
+
+```bash
+# Start recording
+scripts/record-video.py --simulator-id <UDID> --output /tmp/recording.mp4 --start
+
+# Stop recording
+scripts/record-video.py --stop
+```
+
+## Choosing a Simulator
+
+When choosing a simulator:
+
+1. Use `list-simulators.py --booted` to see running simulators
+2. If none are booted, use the simulator-management skill to boot one
+3. Use `--simulator-name` for convenience or `--simulator-id` for precision
+4. Use `--use-latest-os` to get the newest OS version for a device name
+
+## Typical Workflow
+
+```bash
+# 1. List available simulators
+scripts/list-simulators.py
+
+# 2. Build and run (will boot simulator if needed)
+scripts/build-run-simulator.py --workspace MyApp.xcworkspace --scheme MyApp --simulator-name "iPhone 15"
+
+# 3. Take a screenshot
+scripts/screenshot.py
+
+# 4. Run tests
+scripts/test-simulator.py --workspace MyApp.xcworkspace --scheme MyAppTests --simulator-name "iPhone 15"
+```

--- a/XcodeBuildTools/skills/simulator-build/scripts/build-run-simulator.py
+++ b/XcodeBuildTools/skills/simulator-build/scripts/build-run-simulator.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""
+Build and run an app on iOS Simulator.
+
+Usage:
+    ./build-run-simulator.py --workspace MyApp.xcworkspace --scheme MyApp --simulator-name "iPhone 15"
+
+This combines building, installing, and launching in one step.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+import re
+
+
+def find_simulator(name=None, udid=None, use_latest_os=False):
+    """Find a simulator by name or UDID."""
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode != 0:
+            return None, None, "Failed to list simulators"
+
+        data = json.loads(result.stdout)
+
+        if udid:
+            for runtime_devices in data.get("devices", {}).values():
+                for device in runtime_devices:
+                    if device.get("udid") == udid:
+                        return device.get("udid"), device.get("state"), None
+            return None, None, f"Simulator with UDID {udid} not found"
+
+        if name:
+            matches = []
+            runtimes = {r["identifier"]: r["name"] for r in data.get("runtimes", [])}
+
+            for runtime_id, device_list in data.get("devices", {}).items():
+                runtime_name = runtimes.get(runtime_id, "")
+                for device in device_list:
+                    if device.get("name") == name and device.get("isAvailable", False):
+                        matches.append({
+                            "udid": device.get("udid"),
+                            "runtime": runtime_name,
+                            "state": device.get("state")
+                        })
+
+            if not matches:
+                return None, None, f"No simulator named '{name}' found"
+
+            matches.sort(key=lambda x: x["runtime"], reverse=True)
+
+            if use_latest_os:
+                return matches[0]["udid"], matches[0]["state"], None
+
+            for m in matches:
+                if m["state"] == "Booted":
+                    return m["udid"], m["state"], None
+
+            return matches[0]["udid"], matches[0]["state"], None
+
+        return None, None, "Either --simulator-name or --simulator-id is required"
+
+    except Exception as e:
+        return None, None, str(e)
+
+
+def boot_simulator(simulator_id):
+    """Boot a simulator if not already booted."""
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "boot", simulator_id],
+            capture_output=True,
+            text=True,
+            timeout=60
+        )
+        # It's OK if already booted
+        return True, None
+    except Exception as e:
+        return False, str(e)
+
+
+def get_app_path(workspace=None, project=None, scheme=None, configuration="Debug", derived_data=None):
+    """Get the built app path from build settings."""
+    cmd = ["xcodebuild", "-showBuildSettings"]
+
+    if workspace:
+        cmd.extend(["-workspace", workspace])
+    else:
+        cmd.extend(["-project", project])
+
+    cmd.extend(["-scheme", scheme, "-configuration", configuration])
+
+    if derived_data:
+        cmd.extend(["-derivedDataPath", derived_data])
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+
+        built_products_dir = None
+        product_name = None
+
+        for line in result.stdout.split("\n"):
+            if "BUILT_PRODUCTS_DIR = " in line:
+                built_products_dir = line.split("=")[1].strip()
+            elif "PRODUCT_NAME = " in line:
+                product_name = line.split("=")[1].strip()
+
+        if built_products_dir and product_name:
+            return os.path.join(built_products_dir, f"{product_name}.app"), None
+
+        return None, "Could not determine app path from build settings"
+
+    except Exception as e:
+        return None, str(e)
+
+
+def get_bundle_id(app_path):
+    """Get bundle ID from app's Info.plist."""
+    plist_path = os.path.join(app_path, "Info.plist")
+    try:
+        result = subprocess.run(
+            ["defaults", "read", plist_path, "CFBundleIdentifier"],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+        if result.returncode == 0:
+            return result.stdout.strip(), None
+        return None, "Could not read bundle ID"
+    except Exception as e:
+        return None, str(e)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build and run on iOS Simulator")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to .xcworkspace")
+    group.add_argument("--project", help="Path to .xcodeproj")
+    parser.add_argument("--scheme", required=True, help="Build scheme")
+
+    sim_group = parser.add_mutually_exclusive_group(required=True)
+    sim_group.add_argument("--simulator-name", help="Simulator device name")
+    sim_group.add_argument("--simulator-id", help="Simulator UDID")
+
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--use-latest-os", action="store_true", help="Use latest OS")
+    parser.add_argument("--derived-data", help="Derived data path")
+    parser.add_argument("--extra-args", help="Extra xcodebuild args")
+
+    args = parser.parse_args()
+
+    # Validate paths
+    if args.workspace and not os.path.exists(args.workspace):
+        print(json.dumps({"success": False, "error": f"Workspace not found: {args.workspace}"}))
+        return 1
+
+    if args.project and not os.path.exists(args.project):
+        print(json.dumps({"success": False, "error": f"Project not found: {args.project}"}))
+        return 1
+
+    # Find simulator
+    simulator_id, state, error = find_simulator(
+        name=args.simulator_name,
+        udid=args.simulator_id,
+        use_latest_os=args.use_latest_os
+    )
+
+    if error:
+        print(json.dumps({"success": False, "error": error}))
+        return 1
+
+    # Boot if needed
+    if state != "Booted":
+        success, error = boot_simulator(simulator_id)
+        if not success:
+            print(json.dumps({"success": False, "error": f"Failed to boot simulator: {error}"}))
+            return 1
+
+    # Build
+    cmd = ["xcodebuild"]
+
+    if args.workspace:
+        cmd.extend(["-workspace", args.workspace])
+    else:
+        cmd.extend(["-project", args.project])
+
+    cmd.extend([
+        "-scheme", args.scheme,
+        "-configuration", args.configuration,
+        "-destination", f"id={simulator_id}",
+        "-skipMacroValidation",
+        "-skipPackagePluginValidation",
+        "build"
+    ])
+
+    if args.derived_data:
+        cmd.extend(["-derivedDataPath", args.derived_data])
+
+    if args.extra_args:
+        cmd.extend(args.extra_args.split(","))
+
+    try:
+        build_result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+
+        if build_result.returncode != 0:
+            errors = [l for l in build_result.stdout.split("\n") if ": error:" in l][:10]
+            print(json.dumps({
+                "success": False,
+                "error": "Build failed",
+                "errors": errors
+            }))
+            return 1
+
+    except subprocess.TimeoutExpired:
+        print(json.dumps({"success": False, "error": "Build timed out"}))
+        return 1
+
+    # Get app path and bundle ID
+    app_path, error = get_app_path(
+        workspace=args.workspace,
+        project=args.project,
+        scheme=args.scheme,
+        configuration=args.configuration,
+        derived_data=args.derived_data
+    )
+
+    if error:
+        print(json.dumps({"success": False, "error": f"Build succeeded but could not find app: {error}"}))
+        return 1
+
+    bundle_id, error = get_bundle_id(app_path)
+    if error:
+        bundle_id = "unknown"
+
+    # Install and launch
+    try:
+        subprocess.run(
+            ["xcrun", "simctl", "install", simulator_id, app_path],
+            capture_output=True,
+            text=True,
+            timeout=60
+        )
+
+        subprocess.run(
+            ["xcrun", "simctl", "launch", simulator_id, bundle_id],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+    except Exception as e:
+        print(json.dumps({
+            "success": False,
+            "error": f"Build succeeded but launch failed: {e}"
+        }))
+        return 1
+
+    print(json.dumps({
+        "success": True,
+        "message": f"Built and launched {args.scheme} on simulator",
+        "simulator_id": simulator_id,
+        "bundle_id": bundle_id,
+        "app_path": app_path
+    }, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/simulator-build/scripts/build-simulator.py
+++ b/XcodeBuildTools/skills/simulator-build/scripts/build-simulator.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""
+Build an Xcode project/workspace for iOS Simulator.
+
+Usage:
+    ./build-simulator.py --workspace MyApp.xcworkspace --scheme MyApp --simulator-name "iPhone 15"
+    ./build-simulator.py --project MyApp.xcodeproj --scheme MyApp --simulator-id <UDID>
+
+Options:
+    --workspace PATH       Path to .xcworkspace file
+    --project PATH         Path to .xcodeproj file
+    --scheme NAME          Build scheme name (required)
+    --simulator-name NAME  Simulator device name
+    --simulator-id UDID    Simulator UDID
+    --configuration CFG    Build configuration (default: Debug)
+    --use-latest-os        Use latest OS version for simulator name
+    --derived-data PATH    Custom derived data path
+    --extra-args ARGS      Additional xcodebuild arguments (comma-separated)
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+
+
+def find_simulator(name=None, udid=None, use_latest_os=False):
+    """Find a simulator by name or UDID."""
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode != 0:
+            return None, "Failed to list simulators"
+
+        data = json.loads(result.stdout)
+
+        # If UDID provided, find it directly
+        if udid:
+            for runtime_devices in data.get("devices", {}).values():
+                for device in runtime_devices:
+                    if device.get("udid") == udid:
+                        return device.get("udid"), None
+            return None, f"Simulator with UDID {udid} not found"
+
+        # Find by name
+        if name:
+            matches = []
+            runtimes = {r["identifier"]: r["name"] for r in data.get("runtimes", [])}
+
+            for runtime_id, device_list in data.get("devices", {}).items():
+                runtime_name = runtimes.get(runtime_id, "")
+                for device in device_list:
+                    if device.get("name") == name and device.get("isAvailable", False):
+                        matches.append({
+                            "udid": device.get("udid"),
+                            "runtime": runtime_name,
+                            "state": device.get("state")
+                        })
+
+            if not matches:
+                return None, f"No simulator named '{name}' found"
+
+            # Sort by runtime (newest first) - iOS 17 > iOS 16
+            matches.sort(key=lambda x: x["runtime"], reverse=True)
+
+            if use_latest_os:
+                return matches[0]["udid"], None
+
+            # Prefer booted simulator, otherwise use latest
+            for m in matches:
+                if m["state"] == "Booted":
+                    return m["udid"], None
+
+            return matches[0]["udid"], None
+
+        return None, "Either --simulator-name or --simulator-id is required"
+
+    except Exception as e:
+        return None, str(e)
+
+
+def run_xcodebuild(args, timeout=600):
+    """Run xcodebuild and return parsed result."""
+    try:
+        result = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout
+        )
+
+        errors = []
+        warnings = []
+
+        for line in result.stdout.split("\n") + result.stderr.split("\n"):
+            if ": error:" in line:
+                errors.append(line.strip())
+            elif ": warning:" in line:
+                warnings.append(line.strip())
+
+        return {
+            "success": result.returncode == 0,
+            "return_code": result.returncode,
+            "errors": errors[:20],
+            "warnings": warnings[:20],
+            "error_count": len(errors),
+            "warning_count": len(warnings)
+        }
+
+    except subprocess.TimeoutExpired:
+        return {"success": False, "error": "Build timed out after 10 minutes"}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build for iOS Simulator")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to .xcworkspace")
+    group.add_argument("--project", help="Path to .xcodeproj")
+    parser.add_argument("--scheme", required=True, help="Build scheme")
+
+    sim_group = parser.add_mutually_exclusive_group(required=True)
+    sim_group.add_argument("--simulator-name", help="Simulator device name")
+    sim_group.add_argument("--simulator-id", help="Simulator UDID")
+
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--use-latest-os", action="store_true", help="Use latest OS for simulator name")
+    parser.add_argument("--derived-data", help="Derived data path")
+    parser.add_argument("--extra-args", help="Extra xcodebuild args (comma-separated)")
+
+    args = parser.parse_args()
+
+    # Validate paths
+    if args.workspace and not os.path.exists(args.workspace):
+        print(json.dumps({"success": False, "error": f"Workspace not found: {args.workspace}"}))
+        return 1
+
+    if args.project and not os.path.exists(args.project):
+        print(json.dumps({"success": False, "error": f"Project not found: {args.project}"}))
+        return 1
+
+    # Find simulator
+    simulator_id, error = find_simulator(
+        name=args.simulator_name,
+        udid=args.simulator_id,
+        use_latest_os=args.use_latest_os
+    )
+
+    if error:
+        print(json.dumps({"success": False, "error": error}))
+        return 1
+
+    # Build xcodebuild command
+    cmd = ["xcodebuild"]
+
+    if args.workspace:
+        cmd.extend(["-workspace", args.workspace])
+    else:
+        cmd.extend(["-project", args.project])
+
+    cmd.extend([
+        "-scheme", args.scheme,
+        "-configuration", args.configuration,
+        "-destination", f"id={simulator_id}",
+        "-skipMacroValidation",
+        "-skipPackagePluginValidation",
+        "build"
+    ])
+
+    if args.derived_data:
+        cmd.extend(["-derivedDataPath", args.derived_data])
+
+    if args.extra_args:
+        cmd.extend(args.extra_args.split(","))
+
+    # Run build
+    result = run_xcodebuild(cmd)
+
+    if result["success"]:
+        result["message"] = f"Build succeeded for simulator {simulator_id}"
+        result["simulator_id"] = simulator_id
+        result["scheme"] = args.scheme
+        result["configuration"] = args.configuration
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/simulator-build/scripts/install-app-simulator.py
+++ b/XcodeBuildTools/skills/simulator-build/scripts/install-app-simulator.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Install an app on an iOS Simulator.
+
+Usage:
+    ./install-app-simulator.py --simulator-id <UDID> --app /path/to/MyApp.app
+
+Options:
+    --simulator-id UDID    Simulator UDID (required)
+    --app PATH             Path to .app bundle (required)
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Install app on iOS Simulator")
+    parser.add_argument("--simulator-id", required=True, help="Simulator UDID")
+    parser.add_argument("--app", required=True, help="Path to .app bundle")
+
+    args = parser.parse_args()
+
+    # Validate app path
+    if not os.path.exists(args.app):
+        print(json.dumps({"success": False, "error": f"App bundle not found: {args.app}"}))
+        return 1
+
+    if not args.app.endswith(".app"):
+        print(json.dumps({"success": False, "error": "Path must point to a .app bundle"}))
+        return 1
+
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "install", args.simulator_id, args.app],
+            capture_output=True,
+            text=True,
+            timeout=120
+        )
+
+        if result.returncode == 0:
+            print(json.dumps({
+                "success": True,
+                "message": f"App installed on simulator {args.simulator_id}",
+                "simulator_id": args.simulator_id,
+                "app_path": args.app
+            }, indent=2))
+            return 0
+        else:
+            error = result.stderr or result.stdout or "Installation failed"
+            print(json.dumps({
+                "success": False,
+                "error": error,
+                "simulator_id": args.simulator_id
+            }))
+            return 1
+
+    except subprocess.TimeoutExpired:
+        print(json.dumps({"success": False, "error": "Installation timed out"}))
+        return 1
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/simulator-build/scripts/launch-app-simulator.py
+++ b/XcodeBuildTools/skills/simulator-build/scripts/launch-app-simulator.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Launch an app on an iOS Simulator.
+
+Usage:
+    ./launch-app-simulator.py --simulator-id <UDID> --bundle-id com.example.myapp
+    ./launch-app-simulator.py --simulator-id <UDID> --bundle-id com.example.myapp --console
+
+Options:
+    --simulator-id UDID    Simulator UDID (required)
+    --bundle-id ID         App bundle identifier (required)
+    --console              Show console output
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Launch app on iOS Simulator")
+    parser.add_argument("--simulator-id", required=True, help="Simulator UDID")
+    parser.add_argument("--bundle-id", required=True, help="App bundle identifier")
+    parser.add_argument("--console", action="store_true", help="Show console output")
+
+    args = parser.parse_args()
+
+    try:
+        cmd = ["xcrun", "simctl", "launch"]
+
+        if args.console:
+            cmd.append("--console")
+
+        cmd.extend([args.simulator_id, args.bundle_id])
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode == 0:
+            # Try to extract PID from output
+            pid = None
+            output = result.stdout.strip()
+            if output and output.split()[-1].isdigit():
+                pid = int(output.split()[-1])
+
+            response = {
+                "success": True,
+                "message": f"Launched {args.bundle_id}",
+                "bundle_id": args.bundle_id,
+                "simulator_id": args.simulator_id
+            }
+            if pid:
+                response["pid"] = pid
+
+            print(json.dumps(response, indent=2))
+            return 0
+        else:
+            error = result.stderr or result.stdout or "Launch failed"
+
+            # Check for common errors
+            if "Unable to lookup" in error or "not found" in error.lower():
+                error = f"App {args.bundle_id} is not installed on this simulator"
+
+            print(json.dumps({
+                "success": False,
+                "error": error,
+                "bundle_id": args.bundle_id,
+                "simulator_id": args.simulator_id
+            }))
+            return 1
+
+    except subprocess.TimeoutExpired:
+        print(json.dumps({"success": False, "error": "Launch timed out"}))
+        return 1
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/simulator-build/scripts/list-simulators.py
+++ b/XcodeBuildTools/skills/simulator-build/scripts/list-simulators.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+List available iOS simulators.
+
+Usage:
+    ./list-simulators.py [--booted] [--runtime RUNTIME]
+
+Options:
+    --booted          List only booted simulators
+    --runtime RUNTIME Filter by runtime (e.g., "iOS 17")
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def get_simulators():
+    """Get simulator list from simctl."""
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode != 0:
+            return None, result.stderr
+
+        return json.loads(result.stdout), None
+
+    except subprocess.TimeoutExpired:
+        return None, "Command timed out"
+    except json.JSONDecodeError as e:
+        return None, f"Failed to parse JSON: {e}"
+    except Exception as e:
+        return None, str(e)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List iOS simulators")
+    parser.add_argument("--booted", action="store_true", help="List only booted simulators")
+    parser.add_argument("--runtime", help="Filter by runtime (e.g., 'iOS 17')")
+
+    args = parser.parse_args()
+
+    data, error = get_simulators()
+
+    if data is None:
+        print(json.dumps({"success": False, "error": error}))
+        return 1
+
+    # Build runtime lookup
+    runtimes = {}
+    for runtime in data.get("runtimes", []):
+        runtimes[runtime.get("identifier", "")] = runtime.get("name", "Unknown")
+
+    # Collect simulators
+    simulators = []
+    devices = data.get("devices", {})
+
+    for runtime_id, device_list in devices.items():
+        runtime_name = runtimes.get(runtime_id, runtime_id)
+
+        # Filter by runtime if specified
+        if args.runtime and args.runtime.lower() not in runtime_name.lower():
+            continue
+
+        for device in device_list:
+            state = device.get("state", "Unknown")
+
+            # Filter booted only if specified
+            if args.booted and state != "Booted":
+                continue
+
+            simulators.append({
+                "name": device.get("name", "Unknown"),
+                "udid": device.get("udid", "Unknown"),
+                "state": state,
+                "runtime": runtime_name,
+                "is_available": device.get("isAvailable", False)
+            })
+
+    # Sort by runtime (newest first) then by name
+    simulators.sort(key=lambda x: (x["runtime"], x["name"]), reverse=True)
+
+    result = {
+        "success": True,
+        "count": len(simulators),
+        "simulators": simulators
+    }
+
+    if len(simulators) == 0:
+        if args.booted:
+            result["message"] = "No booted simulators. Use simulator-management skill to boot one."
+        else:
+            result["message"] = "No simulators available. Install simulator runtimes in Xcode."
+
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/simulator-build/scripts/record-video.py
+++ b/XcodeBuildTools/skills/simulator-build/scripts/record-video.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""
+Record video of an iOS Simulator.
+
+Usage:
+    ./record-video.py --simulator-id <UDID> --output /path/to/video.mp4 --start
+    ./record-video.py --stop
+
+Options:
+    --simulator-id UDID    Simulator UDID
+    --output PATH          Output file path
+    --start                Start recording
+    --stop                 Stop recording
+    --codec CODEC          Video codec (h264, hevc) - default: h264
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+import signal
+import time
+
+PID_FILE = "/tmp/simctl-record.pid"
+
+
+def get_booted_simulator():
+    """Get the first booted simulator."""
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode != 0:
+            return None, "Failed to list simulators"
+
+        data = json.loads(result.stdout)
+
+        for runtime_devices in data.get("devices", {}).values():
+            for device in runtime_devices:
+                if device.get("state") == "Booted":
+                    return device.get("udid"), None
+
+        return None, "No booted simulator found"
+
+    except Exception as e:
+        return None, str(e)
+
+
+def start_recording(simulator_id, output_path, codec="h264"):
+    """Start video recording."""
+    # Check if already recording
+    if os.path.exists(PID_FILE):
+        print(json.dumps({
+            "success": False,
+            "error": "Recording already in progress. Use --stop first."
+        }))
+        return 1
+
+    # Ensure directory exists
+    output_dir = os.path.dirname(output_path)
+    if output_dir and not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    try:
+        # Start recording in background
+        cmd = ["xcrun", "simctl", "io", simulator_id, "recordVideo"]
+
+        if codec:
+            cmd.extend(["--codec", codec])
+
+        cmd.append(output_path)
+
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True
+        )
+
+        # Save PID and output path for later
+        with open(PID_FILE, "w") as f:
+            f.write(f"{process.pid}\n{output_path}\n{simulator_id}")
+
+        print(json.dumps({
+            "success": True,
+            "message": "Recording started",
+            "output": output_path,
+            "simulator_id": simulator_id,
+            "pid": process.pid,
+            "hint": "Use --stop to stop recording"
+        }, indent=2))
+        return 0
+
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+def stop_recording():
+    """Stop video recording."""
+    if not os.path.exists(PID_FILE):
+        print(json.dumps({
+            "success": False,
+            "error": "No recording in progress"
+        }))
+        return 1
+
+    try:
+        with open(PID_FILE, "r") as f:
+            lines = f.read().strip().split("\n")
+            pid = int(lines[0])
+            output_path = lines[1] if len(lines) > 1 else None
+            simulator_id = lines[2] if len(lines) > 2 else None
+
+        # Send SIGINT to gracefully stop recording
+        os.kill(pid, signal.SIGINT)
+
+        # Wait a bit for file to be finalized
+        time.sleep(1)
+
+        # Clean up PID file
+        os.unlink(PID_FILE)
+
+        response = {
+            "success": True,
+            "message": "Recording stopped"
+        }
+
+        if output_path:
+            response["output"] = output_path
+            if os.path.exists(output_path):
+                response["size_bytes"] = os.path.getsize(output_path)
+
+        if simulator_id:
+            response["simulator_id"] = simulator_id
+
+        print(json.dumps(response, indent=2))
+        return 0
+
+    except ProcessLookupError:
+        # Process already stopped
+        if os.path.exists(PID_FILE):
+            os.unlink(PID_FILE)
+        print(json.dumps({
+            "success": True,
+            "message": "Recording process was already stopped"
+        }))
+        return 0
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Record simulator video")
+    parser.add_argument("--simulator-id", help="Simulator UDID")
+    parser.add_argument("--output", help="Output file path")
+    parser.add_argument("--start", action="store_true", help="Start recording")
+    parser.add_argument("--stop", action="store_true", help="Stop recording")
+    parser.add_argument("--codec", default="h264", choices=["h264", "hevc"], help="Video codec")
+
+    args = parser.parse_args()
+
+    if args.stop:
+        return stop_recording()
+
+    if args.start:
+        # Get simulator ID
+        simulator_id = args.simulator_id
+        if not simulator_id:
+            simulator_id, error = get_booted_simulator()
+            if error:
+                print(json.dumps({"success": False, "error": error}))
+                return 1
+
+        # Get output path
+        output_path = args.output
+        if not output_path:
+            timestamp = int(time.time())
+            output_path = f"/tmp/sim-recording-{timestamp}.mp4"
+
+        return start_recording(simulator_id, output_path, args.codec)
+
+    print(json.dumps({
+        "success": False,
+        "error": "Specify --start or --stop"
+    }))
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/simulator-build/scripts/screenshot.py
+++ b/XcodeBuildTools/skills/simulator-build/scripts/screenshot.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Take a screenshot of an iOS Simulator.
+
+Usage:
+    ./screenshot.py [--simulator-id <UDID>] [--output /path/to/screenshot.png]
+
+Options:
+    --simulator-id UDID    Simulator UDID (uses booted if not specified)
+    --output PATH          Output file path (auto-generated if not specified)
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+import time
+
+
+def get_booted_simulator():
+    """Get the first booted simulator."""
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode != 0:
+            return None, "Failed to list simulators"
+
+        data = json.loads(result.stdout)
+
+        for runtime_devices in data.get("devices", {}).values():
+            for device in runtime_devices:
+                if device.get("state") == "Booted":
+                    return device.get("udid"), None
+
+        return None, "No booted simulator found. Boot a simulator first."
+
+    except Exception as e:
+        return None, str(e)
+
+
+def get_simulator_info(simulator_id):
+    """Get simulator screen info."""
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode != 0:
+            return None
+
+        data = json.loads(result.stdout)
+
+        for runtime_devices in data.get("devices", {}).values():
+            for device in runtime_devices:
+                if device.get("udid") == simulator_id:
+                    return device.get("name", "Unknown")
+
+        return None
+
+    except Exception:
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Take simulator screenshot")
+    parser.add_argument("--simulator-id", help="Simulator UDID")
+    parser.add_argument("--output", help="Output file path")
+
+    args = parser.parse_args()
+
+    # Get simulator ID
+    simulator_id = args.simulator_id
+    if not simulator_id:
+        simulator_id, error = get_booted_simulator()
+        if error:
+            print(json.dumps({"success": False, "error": error}))
+            return 1
+
+    # Generate output path if not provided
+    output_path = args.output
+    if not output_path:
+        timestamp = int(time.time())
+        output_path = f"/tmp/sim-screenshot-{timestamp}.png"
+
+    # Ensure directory exists
+    output_dir = os.path.dirname(output_path)
+    if output_dir and not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "io", simulator_id, "screenshot", output_path],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode == 0 and os.path.exists(output_path):
+            # Get file size
+            size_bytes = os.path.getsize(output_path)
+
+            # Try to get image dimensions
+            screen_info = {}
+            try:
+                from PIL import Image
+                with Image.open(output_path) as img:
+                    width, height = img.size
+                    # Estimate scale (common scales are 2 or 3 for Retina)
+                    scale = 3 if width > 1000 else 2
+                    screen_info = {
+                        "width_pixels": width,
+                        "height_pixels": height,
+                        "width_points": width // scale,
+                        "height_points": height // scale,
+                        "scale": scale
+                    }
+            except ImportError:
+                pass  # PIL not available
+
+            response = {
+                "success": True,
+                "message": "Screenshot saved",
+                "path": output_path,
+                "simulator_id": simulator_id,
+                "size_bytes": size_bytes
+            }
+
+            if screen_info:
+                response["screen"] = screen_info
+
+            # Get simulator name
+            name = get_simulator_info(simulator_id)
+            if name:
+                response["simulator_name"] = name
+
+            print(json.dumps(response, indent=2))
+            return 0
+        else:
+            error = result.stderr or result.stdout or "Screenshot failed"
+            print(json.dumps({"success": False, "error": error}))
+            return 1
+
+    except subprocess.TimeoutExpired:
+        print(json.dumps({"success": False, "error": "Screenshot timed out"}))
+        return 1
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/simulator-build/scripts/stop-app-simulator.py
+++ b/XcodeBuildTools/skills/simulator-build/scripts/stop-app-simulator.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Terminate an app on an iOS Simulator.
+
+Usage:
+    ./stop-app-simulator.py --simulator-id <UDID> --bundle-id com.example.myapp
+
+Options:
+    --simulator-id UDID    Simulator UDID (required)
+    --bundle-id ID         App bundle identifier (required)
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Stop app on iOS Simulator")
+    parser.add_argument("--simulator-id", required=True, help="Simulator UDID")
+    parser.add_argument("--bundle-id", required=True, help="App bundle identifier")
+
+    args = parser.parse_args()
+
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "terminate", args.simulator_id, args.bundle_id],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        # simctl terminate returns 0 even if app wasn't running
+        print(json.dumps({
+            "success": True,
+            "message": f"Terminated {args.bundle_id}",
+            "bundle_id": args.bundle_id,
+            "simulator_id": args.simulator_id
+        }, indent=2))
+        return 0
+
+    except subprocess.TimeoutExpired:
+        print(json.dumps({"success": False, "error": "Terminate timed out"}))
+        return 1
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/simulator-build/scripts/test-simulator.py
+++ b/XcodeBuildTools/skills/simulator-build/scripts/test-simulator.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+Run tests on an iOS Simulator.
+
+Usage:
+    ./test-simulator.py --workspace MyApp.xcworkspace --scheme MyAppTests --simulator-name "iPhone 15"
+    ./test-simulator.py --project MyApp.xcodeproj --scheme MyAppTests --simulator-id <UDID>
+
+Options:
+    --workspace PATH       Path to .xcworkspace file
+    --project PATH         Path to .xcodeproj file
+    --scheme NAME          Test scheme name (required)
+    --simulator-name NAME  Simulator device name
+    --simulator-id UDID    Simulator UDID
+    --configuration CFG    Build configuration (default: Debug)
+    --only-testing TESTS   Run only specific tests (comma-separated)
+    --skip-testing TESTS   Skip specific tests (comma-separated)
+    --derived-data PATH    Custom derived data path
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+import re
+
+
+def find_simulator(name=None, udid=None, use_latest_os=False):
+    """Find a simulator by name or UDID."""
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode != 0:
+            return None, "Failed to list simulators"
+
+        data = json.loads(result.stdout)
+
+        if udid:
+            for runtime_devices in data.get("devices", {}).values():
+                for device in runtime_devices:
+                    if device.get("udid") == udid:
+                        return device.get("udid"), None
+            return None, f"Simulator with UDID {udid} not found"
+
+        if name:
+            matches = []
+            runtimes = {r["identifier"]: r["name"] for r in data.get("runtimes", [])}
+
+            for runtime_id, device_list in data.get("devices", {}).items():
+                runtime_name = runtimes.get(runtime_id, "")
+                for device in device_list:
+                    if device.get("name") == name and device.get("isAvailable", False):
+                        matches.append({
+                            "udid": device.get("udid"),
+                            "runtime": runtime_name,
+                            "state": device.get("state")
+                        })
+
+            if not matches:
+                return None, f"No simulator named '{name}' found"
+
+            matches.sort(key=lambda x: x["runtime"], reverse=True)
+
+            for m in matches:
+                if m["state"] == "Booted":
+                    return m["udid"], None
+
+            return matches[0]["udid"], None
+
+        return None, "Either --simulator-name or --simulator-id is required"
+
+    except Exception as e:
+        return None, str(e)
+
+
+def run_tests(args, simulator_id, timeout=1200):
+    """Run xcodebuild tests and return parsed result."""
+    cmd = ["xcodebuild"]
+
+    if args.workspace:
+        cmd.extend(["-workspace", args.workspace])
+    else:
+        cmd.extend(["-project", args.project])
+
+    cmd.extend([
+        "-scheme", args.scheme,
+        "-configuration", args.configuration,
+        "-destination", f"id={simulator_id}",
+        "-skipMacroValidation",
+        "-skipPackagePluginValidation",
+        "test"
+    ])
+
+    if args.derived_data:
+        cmd.extend(["-derivedDataPath", args.derived_data])
+
+    if args.only_testing:
+        for test in args.only_testing.split(","):
+            cmd.extend(["-only-testing", test.strip()])
+
+    if args.skip_testing:
+        for test in args.skip_testing.split(","):
+            cmd.extend(["-skip-testing", test.strip()])
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout
+        )
+
+        output = result.stdout + result.stderr
+
+        tests_passed = []
+        tests_failed = []
+        errors = []
+
+        for line in output.split("\n"):
+            if "Test Case" in line:
+                if "passed" in line.lower():
+                    match = re.search(r"Test Case '-\[(\S+) (\S+)\]' passed", line)
+                    if match:
+                        tests_passed.append(f"{match.group(1)}/{match.group(2)}")
+                elif "failed" in line.lower():
+                    match = re.search(r"Test Case '-\[(\S+) (\S+)\]' failed", line)
+                    if match:
+                        tests_failed.append(f"{match.group(1)}/{match.group(2)}")
+
+            if ": error:" in line:
+                errors.append(line.strip())
+
+        test_succeeded = "** TEST SUCCEEDED **" in output or result.returncode == 0
+
+        return {
+            "success": test_succeeded and len(tests_failed) == 0,
+            "return_code": result.returncode,
+            "tests_passed": len(tests_passed),
+            "tests_failed": len(tests_failed),
+            "passed_tests": tests_passed[:50],
+            "failed_tests": tests_failed,
+            "errors": errors[:10]
+        }
+
+    except subprocess.TimeoutExpired:
+        return {"success": False, "error": "Tests timed out after 20 minutes"}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run tests on iOS Simulator")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to .xcworkspace")
+    group.add_argument("--project", help="Path to .xcodeproj")
+    parser.add_argument("--scheme", required=True, help="Test scheme")
+
+    sim_group = parser.add_mutually_exclusive_group(required=True)
+    sim_group.add_argument("--simulator-name", help="Simulator device name")
+    sim_group.add_argument("--simulator-id", help="Simulator UDID")
+
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--only-testing", help="Run only these tests (comma-separated)")
+    parser.add_argument("--skip-testing", help="Skip these tests (comma-separated)")
+    parser.add_argument("--derived-data", help="Derived data path")
+
+    args = parser.parse_args()
+
+    # Validate paths
+    if args.workspace and not os.path.exists(args.workspace):
+        print(json.dumps({"success": False, "error": f"Workspace not found: {args.workspace}"}))
+        return 1
+
+    if args.project and not os.path.exists(args.project):
+        print(json.dumps({"success": False, "error": f"Project not found: {args.project}"}))
+        return 1
+
+    # Find simulator
+    simulator_id, error = find_simulator(
+        name=args.simulator_name,
+        udid=args.simulator_id
+    )
+
+    if error:
+        print(json.dumps({"success": False, "error": error}))
+        return 1
+
+    # Run tests
+    result = run_tests(args, simulator_id)
+
+    result["scheme"] = args.scheme
+    result["simulator_id"] = simulator_id
+
+    if result["success"]:
+        result["message"] = f"All {result['tests_passed']} tests passed"
+    elif result.get("tests_failed", 0) > 0:
+        result["message"] = f"{result['tests_failed']} test(s) failed"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/simulator-management/SKILL.md
+++ b/XcodeBuildTools/skills/simulator-management/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: simulator-management
+description: Manage iOS Simulators - boot, shutdown, erase, configure location, appearance, and status bar. Use this skill when you need to control simulator state or settings.
+---
+
+# Simulator Management
+
+Manage iOS Simulator lifecycle and settings.
+
+## Prerequisites
+
+- macOS with Xcode installed
+- At least one iOS Simulator runtime installed
+
+## Scripts
+
+All scripts are in the `scripts/` directory and output JSON.
+
+### boot-simulator.py
+
+Boot an iOS Simulator.
+
+```bash
+# Boot by name (uses latest runtime)
+scripts/boot-simulator.py --name "iPhone 15"
+
+# Boot by UDID
+scripts/boot-simulator.py --udid "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+
+# Boot without opening Simulator.app window
+scripts/boot-simulator.py --name "iPhone 15" --headless
+```
+
+### shutdown-simulator.py
+
+Shutdown a simulator or all simulators.
+
+```bash
+# Shutdown specific simulator
+scripts/shutdown-simulator.py --udid "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+
+# Shutdown all simulators
+scripts/shutdown-simulator.py --all
+```
+
+### open-simulator.py
+
+Open the Simulator.app window for a booted simulator.
+
+```bash
+scripts/open-simulator.py --udid "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+
+# Open and bring to front
+scripts/open-simulator.py --udid "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" --focus
+```
+
+### erase-simulator.py
+
+Erase a simulator (reset to factory settings).
+
+```bash
+# Erase specific simulator
+scripts/erase-simulator.py --udid "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+
+# Erase all simulators
+scripts/erase-simulator.py --all
+
+# Erase all simulators of a specific runtime
+scripts/erase-simulator.py --runtime "iOS 17"
+```
+
+### set-location.py
+
+Set the simulated GPS location.
+
+```bash
+# Set to specific coordinates
+scripts/set-location.py --udid <UDID> --latitude 37.7749 --longitude -122.4194
+
+# Set to a named location
+scripts/set-location.py --udid <UDID> --location "San Francisco"
+```
+
+**Common Locations:**
+- San Francisco: `--latitude 37.7749 --longitude -122.4194`
+- New York: `--latitude 40.7128 --longitude -74.0060`
+- London: `--latitude 51.5074 --longitude -0.1278`
+- Tokyo: `--latitude 35.6762 --longitude 139.6503`
+
+### reset-location.py
+
+Reset/clear the simulated GPS location.
+
+```bash
+scripts/reset-location.py --udid <UDID>
+```
+
+### set-appearance.py
+
+Set the simulator appearance (light/dark mode).
+
+```bash
+scripts/set-appearance.py --udid <UDID> --mode dark
+scripts/set-appearance.py --udid <UDID> --mode light
+```
+
+### set-statusbar.py
+
+Override the simulator status bar display.
+
+```bash
+# Set a clean status bar for screenshots
+scripts/set-statusbar.py --udid <UDID> --time "9:41" --battery 100 --wifi 3 --cellular 4
+
+# Clear overrides
+scripts/set-statusbar.py --udid <UDID> --clear
+```
+
+**Options:**
+- `--time TIME`: Status bar time (e.g., "9:41")
+- `--battery LEVEL`: Battery percentage (0-100)
+- `--wifi BARS`: WiFi signal bars (0-3)
+- `--cellular BARS`: Cellular signal bars (0-4)
+- `--clear`: Remove all overrides
+
+## Common Workflows
+
+### Prepare Simulator for Testing
+```bash
+# 1. Boot simulator
+scripts/boot-simulator.py --name "iPhone 15"
+
+# 2. Set location
+scripts/set-location.py --udid <UDID> --latitude 37.7749 --longitude -122.4194
+
+# 3. Set appearance
+scripts/set-appearance.py --udid <UDID> --mode light
+```
+
+### Prepare for Screenshots
+```bash
+# 1. Boot simulator
+scripts/boot-simulator.py --name "iPhone 15 Pro Max"
+
+# 2. Set clean status bar
+scripts/set-statusbar.py --udid <UDID> --time "9:41" --battery 100 --wifi 3 --cellular 4
+
+# 3. Take screenshot using simulator-build skill
+```
+
+### Clean Up
+```bash
+# Shutdown all simulators
+scripts/shutdown-simulator.py --all
+
+# Or erase all to reset to fresh state
+scripts/erase-simulator.py --all
+```

--- a/XcodeBuildTools/skills/simulator-management/scripts/boot-simulator.py
+++ b/XcodeBuildTools/skills/simulator-management/scripts/boot-simulator.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Boot an iOS Simulator.
+
+Usage:
+    ./boot-simulator.py --name "iPhone 15"
+    ./boot-simulator.py --udid "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+    ./boot-simulator.py --name "iPhone 15" --headless
+
+Options:
+    --name NAME     Simulator device name
+    --udid UDID     Simulator UDID
+    --headless      Don't open Simulator.app window
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def find_simulator_by_name(name):
+    """Find a simulator by name, preferring latest runtime."""
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode != 0:
+            return None, "Failed to list simulators"
+
+        data = json.loads(result.stdout)
+        runtimes = {r["identifier"]: r["name"] for r in data.get("runtimes", [])}
+
+        matches = []
+        for runtime_id, device_list in data.get("devices", {}).items():
+            runtime_name = runtimes.get(runtime_id, "")
+            for device in device_list:
+                if device.get("name") == name and device.get("isAvailable", False):
+                    matches.append({
+                        "udid": device.get("udid"),
+                        "runtime": runtime_name,
+                        "state": device.get("state")
+                    })
+
+        if not matches:
+            return None, f"No simulator named '{name}' found"
+
+        # Sort by runtime (newest first)
+        matches.sort(key=lambda x: x["runtime"], reverse=True)
+        return matches[0], None
+
+    except Exception as e:
+        return None, str(e)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Boot iOS Simulator")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--name", help="Simulator device name")
+    group.add_argument("--udid", help="Simulator UDID")
+    parser.add_argument("--headless", action="store_true", help="Don't open Simulator.app")
+
+    args = parser.parse_args()
+
+    # Get simulator UDID
+    simulator_udid = args.udid
+    simulator_info = None
+
+    if args.name:
+        simulator_info, error = find_simulator_by_name(args.name)
+        if error:
+            print(json.dumps({"success": False, "error": error}))
+            return 1
+        simulator_udid = simulator_info["udid"]
+
+        # Check if already booted
+        if simulator_info["state"] == "Booted":
+            print(json.dumps({
+                "success": True,
+                "message": "Simulator is already booted",
+                "udid": simulator_udid,
+                "name": args.name,
+                "runtime": simulator_info["runtime"]
+            }, indent=2))
+            return 0
+
+    try:
+        # Boot the simulator
+        result = subprocess.run(
+            ["xcrun", "simctl", "boot", simulator_udid],
+            capture_output=True,
+            text=True,
+            timeout=60
+        )
+
+        if result.returncode != 0:
+            # Check if already booted
+            if "Unable to boot device in current state: Booted" in result.stderr:
+                response = {
+                    "success": True,
+                    "message": "Simulator is already booted",
+                    "udid": simulator_udid
+                }
+                if simulator_info:
+                    response["name"] = args.name
+                    response["runtime"] = simulator_info["runtime"]
+                print(json.dumps(response, indent=2))
+                return 0
+            else:
+                print(json.dumps({
+                    "success": False,
+                    "error": result.stderr or "Failed to boot simulator"
+                }))
+                return 1
+
+        # Open Simulator.app unless headless
+        if not args.headless:
+            subprocess.run(
+                ["open", "-a", "Simulator", "--args", "-CurrentDeviceUDID", simulator_udid],
+                capture_output=True,
+                timeout=10
+            )
+
+        response = {
+            "success": True,
+            "message": "Simulator booted successfully",
+            "udid": simulator_udid
+        }
+        if simulator_info:
+            response["name"] = args.name
+            response["runtime"] = simulator_info["runtime"]
+
+        print(json.dumps(response, indent=2))
+        return 0
+
+    except subprocess.TimeoutExpired:
+        print(json.dumps({"success": False, "error": "Boot timed out"}))
+        return 1
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/simulator-management/scripts/erase-simulator.py
+++ b/XcodeBuildTools/skills/simulator-management/scripts/erase-simulator.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Erase iOS Simulator(s) - reset to factory settings.
+
+Usage:
+    ./erase-simulator.py --udid "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+    ./erase-simulator.py --all
+    ./erase-simulator.py --runtime "iOS 17"
+
+Options:
+    --udid UDID       Erase specific simulator
+    --all             Erase all simulators
+    --runtime RUNTIME Erase simulators matching runtime (e.g., "iOS 17")
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def get_simulators_by_runtime(runtime_filter):
+    """Get simulators matching a runtime filter."""
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode != 0:
+            return None, "Failed to list simulators"
+
+        data = json.loads(result.stdout)
+        runtimes = {r["identifier"]: r["name"] for r in data.get("runtimes", [])}
+
+        matches = []
+        for runtime_id, device_list in data.get("devices", {}).items():
+            runtime_name = runtimes.get(runtime_id, "")
+            if runtime_filter.lower() in runtime_name.lower():
+                for device in device_list:
+                    if device.get("isAvailable", False):
+                        matches.append({
+                            "udid": device.get("udid"),
+                            "name": device.get("name"),
+                            "runtime": runtime_name
+                        })
+
+        return matches, None
+
+    except Exception as e:
+        return None, str(e)
+
+
+def erase_simulator(udid):
+    """Erase a single simulator."""
+    result = subprocess.run(
+        ["xcrun", "simctl", "erase", udid],
+        capture_output=True,
+        text=True,
+        timeout=60
+    )
+    return result.returncode == 0, result.stderr
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Erase iOS Simulator(s)")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--udid", help="Simulator UDID")
+    group.add_argument("--all", action="store_true", help="Erase all simulators")
+    group.add_argument("--runtime", help="Erase simulators matching runtime")
+
+    args = parser.parse_args()
+
+    try:
+        if args.all:
+            # Shutdown all first
+            subprocess.run(
+                ["xcrun", "simctl", "shutdown", "all"],
+                capture_output=True,
+                timeout=60
+            )
+
+            result = subprocess.run(
+                ["xcrun", "simctl", "erase", "all"],
+                capture_output=True,
+                text=True,
+                timeout=300
+            )
+
+            if result.returncode == 0:
+                print(json.dumps({
+                    "success": True,
+                    "message": "All simulators erased"
+                }, indent=2))
+                return 0
+            else:
+                print(json.dumps({
+                    "success": False,
+                    "error": result.stderr or "Failed to erase simulators"
+                }))
+                return 1
+
+        elif args.runtime:
+            simulators, error = get_simulators_by_runtime(args.runtime)
+            if error:
+                print(json.dumps({"success": False, "error": error}))
+                return 1
+
+            if not simulators:
+                print(json.dumps({
+                    "success": False,
+                    "error": f"No simulators found matching runtime '{args.runtime}'"
+                }))
+                return 1
+
+            # Shutdown and erase each
+            erased = []
+            failed = []
+
+            for sim in simulators:
+                subprocess.run(
+                    ["xcrun", "simctl", "shutdown", sim["udid"]],
+                    capture_output=True,
+                    timeout=30
+                )
+
+                success, error = erase_simulator(sim["udid"])
+                if success:
+                    erased.append(sim["name"])
+                else:
+                    failed.append({"name": sim["name"], "error": error})
+
+            print(json.dumps({
+                "success": len(failed) == 0,
+                "erased": erased,
+                "erased_count": len(erased),
+                "failed": failed
+            }, indent=2))
+            return 0 if len(failed) == 0 else 1
+
+        else:
+            # Shutdown first
+            subprocess.run(
+                ["xcrun", "simctl", "shutdown", args.udid],
+                capture_output=True,
+                timeout=30
+            )
+
+            success, error = erase_simulator(args.udid)
+
+            if success:
+                print(json.dumps({
+                    "success": True,
+                    "message": "Simulator erased",
+                    "udid": args.udid
+                }, indent=2))
+                return 0
+            else:
+                print(json.dumps({
+                    "success": False,
+                    "error": error or "Failed to erase simulator"
+                }))
+                return 1
+
+    except subprocess.TimeoutExpired:
+        print(json.dumps({"success": False, "error": "Operation timed out"}))
+        return 1
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/simulator-management/scripts/open-simulator.py
+++ b/XcodeBuildTools/skills/simulator-management/scripts/open-simulator.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Open the Simulator.app window for a simulator.
+
+Usage:
+    ./open-simulator.py --udid "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+    ./open-simulator.py --udid "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" --focus
+
+Options:
+    --udid UDID     Simulator UDID
+    --focus         Bring Simulator.app to front
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def get_booted_simulator():
+    """Get the first booted simulator."""
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode != 0:
+            return None
+
+        data = json.loads(result.stdout)
+
+        for runtime_devices in data.get("devices", {}).values():
+            for device in runtime_devices:
+                if device.get("state") == "Booted":
+                    return device.get("udid")
+
+        return None
+
+    except Exception:
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Open Simulator.app")
+    parser.add_argument("--udid", help="Simulator UDID")
+    parser.add_argument("--focus", action="store_true", help="Bring to front")
+
+    args = parser.parse_args()
+
+    # Get simulator UDID
+    simulator_udid = args.udid
+    if not simulator_udid:
+        simulator_udid = get_booted_simulator()
+        if not simulator_udid:
+            print(json.dumps({
+                "success": False,
+                "error": "No booted simulator found. Specify --udid or boot a simulator first."
+            }))
+            return 1
+
+    try:
+        cmd = ["open"]
+
+        if args.focus:
+            cmd.append("-a")
+            cmd.append("Simulator")
+        else:
+            cmd.extend(["-a", "Simulator", "--args", "-CurrentDeviceUDID", simulator_udid])
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+
+        if result.returncode == 0:
+            print(json.dumps({
+                "success": True,
+                "message": "Simulator.app opened",
+                "udid": simulator_udid
+            }, indent=2))
+            return 0
+        else:
+            print(json.dumps({
+                "success": False,
+                "error": result.stderr or "Failed to open Simulator.app"
+            }))
+            return 1
+
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/simulator-management/scripts/reset-location.py
+++ b/XcodeBuildTools/skills/simulator-management/scripts/reset-location.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Reset/clear simulated GPS location on an iOS Simulator.
+
+Usage:
+    ./reset-location.py --udid <UDID>
+
+Options:
+    --udid UDID    Simulator UDID
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def get_booted_simulator():
+    """Get the first booted simulator."""
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode != 0:
+            return None
+
+        data = json.loads(result.stdout)
+
+        for runtime_devices in data.get("devices", {}).values():
+            for device in runtime_devices:
+                if device.get("state") == "Booted":
+                    return device.get("udid")
+
+        return None
+
+    except Exception:
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Reset simulator GPS location")
+    parser.add_argument("--udid", help="Simulator UDID")
+
+    args = parser.parse_args()
+
+    # Get simulator UDID
+    simulator_udid = args.udid
+    if not simulator_udid:
+        simulator_udid = get_booted_simulator()
+        if not simulator_udid:
+            print(json.dumps({
+                "success": False,
+                "error": "No booted simulator found. Specify --udid or boot a simulator first."
+            }))
+            return 1
+
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "location", simulator_udid, "clear"],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+
+        if result.returncode == 0:
+            print(json.dumps({
+                "success": True,
+                "message": "Location cleared",
+                "udid": simulator_udid
+            }, indent=2))
+            return 0
+        else:
+            print(json.dumps({
+                "success": False,
+                "error": result.stderr or "Failed to clear location"
+            }))
+            return 1
+
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/simulator-management/scripts/set-appearance.py
+++ b/XcodeBuildTools/skills/simulator-management/scripts/set-appearance.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Set simulator appearance (light/dark mode).
+
+Usage:
+    ./set-appearance.py --udid <UDID> --mode dark
+    ./set-appearance.py --udid <UDID> --mode light
+
+Options:
+    --udid UDID    Simulator UDID
+    --mode MODE    Appearance mode (light or dark)
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def get_booted_simulator():
+    """Get the first booted simulator."""
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode != 0:
+            return None
+
+        data = json.loads(result.stdout)
+
+        for runtime_devices in data.get("devices", {}).values():
+            for device in runtime_devices:
+                if device.get("state") == "Booted":
+                    return device.get("udid")
+
+        return None
+
+    except Exception:
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Set simulator appearance")
+    parser.add_argument("--udid", help="Simulator UDID")
+    parser.add_argument("--mode", required=True, choices=["light", "dark"], help="Appearance mode")
+
+    args = parser.parse_args()
+
+    # Get simulator UDID
+    simulator_udid = args.udid
+    if not simulator_udid:
+        simulator_udid = get_booted_simulator()
+        if not simulator_udid:
+            print(json.dumps({
+                "success": False,
+                "error": "No booted simulator found. Specify --udid or boot a simulator first."
+            }))
+            return 1
+
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "ui", simulator_udid, "appearance", args.mode],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+
+        if result.returncode == 0:
+            print(json.dumps({
+                "success": True,
+                "message": f"Appearance set to {args.mode}",
+                "mode": args.mode,
+                "udid": simulator_udid
+            }, indent=2))
+            return 0
+        else:
+            print(json.dumps({
+                "success": False,
+                "error": result.stderr or "Failed to set appearance"
+            }))
+            return 1
+
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/simulator-management/scripts/set-location.py
+++ b/XcodeBuildTools/skills/simulator-management/scripts/set-location.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Set simulated GPS location on an iOS Simulator.
+
+Usage:
+    ./set-location.py --udid <UDID> --latitude 37.7749 --longitude -122.4194
+    ./set-location.py --udid <UDID> --location "San Francisco"
+
+Options:
+    --udid UDID            Simulator UDID
+    --latitude LAT         Latitude (-90 to 90)
+    --longitude LON        Longitude (-180 to 180)
+    --location NAME        Named location (San Francisco, New York, London, Tokyo)
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+# Named locations
+LOCATIONS = {
+    "san francisco": (37.7749, -122.4194),
+    "sf": (37.7749, -122.4194),
+    "new york": (40.7128, -74.0060),
+    "nyc": (40.7128, -74.0060),
+    "london": (51.5074, -0.1278),
+    "tokyo": (35.6762, 139.6503),
+    "paris": (48.8566, 2.3522),
+    "sydney": (-33.8688, 151.2093),
+    "los angeles": (34.0522, -118.2437),
+    "la": (34.0522, -118.2437),
+    "seattle": (47.6062, -122.3321),
+    "austin": (30.2672, -97.7431),
+    "cupertino": (37.3230, -122.0322),
+}
+
+
+def get_booted_simulator():
+    """Get the first booted simulator."""
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode != 0:
+            return None
+
+        data = json.loads(result.stdout)
+
+        for runtime_devices in data.get("devices", {}).values():
+            for device in runtime_devices:
+                if device.get("state") == "Booted":
+                    return device.get("udid")
+
+        return None
+
+    except Exception:
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Set simulator GPS location")
+    parser.add_argument("--udid", help="Simulator UDID")
+    parser.add_argument("--latitude", type=float, help="Latitude (-90 to 90)")
+    parser.add_argument("--longitude", type=float, help="Longitude (-180 to 180)")
+    parser.add_argument("--location", help="Named location")
+
+    args = parser.parse_args()
+
+    # Get simulator UDID
+    simulator_udid = args.udid
+    if not simulator_udid:
+        simulator_udid = get_booted_simulator()
+        if not simulator_udid:
+            print(json.dumps({
+                "success": False,
+                "error": "No booted simulator found. Specify --udid or boot a simulator first."
+            }))
+            return 1
+
+    # Get coordinates
+    latitude = args.latitude
+    longitude = args.longitude
+
+    if args.location:
+        location_key = args.location.lower()
+        if location_key not in LOCATIONS:
+            print(json.dumps({
+                "success": False,
+                "error": f"Unknown location '{args.location}'. Available: {', '.join(LOCATIONS.keys())}"
+            }))
+            return 1
+        latitude, longitude = LOCATIONS[location_key]
+
+    if latitude is None or longitude is None:
+        print(json.dumps({
+            "success": False,
+            "error": "Either --latitude/--longitude or --location is required"
+        }))
+        return 1
+
+    # Validate coordinates
+    if latitude < -90 or latitude > 90:
+        print(json.dumps({
+            "success": False,
+            "error": "Latitude must be between -90 and 90"
+        }))
+        return 1
+
+    if longitude < -180 or longitude > 180:
+        print(json.dumps({
+            "success": False,
+            "error": "Longitude must be between -180 and 180"
+        }))
+        return 1
+
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "location", simulator_udid, "set", f"{latitude},{longitude}"],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+
+        if result.returncode == 0:
+            response = {
+                "success": True,
+                "message": "Location set",
+                "latitude": latitude,
+                "longitude": longitude,
+                "udid": simulator_udid
+            }
+            if args.location:
+                response["location_name"] = args.location
+
+            print(json.dumps(response, indent=2))
+            return 0
+        else:
+            print(json.dumps({
+                "success": False,
+                "error": result.stderr or "Failed to set location"
+            }))
+            return 1
+
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/simulator-management/scripts/set-statusbar.py
+++ b/XcodeBuildTools/skills/simulator-management/scripts/set-statusbar.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Override simulator status bar display.
+
+Usage:
+    ./set-statusbar.py --udid <UDID> --time "9:41" --battery 100 --wifi 3 --cellular 4
+    ./set-statusbar.py --udid <UDID> --clear
+
+Options:
+    --udid UDID          Simulator UDID
+    --time TIME          Status bar time (e.g., "9:41")
+    --battery LEVEL      Battery percentage (0-100)
+    --wifi BARS          WiFi signal bars (0-3)
+    --cellular BARS      Cellular signal bars (0-4)
+    --clear              Remove all status bar overrides
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def get_booted_simulator():
+    """Get the first booted simulator."""
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode != 0:
+            return None
+
+        data = json.loads(result.stdout)
+
+        for runtime_devices in data.get("devices", {}).values():
+            for device in runtime_devices:
+                if device.get("state") == "Booted":
+                    return device.get("udid")
+
+        return None
+
+    except Exception:
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Set simulator status bar")
+    parser.add_argument("--udid", help="Simulator UDID")
+    parser.add_argument("--time", help="Status bar time (e.g., '9:41')")
+    parser.add_argument("--battery", type=int, help="Battery percentage (0-100)")
+    parser.add_argument("--wifi", type=int, choices=[0, 1, 2, 3], help="WiFi signal bars")
+    parser.add_argument("--cellular", type=int, choices=[0, 1, 2, 3, 4], help="Cellular signal bars")
+    parser.add_argument("--clear", action="store_true", help="Clear all overrides")
+
+    args = parser.parse_args()
+
+    # Get simulator UDID
+    simulator_udid = args.udid
+    if not simulator_udid:
+        simulator_udid = get_booted_simulator()
+        if not simulator_udid:
+            print(json.dumps({
+                "success": False,
+                "error": "No booted simulator found. Specify --udid or boot a simulator first."
+            }))
+            return 1
+
+    try:
+        if args.clear:
+            result = subprocess.run(
+                ["xcrun", "simctl", "status_bar", simulator_udid, "clear"],
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+
+            if result.returncode == 0:
+                print(json.dumps({
+                    "success": True,
+                    "message": "Status bar overrides cleared",
+                    "udid": simulator_udid
+                }, indent=2))
+                return 0
+            else:
+                print(json.dumps({
+                    "success": False,
+                    "error": result.stderr or "Failed to clear status bar"
+                }))
+                return 1
+
+        # Build override command
+        cmd = ["xcrun", "simctl", "status_bar", simulator_udid, "override"]
+
+        settings = {}
+
+        if args.time:
+            cmd.extend(["--time", args.time])
+            settings["time"] = args.time
+
+        if args.battery is not None:
+            if args.battery < 0 or args.battery > 100:
+                print(json.dumps({
+                    "success": False,
+                    "error": "Battery must be between 0 and 100"
+                }))
+                return 1
+            cmd.extend(["--batteryLevel", str(args.battery)])
+            cmd.extend(["--batteryState", "charged" if args.battery == 100 else "charging"])
+            settings["battery"] = args.battery
+
+        if args.wifi is not None:
+            cmd.extend(["--wifiBars", str(args.wifi)])
+            cmd.extend(["--wifiMode", "active"])
+            settings["wifi"] = args.wifi
+
+        if args.cellular is not None:
+            cmd.extend(["--cellularBars", str(args.cellular)])
+            cmd.extend(["--cellularMode", "active"])
+            settings["cellular"] = args.cellular
+
+        if not settings:
+            print(json.dumps({
+                "success": False,
+                "error": "No status bar settings provided. Use --time, --battery, --wifi, --cellular, or --clear"
+            }))
+            return 1
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+
+        if result.returncode == 0:
+            print(json.dumps({
+                "success": True,
+                "message": "Status bar overridden",
+                "settings": settings,
+                "udid": simulator_udid
+            }, indent=2))
+            return 0
+        else:
+            print(json.dumps({
+                "success": False,
+                "error": result.stderr or "Failed to override status bar"
+            }))
+            return 1
+
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/simulator-management/scripts/shutdown-simulator.py
+++ b/XcodeBuildTools/skills/simulator-management/scripts/shutdown-simulator.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Shutdown iOS Simulator(s).
+
+Usage:
+    ./shutdown-simulator.py --udid "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+    ./shutdown-simulator.py --all
+
+Options:
+    --udid UDID     Simulator UDID to shutdown
+    --all           Shutdown all simulators
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Shutdown iOS Simulator")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--udid", help="Simulator UDID")
+    group.add_argument("--all", action="store_true", help="Shutdown all simulators")
+
+    args = parser.parse_args()
+
+    try:
+        if args.all:
+            result = subprocess.run(
+                ["xcrun", "simctl", "shutdown", "all"],
+                capture_output=True,
+                text=True,
+                timeout=60
+            )
+
+            print(json.dumps({
+                "success": True,
+                "message": "All simulators shutdown"
+            }, indent=2))
+            return 0
+        else:
+            result = subprocess.run(
+                ["xcrun", "simctl", "shutdown", args.udid],
+                capture_output=True,
+                text=True,
+                timeout=60
+            )
+
+            if result.returncode != 0:
+                # Already shutdown is OK
+                if "current state: Shutdown" in result.stderr:
+                    print(json.dumps({
+                        "success": True,
+                        "message": "Simulator is already shutdown",
+                        "udid": args.udid
+                    }, indent=2))
+                    return 0
+                else:
+                    print(json.dumps({
+                        "success": False,
+                        "error": result.stderr or "Failed to shutdown"
+                    }))
+                    return 1
+
+            print(json.dumps({
+                "success": True,
+                "message": "Simulator shutdown",
+                "udid": args.udid
+            }, indent=2))
+            return 0
+
+    except subprocess.TimeoutExpired:
+        print(json.dumps({"success": False, "error": "Shutdown timed out"}))
+        return 1
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/swift-package/SKILL.md
+++ b/XcodeBuildTools/skills/swift-package/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: swift-package
+description: Build, test, run, and manage Swift packages (SPM). Use this skill when working with Swift Package Manager projects.
+---
+
+# Swift Package
+
+Build, test, run, and manage Swift Package Manager (SPM) packages.
+
+## Prerequisites
+
+- macOS with Xcode or Swift toolchain installed
+- A Swift package (directory containing Package.swift)
+
+## Scripts
+
+All scripts are in the `scripts/` directory and output JSON.
+
+### swift-build.py
+
+Build a Swift package.
+
+```bash
+# Build in debug mode
+scripts/swift-build.py --path /path/to/package
+
+# Build in release mode
+scripts/swift-build.py --path /path/to/package --configuration release
+
+# Build specific target
+scripts/swift-build.py --path /path/to/package --target MyLibrary
+
+# Build for specific architecture
+scripts/swift-build.py --path /path/to/package --arch arm64
+```
+
+**Parameters:**
+- `--path`: Path to Swift package (default: current directory)
+- `--configuration`: Build mode (debug or release, default: debug)
+- `--target`: Specific target to build
+- `--arch`: Target architecture (arm64 or x86_64)
+
+### swift-test.py
+
+Run Swift package tests.
+
+```bash
+# Run all tests
+scripts/swift-test.py --path /path/to/package
+
+# Run specific test
+scripts/swift-test.py --path /path/to/package --filter "MyTests.testSomething"
+
+# Run with coverage
+scripts/swift-test.py --path /path/to/package --enable-code-coverage
+```
+
+### swift-run.py
+
+Build and run a Swift package executable.
+
+```bash
+# Run default executable
+scripts/swift-run.py --path /path/to/package
+
+# Run specific executable
+scripts/swift-run.py --path /path/to/package --target MyCLI
+
+# Pass arguments to executable
+scripts/swift-run.py --path /path/to/package --target MyCLI -- --verbose input.txt
+```
+
+### swift-clean.py
+
+Clean Swift package build artifacts.
+
+```bash
+scripts/swift-clean.py --path /path/to/package
+```
+
+### swift-package-info.py
+
+Show Swift package information.
+
+```bash
+# Show package description
+scripts/swift-package-info.py --path /path/to/package
+
+# Show dependencies
+scripts/swift-package-info.py --path /path/to/package --show-dependencies
+```
+
+## Typical Workflow
+
+```bash
+# 1. Check package info
+scripts/swift-package-info.py --path .
+
+# 2. Build the package
+scripts/swift-build.py --path .
+
+# 3. Run tests
+scripts/swift-test.py --path .
+
+# 4. Run the executable (if any)
+scripts/swift-run.py --path . --target MyCLI
+
+# 5. Build for release
+scripts/swift-build.py --path . --configuration release
+```
+
+## Notes
+
+- Swift packages are identified by the presence of a `Package.swift` file
+- Use `swift package resolve` to fetch dependencies before building
+- Debug builds go to `.build/debug/`, release builds to `.build/release/`

--- a/XcodeBuildTools/skills/swift-package/scripts/swift-build.py
+++ b/XcodeBuildTools/skills/swift-package/scripts/swift-build.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Build a Swift package.
+
+Usage:
+    ./swift-build.py --path /path/to/package
+    ./swift-build.py --path /path/to/package --configuration release
+
+Options:
+    --path PATH            Path to Swift package (default: current directory)
+    --configuration CFG    Build mode (debug or release)
+    --target TARGET        Specific target to build
+    --arch ARCH            Architecture (arm64 or x86_64)
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build Swift package")
+    parser.add_argument("--path", default=".", help="Path to Swift package")
+    parser.add_argument("--configuration", choices=["debug", "release"], default="debug", help="Build configuration")
+    parser.add_argument("--target", help="Specific target to build")
+    parser.add_argument("--arch", choices=["arm64", "x86_64"], help="Architecture")
+
+    args = parser.parse_args()
+
+    # Resolve and validate path
+    package_path = os.path.abspath(args.path)
+    package_swift = os.path.join(package_path, "Package.swift")
+
+    if not os.path.exists(package_swift):
+        print(json.dumps({
+            "success": False,
+            "error": f"No Package.swift found at {package_path}"
+        }))
+        return 1
+
+    # Build command
+    cmd = ["swift", "build", "--package-path", package_path]
+
+    if args.configuration == "release":
+        cmd.extend(["-c", "release"])
+
+    if args.target:
+        cmd.extend(["--target", args.target])
+
+    if args.arch:
+        cmd.extend(["--arch", args.arch])
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=600
+        )
+
+        # Parse output for errors and warnings
+        errors = []
+        warnings = []
+
+        for line in result.stdout.split("\n") + result.stderr.split("\n"):
+            if ": error:" in line:
+                errors.append(line.strip())
+            elif ": warning:" in line:
+                warnings.append(line.strip())
+
+        if result.returncode == 0:
+            print(json.dumps({
+                "success": True,
+                "message": "Build succeeded",
+                "configuration": args.configuration,
+                "target": args.target,
+                "warning_count": len(warnings),
+                "warnings": warnings[:20]
+            }, indent=2))
+            return 0
+        else:
+            print(json.dumps({
+                "success": False,
+                "error": "Build failed",
+                "error_count": len(errors),
+                "errors": errors[:20],
+                "warnings": warnings[:20]
+            }, indent=2))
+            return 1
+
+    except subprocess.TimeoutExpired:
+        print(json.dumps({"success": False, "error": "Build timed out after 10 minutes"}))
+        return 1
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/swift-package/scripts/swift-clean.py
+++ b/XcodeBuildTools/skills/swift-package/scripts/swift-clean.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+Clean Swift package build artifacts.
+
+Usage:
+    ./swift-clean.py --path /path/to/package
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Clean Swift package")
+    parser.add_argument("--path", default=".", help="Path to Swift package")
+
+    args = parser.parse_args()
+
+    # Resolve and validate path
+    package_path = os.path.abspath(args.path)
+    package_swift = os.path.join(package_path, "Package.swift")
+
+    if not os.path.exists(package_swift):
+        print(json.dumps({
+            "success": False,
+            "error": f"No Package.swift found at {package_path}"
+        }))
+        return 1
+
+    try:
+        result = subprocess.run(
+            ["swift", "package", "clean", "--package-path", package_path],
+            capture_output=True,
+            text=True,
+            timeout=60
+        )
+
+        if result.returncode == 0:
+            print(json.dumps({
+                "success": True,
+                "message": "Package cleaned",
+                "path": package_path
+            }, indent=2))
+            return 0
+        else:
+            print(json.dumps({
+                "success": False,
+                "error": result.stderr or "Clean failed"
+            }))
+            return 1
+
+    except subprocess.TimeoutExpired:
+        print(json.dumps({"success": False, "error": "Clean timed out"}))
+        return 1
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/swift-package/scripts/swift-package-info.py
+++ b/XcodeBuildTools/skills/swift-package/scripts/swift-package-info.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Show Swift package information.
+
+Usage:
+    ./swift-package-info.py --path /path/to/package
+    ./swift-package-info.py --path /path/to/package --show-dependencies
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Show Swift package info")
+    parser.add_argument("--path", default=".", help="Path to Swift package")
+    parser.add_argument("--show-dependencies", action="store_true", help="Show dependencies")
+
+    args = parser.parse_args()
+
+    # Resolve and validate path
+    package_path = os.path.abspath(args.path)
+    package_swift = os.path.join(package_path, "Package.swift")
+
+    if not os.path.exists(package_swift):
+        print(json.dumps({
+            "success": False,
+            "error": f"No Package.swift found at {package_path}"
+        }))
+        return 1
+
+    try:
+        # Get package description
+        result = subprocess.run(
+            ["swift", "package", "describe", "--type", "json", "--package-path", package_path],
+            capture_output=True,
+            text=True,
+            timeout=60
+        )
+
+        if result.returncode != 0:
+            # Fallback: try dump
+            result = subprocess.run(
+                ["swift", "package", "dump-package", "--package-path", package_path],
+                capture_output=True,
+                text=True,
+                timeout=60
+            )
+
+        if result.returncode != 0:
+            print(json.dumps({
+                "success": False,
+                "error": result.stderr or "Failed to get package info"
+            }))
+            return 1
+
+        try:
+            data = json.loads(result.stdout)
+
+            response = {
+                "success": True,
+                "name": data.get("name"),
+                "path": package_path
+            }
+
+            # Extract targets
+            targets = data.get("targets", [])
+            if targets:
+                response["targets"] = [
+                    {
+                        "name": t.get("name"),
+                        "type": t.get("type")
+                    }
+                    for t in targets
+                ]
+
+            # Extract products
+            products = data.get("products", [])
+            if products:
+                response["products"] = [
+                    {
+                        "name": p.get("name"),
+                        "type": list(p.get("type", {}).keys())[0] if isinstance(p.get("type"), dict) else p.get("type")
+                    }
+                    for p in products
+                ]
+
+            # Extract dependencies if requested
+            if args.show_dependencies:
+                deps = data.get("dependencies", [])
+                if deps:
+                    response["dependencies"] = [
+                        {
+                            "name": d.get("identity") or d.get("name"),
+                            "url": d.get("url"),
+                            "requirement": d.get("requirement")
+                        }
+                        for d in deps
+                    ]
+
+            print(json.dumps(response, indent=2))
+            return 0
+
+        except json.JSONDecodeError:
+            # Return raw output if not JSON
+            print(json.dumps({
+                "success": True,
+                "path": package_path,
+                "description": result.stdout[:2000]
+            }, indent=2))
+            return 0
+
+    except subprocess.TimeoutExpired:
+        print(json.dumps({"success": False, "error": "Command timed out"}))
+        return 1
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/swift-package/scripts/swift-run.py
+++ b/XcodeBuildTools/skills/swift-package/scripts/swift-run.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Build and run a Swift package executable.
+
+Usage:
+    ./swift-run.py --path /path/to/package
+    ./swift-run.py --path /path/to/package --target MyCLI
+    ./swift-run.py --path /path/to/package --target MyCLI -- --verbose input.txt
+
+Options:
+    --path PATH       Path to Swift package
+    --target TARGET   Executable target to run
+    -- ARGS           Arguments to pass to executable
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+
+
+def main():
+    # Find the separator
+    separator_idx = None
+    for i, arg in enumerate(sys.argv):
+        if arg == "--":
+            separator_idx = i
+            break
+
+    if separator_idx:
+        our_args = sys.argv[1:separator_idx]
+        exec_args = sys.argv[separator_idx + 1:]
+    else:
+        our_args = sys.argv[1:]
+        exec_args = []
+
+    parser = argparse.ArgumentParser(description="Run Swift package executable")
+    parser.add_argument("--path", default=".", help="Path to Swift package")
+    parser.add_argument("--target", help="Executable target to run")
+    parser.add_argument("--configuration", choices=["debug", "release"], default="debug", help="Build configuration")
+
+    args = parser.parse_args(our_args)
+
+    # Resolve and validate path
+    package_path = os.path.abspath(args.path)
+    package_swift = os.path.join(package_path, "Package.swift")
+
+    if not os.path.exists(package_swift):
+        print(json.dumps({
+            "success": False,
+            "error": f"No Package.swift found at {package_path}"
+        }))
+        return 1
+
+    # Build command
+    cmd = ["swift", "run", "--package-path", package_path]
+
+    if args.configuration == "release":
+        cmd.extend(["-c", "release"])
+
+    if args.target:
+        cmd.append(args.target)
+
+    if exec_args:
+        cmd.extend(exec_args)
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=300
+        )
+
+        if result.returncode == 0:
+            print(json.dumps({
+                "success": True,
+                "message": "Execution completed",
+                "target": args.target,
+                "output": result.stdout[:5000] if result.stdout else None,
+                "output_truncated": len(result.stdout) > 5000 if result.stdout else False
+            }, indent=2))
+            return 0
+        else:
+            print(json.dumps({
+                "success": False,
+                "error": "Execution failed",
+                "stderr": result.stderr[:2000] if result.stderr else None,
+                "return_code": result.returncode
+            }, indent=2))
+            return 1
+
+    except subprocess.TimeoutExpired:
+        print(json.dumps({"success": False, "error": "Execution timed out after 5 minutes"}))
+        return 1
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/swift-package/scripts/swift-test.py
+++ b/XcodeBuildTools/skills/swift-package/scripts/swift-test.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Run Swift package tests.
+
+Usage:
+    ./swift-test.py --path /path/to/package
+    ./swift-test.py --path /path/to/package --filter "MyTests.testSomething"
+
+Options:
+    --path PATH               Path to Swift package
+    --filter PATTERN          Filter tests by pattern
+    --enable-code-coverage    Enable code coverage
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+import re
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run Swift package tests")
+    parser.add_argument("--path", default=".", help="Path to Swift package")
+    parser.add_argument("--filter", help="Filter tests by pattern")
+    parser.add_argument("--enable-code-coverage", action="store_true", help="Enable code coverage")
+
+    args = parser.parse_args()
+
+    # Resolve and validate path
+    package_path = os.path.abspath(args.path)
+    package_swift = os.path.join(package_path, "Package.swift")
+
+    if not os.path.exists(package_swift):
+        print(json.dumps({
+            "success": False,
+            "error": f"No Package.swift found at {package_path}"
+        }))
+        return 1
+
+    # Build command
+    cmd = ["swift", "test", "--package-path", package_path]
+
+    if args.filter:
+        cmd.extend(["--filter", args.filter])
+
+    if args.enable_code_coverage:
+        cmd.append("--enable-code-coverage")
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=1200
+        )
+
+        output = result.stdout + result.stderr
+
+        # Parse test results
+        tests_passed = []
+        tests_failed = []
+
+        for line in output.split("\n"):
+            # Swift test output format: "Test Case 'TestClass.testMethod' passed"
+            if "passed" in line.lower() and "Test Case" in line:
+                match = re.search(r"Test Case '([^']+)'", line)
+                if match:
+                    tests_passed.append(match.group(1))
+            elif "failed" in line.lower() and "Test Case" in line:
+                match = re.search(r"Test Case '([^']+)'", line)
+                if match:
+                    tests_failed.append(match.group(1))
+
+        success = result.returncode == 0 and len(tests_failed) == 0
+
+        response = {
+            "success": success,
+            "tests_passed": len(tests_passed),
+            "tests_failed": len(tests_failed),
+            "passed_tests": tests_passed[:50],
+            "failed_tests": tests_failed
+        }
+
+        if success:
+            response["message"] = f"All {len(tests_passed)} tests passed"
+        else:
+            response["message"] = f"{len(tests_failed)} test(s) failed"
+
+        print(json.dumps(response, indent=2))
+        return 0 if success else 1
+
+    except subprocess.TimeoutExpired:
+        print(json.dumps({"success": False, "error": "Tests timed out after 20 minutes"}))
+        return 1
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/xcode-clean/SKILL.md
+++ b/XcodeBuildTools/skills/xcode-clean/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: xcode-clean
+description: Clean Xcode build products and derived data. Use this skill to free up disk space or resolve build issues by cleaning caches.
+---
+
+# Xcode Clean
+
+Clean Xcode build products, derived data, and caches.
+
+## Prerequisites
+
+- macOS with Xcode installed
+
+## Scripts
+
+All scripts are in the `scripts/` directory and output JSON.
+
+### clean-build.py
+
+Clean build products for a specific project/workspace.
+
+```bash
+# Clean with workspace
+scripts/clean-build.py --workspace MyApp.xcworkspace --scheme MyApp
+
+# Clean with project
+scripts/clean-build.py --project MyApp.xcodeproj --scheme MyApp
+
+# Clean for specific platform
+scripts/clean-build.py --workspace MyApp.xcworkspace --scheme MyApp --platform ios-simulator
+```
+
+**Parameters:**
+- `--workspace` or `--project`: Path to .xcworkspace or .xcodeproj
+- `--scheme`: Build scheme name (required)
+- `--configuration`: Build configuration (default: Debug)
+- `--platform`: Target platform (ios, ios-simulator, macos, watchos, tvos, visionos)
+
+### clean-derived-data.py
+
+Clean Xcode derived data.
+
+```bash
+# Clean all derived data
+scripts/clean-derived-data.py --all
+
+# Clean derived data for specific project
+scripts/clean-derived-data.py --project MyApp
+
+# Just show what would be cleaned
+scripts/clean-derived-data.py --all --dry-run
+```
+
+**Parameters:**
+- `--all`: Clean all derived data
+- `--project`: Clean derived data for specific project name
+- `--dry-run`: Show what would be cleaned without deleting
+- `--older-than`: Only clean data older than N days
+
+### clean-caches.py
+
+Clean various Xcode caches.
+
+```bash
+# Clean module cache
+scripts/clean-caches.py --module-cache
+
+# Clean package cache (SPM)
+scripts/clean-caches.py --package-cache
+
+# Clean all caches
+scripts/clean-caches.py --all
+```
+
+## Typical Workflow
+
+### Resolve Build Issues
+```bash
+# 1. Clean the build
+scripts/clean-build.py --workspace MyApp.xcworkspace --scheme MyApp
+
+# 2. Clean derived data for project
+scripts/clean-derived-data.py --project MyApp
+
+# 3. Rebuild
+# (Use simulator-build or device-build skill)
+```
+
+### Free Up Disk Space
+```bash
+# 1. Check what would be cleaned
+scripts/clean-derived-data.py --all --dry-run
+
+# 2. Clean old derived data
+scripts/clean-derived-data.py --all --older-than 30
+
+# 3. Clean caches
+scripts/clean-caches.py --all
+```
+
+## Notes
+
+- Derived data is stored in `~/Library/Developer/Xcode/DerivedData/`
+- Module cache is in `~/Library/Developer/Xcode/DerivedData/ModuleCache.noindex/`
+- SPM cache is in `~/Library/Caches/org.swift.swiftpm/`
+- Cleaning derived data requires rebuilding the project

--- a/XcodeBuildTools/skills/xcode-clean/scripts/clean-build.py
+++ b/XcodeBuildTools/skills/xcode-clean/scripts/clean-build.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Clean Xcode build products for a project/workspace.
+
+Usage:
+    ./clean-build.py --workspace MyApp.xcworkspace --scheme MyApp
+    ./clean-build.py --project MyApp.xcodeproj --scheme MyApp
+
+Options:
+    --workspace PATH       Path to .xcworkspace file
+    --project PATH         Path to .xcodeproj file
+    --scheme NAME          Build scheme name (required)
+    --configuration CFG    Build configuration (default: Debug)
+    --platform PLATFORM    Target platform
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import os
+
+
+PLATFORMS = {
+    "ios": "iOS",
+    "ios-simulator": "iOS Simulator",
+    "macos": "macOS",
+    "watchos": "watchOS",
+    "watchos-simulator": "watchOS Simulator",
+    "tvos": "tvOS",
+    "tvos-simulator": "tvOS Simulator",
+    "visionos": "visionOS",
+    "visionos-simulator": "visionOS Simulator"
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Clean Xcode build")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to .xcworkspace")
+    group.add_argument("--project", help="Path to .xcodeproj")
+    parser.add_argument("--scheme", required=True, help="Build scheme")
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--platform", choices=list(PLATFORMS.keys()), help="Target platform")
+
+    args = parser.parse_args()
+
+    # Validate path
+    path = args.workspace or args.project
+    if not os.path.exists(path):
+        print(json.dumps({"success": False, "error": f"Not found: {path}"}))
+        return 1
+
+    # Build command
+    cmd = ["xcodebuild", "clean"]
+
+    if args.workspace:
+        cmd.extend(["-workspace", args.workspace])
+    else:
+        cmd.extend(["-project", args.project])
+
+    cmd.extend(["-scheme", args.scheme, "-configuration", args.configuration])
+
+    if args.platform:
+        platform = PLATFORMS[args.platform]
+        if "simulator" in args.platform.lower():
+            cmd.extend(["-destination", f"generic/platform={platform}"])
+        else:
+            cmd.extend(["-destination", f"generic/platform={platform}"])
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=120
+        )
+
+        if result.returncode == 0:
+            print(json.dumps({
+                "success": True,
+                "message": "Build products cleaned",
+                "scheme": args.scheme,
+                "configuration": args.configuration
+            }, indent=2))
+            return 0
+        else:
+            print(json.dumps({
+                "success": False,
+                "error": result.stderr or "Clean failed"
+            }))
+            return 1
+
+    except subprocess.TimeoutExpired:
+        print(json.dumps({"success": False, "error": "Clean timed out"}))
+        return 1
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/xcode-clean/scripts/clean-caches.py
+++ b/XcodeBuildTools/skills/xcode-clean/scripts/clean-caches.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Clean various Xcode caches.
+
+Usage:
+    ./clean-caches.py --module-cache
+    ./clean-caches.py --package-cache
+    ./clean-caches.py --all
+
+Options:
+    --module-cache     Clean Swift/Clang module cache
+    --package-cache    Clean Swift Package Manager cache
+    --all              Clean all caches
+    --dry-run          Show what would be cleaned
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sys
+
+
+CACHE_PATHS = {
+    "module_cache": os.path.expanduser("~/Library/Developer/Xcode/DerivedData/ModuleCache.noindex"),
+    "package_cache": os.path.expanduser("~/Library/Caches/org.swift.swiftpm"),
+    "swift_build_cache": os.path.expanduser("~/Library/Developer/Xcode/DerivedData/SourcePackages"),
+}
+
+
+def get_folder_size(path):
+    """Get folder size in bytes."""
+    total = 0
+    try:
+        for dirpath, dirnames, filenames in os.walk(path):
+            for f in filenames:
+                fp = os.path.join(dirpath, f)
+                try:
+                    total += os.path.getsize(fp)
+                except (OSError, IOError):
+                    pass
+    except (OSError, IOError):
+        pass
+    return total
+
+
+def format_size(size_bytes):
+    """Format size in human-readable format."""
+    for unit in ['B', 'KB', 'MB', 'GB']:
+        if size_bytes < 1024:
+            return f"{size_bytes:.1f} {unit}"
+        size_bytes /= 1024
+    return f"{size_bytes:.1f} TB"
+
+
+def clean_cache(name, path, dry_run=False):
+    """Clean a specific cache."""
+    if not os.path.exists(path):
+        return {
+            "name": name,
+            "path": path,
+            "status": "not_found",
+            "message": "Cache not found"
+        }
+
+    size = get_folder_size(path)
+
+    if dry_run:
+        return {
+            "name": name,
+            "path": path,
+            "status": "would_clean",
+            "size": format_size(size),
+            "size_bytes": size
+        }
+
+    try:
+        shutil.rmtree(path)
+        return {
+            "name": name,
+            "path": path,
+            "status": "cleaned",
+            "freed": format_size(size),
+            "size_bytes": size
+        }
+    except Exception as e:
+        return {
+            "name": name,
+            "path": path,
+            "status": "error",
+            "error": str(e)
+        }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Clean Xcode caches")
+    parser.add_argument("--module-cache", action="store_true", help="Clean module cache")
+    parser.add_argument("--package-cache", action="store_true", help="Clean SPM cache")
+    parser.add_argument("--all", action="store_true", help="Clean all caches")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be cleaned")
+
+    args = parser.parse_args()
+
+    if not args.all and not args.module_cache and not args.package_cache:
+        print(json.dumps({
+            "success": False,
+            "error": "Specify --module-cache, --package-cache, or --all"
+        }))
+        return 1
+
+    caches_to_clean = []
+
+    if args.all or args.module_cache:
+        caches_to_clean.append(("module_cache", CACHE_PATHS["module_cache"]))
+
+    if args.all or args.package_cache:
+        caches_to_clean.append(("package_cache", CACHE_PATHS["package_cache"]))
+
+    results = []
+    total_freed = 0
+
+    for name, path in caches_to_clean:
+        result = clean_cache(name, path, args.dry_run)
+        results.append(result)
+        if result.get("size_bytes"):
+            total_freed += result["size_bytes"]
+
+    success = all(r.get("status") != "error" for r in results)
+
+    response = {
+        "success": success,
+        "dry_run": args.dry_run,
+        "caches": results,
+        "total_freed": format_size(total_freed)
+    }
+
+    if args.dry_run:
+        response["message"] = f"Would free {format_size(total_freed)}"
+    else:
+        response["message"] = f"Freed {format_size(total_freed)}"
+
+    print(json.dumps(response, indent=2))
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/xcode-clean/scripts/clean-derived-data.py
+++ b/XcodeBuildTools/skills/xcode-clean/scripts/clean-derived-data.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Clean Xcode derived data.
+
+Usage:
+    ./clean-derived-data.py --all
+    ./clean-derived-data.py --project MyApp
+    ./clean-derived-data.py --all --dry-run
+
+Options:
+    --all                 Clean all derived data
+    --project NAME        Clean derived data for specific project
+    --dry-run             Show what would be cleaned
+    --older-than DAYS     Only clean data older than N days
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import time
+
+
+def get_derived_data_path():
+    """Get the derived data path."""
+    return os.path.expanduser("~/Library/Developer/Xcode/DerivedData")
+
+
+def get_folder_size(path):
+    """Get folder size in bytes."""
+    total = 0
+    try:
+        for dirpath, dirnames, filenames in os.walk(path):
+            for f in filenames:
+                fp = os.path.join(dirpath, f)
+                try:
+                    total += os.path.getsize(fp)
+                except (OSError, IOError):
+                    pass
+    except (OSError, IOError):
+        pass
+    return total
+
+
+def format_size(size_bytes):
+    """Format size in human-readable format."""
+    for unit in ['B', 'KB', 'MB', 'GB']:
+        if size_bytes < 1024:
+            return f"{size_bytes:.1f} {unit}"
+        size_bytes /= 1024
+    return f"{size_bytes:.1f} TB"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Clean Xcode derived data")
+    parser.add_argument("--all", action="store_true", help="Clean all derived data")
+    parser.add_argument("--project", help="Clean derived data for specific project")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be cleaned")
+    parser.add_argument("--older-than", type=int, help="Only clean data older than N days")
+
+    args = parser.parse_args()
+
+    if not args.all and not args.project:
+        print(json.dumps({
+            "success": False,
+            "error": "Either --all or --project is required"
+        }))
+        return 1
+
+    derived_data_path = get_derived_data_path()
+
+    if not os.path.exists(derived_data_path):
+        print(json.dumps({
+            "success": True,
+            "message": "No derived data found",
+            "path": derived_data_path
+        }))
+        return 0
+
+    # Find folders to clean
+    folders_to_clean = []
+    now = time.time()
+    cutoff = now - (args.older_than * 86400) if args.older_than else 0
+
+    try:
+        for item in os.listdir(derived_data_path):
+            item_path = os.path.join(derived_data_path, item)
+
+            if not os.path.isdir(item_path):
+                continue
+
+            # Skip module cache
+            if item.endswith(".noindex"):
+                continue
+
+            # Filter by project name if specified
+            if args.project and args.project.lower() not in item.lower():
+                continue
+
+            # Check age if specified
+            if args.older_than:
+                mtime = os.path.getmtime(item_path)
+                if mtime > cutoff:
+                    continue
+
+            size = get_folder_size(item_path)
+            folders_to_clean.append({
+                "name": item,
+                "path": item_path,
+                "size_bytes": size,
+                "size": format_size(size)
+            })
+
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        return 1
+
+    if not folders_to_clean:
+        print(json.dumps({
+            "success": True,
+            "message": "No matching derived data found",
+            "path": derived_data_path
+        }))
+        return 0
+
+    total_size = sum(f["size_bytes"] for f in folders_to_clean)
+
+    if args.dry_run:
+        print(json.dumps({
+            "success": True,
+            "dry_run": True,
+            "message": f"Would clean {len(folders_to_clean)} folder(s), {format_size(total_size)}",
+            "folders": folders_to_clean,
+            "total_size": format_size(total_size)
+        }, indent=2))
+        return 0
+
+    # Actually clean
+    cleaned = []
+    failed = []
+
+    for folder in folders_to_clean:
+        try:
+            shutil.rmtree(folder["path"])
+            cleaned.append(folder["name"])
+        except Exception as e:
+            failed.append({"name": folder["name"], "error": str(e)})
+
+    print(json.dumps({
+        "success": len(failed) == 0,
+        "message": f"Cleaned {len(cleaned)} folder(s), freed {format_size(total_size)}",
+        "cleaned_count": len(cleaned),
+        "cleaned": cleaned,
+        "failed": failed,
+        "freed_space": format_size(total_size)
+    }, indent=2))
+
+    return 0 if len(failed) == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/XcodeBuildTools/skills/xcode-doctor/SKILL.md
+++ b/XcodeBuildTools/skills/xcode-doctor/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: xcode-doctor
+description: Diagnose and validate your Xcode development environment. Use this skill to check if Xcode, simulators, and command line tools are properly installed and configured.
+---
+
+# Xcode Doctor
+
+Diagnose and validate your Xcode development environment to ensure all tools are properly configured.
+
+## Prerequisites
+
+- macOS with Xcode installed
+- Xcode Command Line Tools (`xcode-select --install`)
+
+## Running the Diagnostic
+
+```bash
+scripts/xcode-doctor.py
+```
+
+## What It Checks
+
+The doctor script validates:
+
+1. **Xcode Installation**
+   - Xcode path and version
+   - Command line tools installation
+   - Active developer directory
+
+2. **Required Tools**
+   - `xcodebuild` availability and version
+   - `xcrun` functionality
+   - `simctl` for simulator control
+   - `devicectl` for device management (iOS 17+/Xcode 15+)
+
+3. **Simulators**
+   - Available simulator runtimes
+   - Installed simulators
+
+4. **Connected Devices**
+   - Physical devices connected via USB or network
+
+## Output Format
+
+The script outputs JSON with the following structure:
+
+```json
+{
+  "success": true,
+  "xcode": {
+    "path": "/Applications/Xcode.app",
+    "version": "15.0",
+    "build": "15A240d"
+  },
+  "command_line_tools": {
+    "installed": true,
+    "path": "/Library/Developer/CommandLineTools"
+  },
+  "tools": {
+    "xcodebuild": {"available": true, "version": "15.0"},
+    "xcrun": {"available": true},
+    "simctl": {"available": true},
+    "devicectl": {"available": true}
+  },
+  "simulators": {
+    "runtimes": ["iOS 17.0", "iOS 16.4"],
+    "count": 15
+  },
+  "devices": {
+    "connected": 1,
+    "list": [{"name": "iPhone 15", "udid": "..."}]
+  }
+}
+```
+
+## Troubleshooting
+
+### Xcode Not Found
+```bash
+# Install Xcode from the App Store or download from developer.apple.com
+# Then accept the license:
+sudo xcodebuild -license accept
+```
+
+### Command Line Tools Missing
+```bash
+xcode-select --install
+```
+
+### Wrong Xcode Selected
+```bash
+# List available Xcode installations
+ls /Applications | grep Xcode
+
+# Select the correct one
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+```

--- a/XcodeBuildTools/skills/xcode-doctor/scripts/xcode-doctor.py
+++ b/XcodeBuildTools/skills/xcode-doctor/scripts/xcode-doctor.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+Xcode Doctor - Diagnose and validate Xcode development environment.
+
+Usage:
+    ./xcode-doctor.py [--verbose]
+
+Options:
+    --verbose    Show detailed output including all simulator runtimes
+"""
+
+import json
+import subprocess
+import sys
+import os
+import re
+
+
+def run_command(cmd, capture_stderr=False):
+    """Run a command and return output, or None if it fails."""
+    try:
+        stderr = subprocess.STDOUT if capture_stderr else subprocess.DEVNULL
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        return result.stdout.strip() if result.returncode == 0 else None
+    except (subprocess.TimeoutExpired, FileNotFoundError, Exception):
+        return None
+
+
+def get_xcode_info():
+    """Get Xcode installation information."""
+    info = {
+        "installed": False,
+        "path": None,
+        "version": None,
+        "build": None
+    }
+
+    # Get Xcode path
+    path = run_command(["xcode-select", "-p"])
+    if path:
+        # Convert developer path to app path
+        if "/Contents/Developer" in path:
+            info["path"] = path.replace("/Contents/Developer", "")
+        else:
+            info["path"] = path
+        info["installed"] = True
+
+    # Get Xcode version
+    version_output = run_command(["xcodebuild", "-version"])
+    if version_output:
+        lines = version_output.split("\n")
+        for line in lines:
+            if line.startswith("Xcode "):
+                info["version"] = line.replace("Xcode ", "")
+            elif line.startswith("Build version "):
+                info["build"] = line.replace("Build version ", "")
+
+    return info
+
+
+def get_command_line_tools():
+    """Check if command line tools are installed."""
+    info = {
+        "installed": False,
+        "path": None
+    }
+
+    # Check for CLT
+    clt_path = "/Library/Developer/CommandLineTools"
+    if os.path.exists(clt_path):
+        info["installed"] = True
+        info["path"] = clt_path
+
+    # Also check via xcode-select
+    result = run_command(["xcode-select", "-p"])
+    if result and "CommandLineTools" in result:
+        info["installed"] = True
+        info["path"] = result
+
+    return info
+
+
+def check_tool(tool_name, version_args=None):
+    """Check if a tool is available and optionally get its version."""
+    result = {
+        "available": False,
+        "version": None
+    }
+
+    # Check if tool exists
+    which_result = run_command(["which", tool_name])
+    if not which_result:
+        # Try with xcrun
+        which_result = run_command(["xcrun", "--find", tool_name])
+
+    if which_result:
+        result["available"] = True
+
+        # Get version if args provided
+        if version_args:
+            version_output = run_command([tool_name] + version_args)
+            if version_output:
+                # Extract first line or version number
+                result["version"] = version_output.split("\n")[0]
+
+    return result
+
+
+def get_simulators():
+    """Get available simulator information."""
+    info = {
+        "available": False,
+        "runtimes": [],
+        "count": 0
+    }
+
+    # Get simulator list as JSON
+    output = run_command(["xcrun", "simctl", "list", "--json"])
+    if not output:
+        return info
+
+    try:
+        data = json.loads(output)
+        info["available"] = True
+
+        # Get runtimes
+        runtimes = data.get("runtimes", [])
+        info["runtimes"] = [
+            rt.get("name", rt.get("identifier", "Unknown"))
+            for rt in runtimes
+            if rt.get("isAvailable", True)
+        ]
+
+        # Count devices
+        devices = data.get("devices", {})
+        count = 0
+        for runtime_devices in devices.values():
+            count += len(runtime_devices)
+        info["count"] = count
+
+    except json.JSONDecodeError:
+        pass
+
+    return info
+
+
+def get_devices():
+    """Get connected physical devices."""
+    info = {
+        "available": False,
+        "connected": 0,
+        "list": []
+    }
+
+    # Try modern devicectl first (iOS 17+/Xcode 15+)
+    import tempfile
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+        temp_path = f.name
+
+    try:
+        result = subprocess.run(
+            ["xcrun", "devicectl", "list", "devices", "--json-output", temp_path],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode == 0 and os.path.exists(temp_path):
+            with open(temp_path, 'r') as f:
+                data = json.load(f)
+
+            devices = data.get("result", {}).get("devices", [])
+            info["available"] = True
+            info["connected"] = len(devices)
+            info["list"] = [
+                {
+                    "name": d.get("deviceProperties", {}).get("name", "Unknown"),
+                    "udid": d.get("hardwareProperties", {}).get("udid", "Unknown"),
+                    "model": d.get("hardwareProperties", {}).get("marketingName", "Unknown")
+                }
+                for d in devices
+            ]
+    except (subprocess.TimeoutExpired, FileNotFoundError, Exception):
+        pass
+    finally:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+
+    # Fallback to xctrace if devicectl not available
+    if not info["available"]:
+        output = run_command(["xcrun", "xctrace", "list", "devices"])
+        if output:
+            info["available"] = True
+            # Parse basic device info (format: Name (UUID))
+            for line in output.split("\n"):
+                if "(" in line and "Simulator" not in line:
+                    match = re.match(r"(.+)\s+\(([A-F0-9-]+)\)", line.strip())
+                    if match:
+                        info["list"].append({
+                            "name": match.group(1).strip(),
+                            "udid": match.group(2)
+                        })
+            info["connected"] = len(info["list"])
+
+    return info
+
+
+def main():
+    verbose = "--verbose" in sys.argv
+
+    result = {
+        "success": True,
+        "xcode": get_xcode_info(),
+        "command_line_tools": get_command_line_tools(),
+        "tools": {
+            "xcodebuild": check_tool("xcodebuild", ["-version"]),
+            "xcrun": check_tool("xcrun", ["--version"]),
+            "simctl": check_tool("simctl"),
+            "devicectl": check_tool("devicectl")
+        },
+        "simulators": get_simulators(),
+        "devices": get_devices()
+    }
+
+    # Determine overall success
+    if not result["xcode"]["installed"]:
+        result["success"] = False
+        result["error"] = "Xcode is not installed"
+    elif not result["tools"]["xcodebuild"]["available"]:
+        result["success"] = False
+        result["error"] = "xcodebuild is not available"
+
+    # Limit runtimes in non-verbose mode
+    if not verbose and len(result["simulators"]["runtimes"]) > 5:
+        result["simulators"]["runtimes"] = result["simulators"]["runtimes"][:5]
+        result["simulators"]["runtimes_truncated"] = True
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This plugin reimplements the functionality of XcodeBuildMCP as Claude Code skills, providing Xcode build and development tools without requiring an MCP server.

Skills included:
- xcode-doctor: Environment diagnostics and validation
- device-build: Build, install, launch, and test apps on physical devices
- simulator-build: Build, run, and test apps on iOS simulators
- simulator-management: Boot, shutdown, configure simulators
- macos-build: Build, run, and test macOS applications
- project-discovery: Discover projects, list schemes, show build settings
- swift-package: Build, test, run Swift packages
- xcode-clean: Clean build products and derived data

Each skill provides Python scripts with JSON output that can be used directly from the command line. All scripts have proper shebangs and are executable without requiring python/uv in the command line.

Based on: https://github.com/cameroncooke/XcodeBuildMCP