### PR TITLE
Add Xcode MCP detection and conditional tool delegation (v0.4.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -63,8 +63,8 @@
     },
     {
       "name": "XcodeBuildTools",
-      "version": "0.3.17",
-      "description": "Xcode development tools: build/test/run Swift packages, discover projects and schemes, build for simulator/device/macOS, run tests, manage device apps, capture simulator logs, Sparkle auto-update integration",
+      "version": "0.4.0",
+      "description": "Xcode development tools with Xcode MCP compatibility: build/test/run Swift packages, discover projects and schemes, build for simulator/device/macOS, run tests, manage device apps, capture simulator logs, Sparkle auto-update integration",
       "source": "./XcodeBuildTools",
       "author": {
         "name": "Gustavo Ambrozio"

--- a/XcodeBuildTools/.claude-plugin/plugin.json
+++ b/XcodeBuildTools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "XcodeBuildTools",
-  "version": "0.3.17",
+  "version": "0.4.0",
   "description": "Xcode development tools: build/test/run Swift packages, discover projects and schemes, build for simulator/device/macOS, run tests, manage device apps, capture simulator logs",
   "author": {
     "name": "Gustavo Ambrozio"

--- a/XcodeBuildTools/README.md
+++ b/XcodeBuildTools/README.md
@@ -29,12 +29,44 @@ brew install xcsift
 | `sim-log` | Capture logs from iOS Simulator apps |
 | `sparkle-integration` | Integrate Sparkle 2.x auto-update framework into macOS apps |
 
+## Xcode MCP Compatibility
+
+Starting with v0.4.0, XcodeBuildTools automatically detects Xcode 26.3+'s native MCP server and delegates overlapping capabilities when available.
+
+### Tool Delegation
+
+| Domain | Xcode MCP Tool | XcodeBuildTools Fallback |
+|--------|---------------|------------------------|
+| Building | `BuildProject`, `GetBuildLog` | `xcodebuild` skill |
+| Testing | `RunAllTests`, `RunSomeTests`, `GetTestList` | `xcode-test` skill |
+| Project inspection | `XcodeGlob`, `XcodeLS`, `XcodeListWindows` | `xcode-project` skill |
+| SPM (Xcode open) | `BuildProject` | `swift-package` skill |
+| Documentation | `DocumentationSearch` | `sosumi` MCP server |
+
+Skills with **no MCP equivalent** (always used directly): `device-app`, `sim-log`, `xcode-doctor`, `macos-app`, `sparkle-integration`.
+
+### Auto-Approve Hook
+
+The plugin includes an async hook that automatically clicks "Allow" on Xcode's MCP authorization dialog. It:
+- Runs only when Xcode is active and `mcpbridge` exists
+- Uses a PID-based lock file to avoid re-running for the same Xcode instance
+- Times out silently after 10 seconds if no dialog appears
+
+**Prerequisite**: Grant Accessibility access to your terminal app in System Settings > Privacy & Security > Accessibility. The script will prompt you if this is missing.
+
 ## Related Plugins
 
 - **iOSSimulator** - Simulator control, screenshots, video, status bar
 - **SwiftDevelopment** - swift-compile skill with xcsift integration
 
 ## Changelog
+
+### 0.4.0
+- Xcode MCP compatibility: auto-detects Xcode 26.3+ native MCP server at session start
+- Conditional tool delegation: prefers Xcode MCP tools for build, test, project inspection, and documentation when available
+- Auto-approve hook: automatically clicks "Allow" on Xcode's MCP authorization dialog (async, PID-locked)
+- Future-proofing: generic fallback instruction for new Xcode MCP tools beyond the known set
+- MCP notes added to all 9 skills indicating delegation preference or uniqueness
 
 ### 0.3.17
 - Improved sparkle-integration security: separate Debug/Release entitlements for `disable-library-validation`

--- a/XcodeBuildTools/hooks/approve-xcode-mcp.sh
+++ b/XcodeBuildTools/hooks/approve-xcode-mcp.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# approve-xcode-mcp.sh
+# Auto-clicks "Allow" on Xcode's MCP agent authorization dialog.
+#
+# Runs as an async hook (async: true in hooks.json) so it doesn't block startup.
+#   1. Pre-checks: Xcode must be running and mcpbridge must exist
+#   2. Lock file prevents redundant runs for the same Xcode instance
+#   3. Checks Accessibility permissions (notifies + opens Settings if missing)
+#   4. Polls Xcode's windows for the auth dialog (up to 10 seconds)
+#   5. Clicks "Allow" when found, or exits silently on timeout
+#
+# Prerequisite (one-time):
+#   System Settings > Privacy & Security > Accessibility
+#   → Add your terminal app (Terminal.app, iTerm2, etc.)
+
+# --- Pre-checks: bail early if Xcode or mcpbridge aren't available ---
+XCODE_PID=$(pgrep -x Xcode 2>/dev/null)
+if [[ -z "$XCODE_PID" ]]; then
+    exit 0
+fi
+
+if ! xcrun --find mcpbridge &>/dev/null; then
+    exit 0
+fi
+
+# --- Lock file keyed on Xcode PID (prevents re-runs for same instance) ---
+LOCK_FILE="${TMPDIR:-/tmp}/xcode-mcp-approve-${XCODE_PID}.lock"
+if [[ -f "$LOCK_FILE" ]]; then
+    exit 0
+fi
+touch "$LOCK_FILE"
+
+# --- Check Accessibility permissions ---
+if ! osascript -e 'tell application "System Events" to get name of first process' &>/dev/null; then
+    osascript -e '
+        display notification "Grant Accessibility access to your terminal app in System Settings → Privacy & Security → Accessibility" ¬
+            with title "Xcode MCP Auto-Approve" ¬
+            subtitle "Missing Accessibility permissions"
+    '
+    open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+    rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+# --- Give MCP bridge time to connect and trigger the dialog ---
+sleep 2
+
+# --- Poll for up to 10s for the MCP auth dialog and click Allow ---
+osascript <<'APPLESCRIPT' >/dev/null 2>&1
+tell application "System Events"
+    tell process "Xcode"
+        repeat 10 times
+            repeat with xcodeWindow in windows
+                try
+                    repeat with dialogText in static texts of xcodeWindow
+                        if value of dialogText contains "access Xcode" then
+                            click button "Allow" of xcodeWindow
+                            return "approved"
+                        end if
+                    end repeat
+                end try
+                try
+                    repeat with sheetText in static texts of sheet 1 of xcodeWindow
+                        if value of sheetText contains "access Xcode" then
+                            click button "Allow" of sheet 1 of xcodeWindow
+                            return "approved"
+                        end if
+                    end repeat
+                end try
+            end repeat
+            delay 1
+        end repeat
+    end tell
+end tell
+return "timeout"
+APPLESCRIPT
+
+# Silent exit regardless of result — no notification spam
+exit 0

--- a/XcodeBuildTools/hooks/hooks.json
+++ b/XcodeBuildTools/hooks/hooks.json
@@ -10,6 +10,11 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/common/session-start.py XcodeBuildTools"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/approve-xcode-mcp.sh",
+            "async": true
           }
         ]
       }

--- a/XcodeBuildTools/info.json
+++ b/XcodeBuildTools/info.json
@@ -45,6 +45,10 @@
     ],
     "versions": [
         {
+            "version": "0.4.0",
+            "changes": "Xcode MCP compatibility: auto-detects Xcode 26.3+ native MCP server and delegates overlapping tools (build, test, project inspection, docs). Adds auto-approve hook for MCP authorization dialog"
+        },
+        {
             "version": "0.3.17",
             "changes": "Improved sparkle-integration: separate Debug/Release entitlements, @Observable pattern, Claude CLI release notes generation"
         },

--- a/XcodeBuildTools/session-start.md
+++ b/XcodeBuildTools/session-start.md
@@ -6,6 +6,39 @@ The `XcodeBuildTools` plugin provides specialized tools for Xcode build and test
 
 **IMPORTANT**: Whenever you need to build or test an Xcode project/workspace, compile or test Swift packages, or anytime you would use `swift`/`xcodebuild` commands, **always** use the `xcodebuild` skill instead. This skill provides token-efficient, AI-friendly compilation output.
 
+<!-- IF_XCODE_MCP -->
+## Xcode MCP Tool Delegation
+
+The Xcode MCP server is available. **Before using an XcodeBuildTools skill, check if an equivalent Xcode MCP tool exists in your tool list.** Prefer Xcode MCP tools when available — they run inside Xcode's process and have richer project context.
+
+### Delegation Rules
+
+| Domain | Prefer (Xcode MCP) | Fallback (XcodeBuildTools skill) |
+|--------|--------------------|---------------------------------|
+| Building | `BuildProject`, `GetBuildLog` | `xcodebuild` skill |
+| Testing | `RunAllTests`, `RunSomeTests`, `GetTestList` | `xcode-test` skill |
+| Project inspection | `XcodeGlob`, `XcodeLS`, `XcodeListWindows` | `xcode-project` skill |
+| SPM (when project open in Xcode) | `BuildProject` | `swift-package` skill |
+| Documentation | `DocumentationSearch` | `sosumi` MCP server |
+
+**How to delegate**: Before each build/test/inspection task, check your available tools. If the Xcode MCP tool is listed, use it. If not (e.g., MCP connection dropped), fall back to the corresponding XcodeBuildTools skill.
+
+### Always Use XcodeBuildTools (No MCP Equivalent)
+
+These skills have no Xcode MCP equivalent — always use them directly:
+- `device-app` — Install/launch apps on physical devices
+- `sim-log` — Capture iOS Simulator logs
+- `xcode-doctor` — Xcode environment diagnostics
+- `macos-app` — macOS application lifecycle management
+- `sparkle-integration` — Sparkle auto-update framework
+
+### Future Xcode MCP Tools
+
+Beyond the specific tools listed above, if you discover additional Xcode MCP tools in your tool list that could handle a task more directly than an XcodeBuildTools skill, prefer the Xcode MCP tool. Xcode MCP tools follow naming patterns like `BuildProject`, `RunAllTests`, `Xcode*`, `Get*`, `DocumentationSearch`.
+<!-- END_XCODE_MCP -->
+
+<!-- IF_NO_XCODE_MCP -->
 ## Documentation
 
 The `sosumi` MCP server provides quick access to Apple's official documentation for Swift, SwiftUI, UIKit, and other frameworks. Use it for new APIs or to verify the correct parameters.
+<!-- END_NO_XCODE_MCP -->

--- a/XcodeBuildTools/skills/device-app/SKILL.md
+++ b/XcodeBuildTools/skills/device-app/SKILL.md
@@ -3,6 +3,8 @@ name: device-app
 description: Manage apps on physical Apple devices (iPhone, iPad, Watch, TV, Vision Pro). Use when listing connected devices, installing apps on physical devices, launching or stopping apps on devices.
 ---
 
+> This skill has no equivalent in the Xcode MCP server.
+
 # Device App Management
 
 List devices and manage apps on physical Apple devices.

--- a/XcodeBuildTools/skills/macos-app/SKILL.md
+++ b/XcodeBuildTools/skills/macos-app/SKILL.md
@@ -3,6 +3,8 @@ name: macos-app
 description: Launch and stop macOS applications. Use after building a macOS app to run it, or to terminate running macOS applications.
 ---
 
+> This skill has no equivalent in the Xcode MCP server.
+
 # macOS App Management
 
 Launch and terminate macOS applications.

--- a/XcodeBuildTools/skills/sim-log/SKILL.md
+++ b/XcodeBuildTools/skills/sim-log/SKILL.md
@@ -3,6 +3,8 @@ name: sim-log
 description: Capture logs from iOS Simulator apps. Use when debugging simulator apps, monitoring app output, or capturing logs for analysis.
 ---
 
+> This skill has no equivalent in the Xcode MCP server.
+
 # Simulator Log Capture
 
 Stream logs from apps running in iOS Simulator.

--- a/XcodeBuildTools/skills/sparkle-integration/SKILL.md
+++ b/XcodeBuildTools/skills/sparkle-integration/SKILL.md
@@ -3,6 +3,8 @@ name: sparkle-integration
 description: Integrate Sparkle 2.x auto-update framework into macOS apps. Use when adding auto-update functionality for macOS applications.
 ---
 
+> This skill has no equivalent in the Xcode MCP server.
+
 # Sparkle Auto-Update Integration
 
 Integrate Sparkle 2.x into macOS apps with workspace + SPM architecture, release automation, and GitHub Pages hosting.

--- a/XcodeBuildTools/skills/swift-package/SKILL.md
+++ b/XcodeBuildTools/skills/swift-package/SKILL.md
@@ -3,6 +3,8 @@ name: swift-package
 description: Build, test, run, and manage Swift Package Manager projects. Use when working with Package.swift projects, running "swift build", "swift test", or "swift run", managing package executables, or cleaning SPM build artifacts.
 ---
 
+> **Xcode MCP**: If the package is open in Xcode and `BuildProject` is in your tool list, prefer that over this skill.
+
 # Swift Package
 
 Manage Swift Package Manager projects.

--- a/XcodeBuildTools/skills/xcode-doctor/SKILL.md
+++ b/XcodeBuildTools/skills/xcode-doctor/SKILL.md
@@ -3,6 +3,8 @@ name: xcode-doctor
 description: Diagnose Xcode development environment health. Use when encountering build errors, setting up a new Mac, troubleshooting missing tools, or verifying Xcode installation.
 ---
 
+> This skill has no equivalent in the Xcode MCP server.
+
 # Xcode Doctor
 
 Diagnose your development environment.

--- a/XcodeBuildTools/skills/xcode-project/SKILL.md
+++ b/XcodeBuildTools/skills/xcode-project/SKILL.md
@@ -3,6 +3,8 @@ name: xcode-project
 description: Discover and inspect Xcode projects and workspaces. Use when finding .xcodeproj/.xcworkspace files, listing available schemes, viewing build settings, or extracting bundle identifiers from apps.
 ---
 
+> **Xcode MCP**: If `XcodeGlob` / `XcodeLS` / `XcodeListWindows` are in your tool list, prefer those over this skill.
+
 # Xcode Project Discovery
 
 Find and inspect Xcode projects, schemes, build settings, and app metadata.

--- a/XcodeBuildTools/skills/xcode-test/SKILL.md
+++ b/XcodeBuildTools/skills/xcode-test/SKILL.md
@@ -3,6 +3,8 @@ name: xcode-test
 description: Run Xcode unit tests and UI tests using xcodebuild with xcsift for token-efficient output. Use when running tests for iOS/macOS projects, filtering specific test cases, or checking test results.
 ---
 
+> **Xcode MCP**: If `RunAllTests` / `RunSomeTests` / `GetTestList` are in your tool list, prefer those over this skill.
+
 # Xcode Test
 
 Run unit and UI tests with `xcodebuild test` and `xcsift --format toon`.

--- a/XcodeBuildTools/skills/xcodebuild/SKILL.md
+++ b/XcodeBuildTools/skills/xcodebuild/SKILL.md
@@ -3,6 +3,8 @@ name: xcodebuild
 description: Build Xcode projects for simulator, device, or macOS using `xcodebuild` with xcsift for token-efficient output. Use when compiling iOS/tvOS/watchOS apps, building macOS apps, cleaning build products or before you invoke any Bash command with `xcodebuild` or `swift`.
 ---
 
+> **Xcode MCP**: If `BuildProject` / `GetBuildLog` are in your tool list, prefer those over this skill.
+
 # Xcodebuild
 
 Build Xcode projects and workspaces using `xcodebuild` with `xcsift --format toon --warnings --executable` for token-efficient output.

--- a/common/detect_xcode_mcp.py
+++ b/common/detect_xcode_mcp.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Detect whether Xcode's native MCP server is available."""
+
+import subprocess
+
+
+def detect_xcode_mcp() -> dict:
+    """Check if Xcode MCP bridge is installed and likely active.
+
+    Returns dict with:
+        xcode_mcp_installed: xcrun --find mcpbridge succeeds
+        xcode_running: Xcode process is running
+        mcpbridge_running: mcpbridge process is running
+        xcode_mcp_likely: installed AND (xcode OR bridge running)
+    """
+    result = {
+        "xcode_mcp_installed": False,
+        "xcode_running": False,
+        "mcpbridge_running": False,
+        "xcode_mcp_likely": False,
+    }
+
+    # Check if mcpbridge binary exists (Xcode 26.3+)
+    try:
+        subprocess.run(
+            ["xcrun", "--find", "mcpbridge"],
+            capture_output=True, timeout=5
+        ).returncode == 0 and result.update({"xcode_mcp_installed": True})
+    except Exception:
+        pass
+
+    if not result["xcode_mcp_installed"]:
+        return result
+
+    # Check if Xcode is running
+    try:
+        if subprocess.run(
+            ["pgrep", "-x", "Xcode"],
+            capture_output=True, timeout=3
+        ).returncode == 0:
+            result["xcode_running"] = True
+    except Exception:
+        pass
+
+    # Check if mcpbridge is running
+    try:
+        if subprocess.run(
+            ["pgrep", "-f", "mcpbridge"],
+            capture_output=True, timeout=3
+        ).returncode == 0:
+            result["mcpbridge_running"] = True
+    except Exception:
+        pass
+
+    result["xcode_mcp_likely"] = (
+        result["xcode_running"] or result["mcpbridge_running"]
+    )
+    return result

--- a/common/session-start.py
+++ b/common/session-start.py
@@ -3,6 +3,7 @@
 import sys
 import json
 import os
+import re
 
 from version_tracker import check_for_updates, load_json_file
 
@@ -42,7 +43,38 @@ def main():
         else:
             additional_context = ""
 
+        # Detect Xcode MCP availability (fail-open: treat as unavailable on error)
+        xcode_mcp_likely = False
+        try:
+            from detect_xcode_mcp import detect_xcode_mcp
+            detection = detect_xcode_mcp()
+            xcode_mcp_likely = detection.get("xcode_mcp_likely", False)
+        except Exception:
+            pass
+
+        # Process conditional blocks in markdown (no-op if markers absent)
+        if xcode_mcp_likely:
+            # Keep IF_XCODE_MCP content, remove IF_NO_XCODE_MCP content
+            additional_context = re.sub(
+                r'<!-- IF_XCODE_MCP -->\n?', '', additional_context)
+            additional_context = re.sub(
+                r'<!-- END_XCODE_MCP -->\n?', '', additional_context)
+            additional_context = re.sub(
+                r'<!-- IF_NO_XCODE_MCP -->.*?<!-- END_NO_XCODE_MCP -->\n?',
+                '', additional_context, flags=re.DOTALL)
+        else:
+            # Keep IF_NO_XCODE_MCP content, remove IF_XCODE_MCP content
+            additional_context = re.sub(
+                r'<!-- IF_NO_XCODE_MCP -->\n?', '', additional_context)
+            additional_context = re.sub(
+                r'<!-- END_NO_XCODE_MCP -->\n?', '', additional_context)
+            additional_context = re.sub(
+                r'<!-- IF_XCODE_MCP -->.*?<!-- END_XCODE_MCP -->\n?',
+                '', additional_context, flags=re.DOTALL)
+
         system_message = f"The {plugin_name} plugin is loaded and ready."
+        if xcode_mcp_likely:
+            system_message += " Xcode MCP server detected."
         if welcome_message:
             system_message += f" {welcome_message}"
 


### PR DESCRIPTION
## Summary

Adds automatic detection of Xcode 26.3+'s native MCP server at session start. When detected, XcodeBuildTools conditionally shows delegation rules that prefer Xcode MCP tools over equivalent plugin skills, with graceful fallback when MCP is unavailable.

- **Detection module** (`common/detect_xcode_mcp.py`): Checks if `mcpbridge` binary exists and if Xcode/bridge are running. Fail-open design — all subprocess calls have timeouts and return `False` on error.
- **Conditional blocks** in `session-start.py`: Processes `<!-- IF_XCODE_MCP -->` / `<!-- IF_NO_XCODE_MCP -->` markers in `session-start.md`. No-op for plugins without markers (safe for all 5 plugins sharing `common/`).
- **Auto-approve hook** (`approve-xcode-mcp.sh`): Async SessionStart hook that clicks "Allow" on Xcode's MCP authorization dialog. PID-based lock file prevents re-runs for the same Xcode instance.
- **Skill annotations**: All 9 skills now have a one-line blockquote indicating MCP preference (4 overlapping) or uniqueness (5 with no equivalent).
- **Future-proofing**: Generic fallback instruction for new Xcode MCP tools beyond the known set.

## Tool Overlap Map

| XcodeBuildTools Skill | Xcode MCP Equivalent | Strategy |
|---|---|---|
| `xcodebuild` | `BuildProject` + `GetBuildLog` | Prefer MCP, fallback to skill |
| `xcode-test` | `RunAllTests` / `RunSomeTests` / `GetTestList` | Prefer MCP, fallback to skill |
| `xcode-project` | `XcodeGlob` / `XcodeLS` / `XcodeListWindows` | Prefer MCP, fallback to skill |
| `swift-package` | `BuildProject` (partial) | Prefer MCP when project open in Xcode |
| sosumi MCP (docs) | `DocumentationSearch` | Prefer MCP |

**No MCP equivalent** (always use skills): `device-app`, `sim-log`, `xcode-doctor`, `macos-app`, `sparkle-integration`

## Files Changed (18 files, +264/-3)

| Action | File |
|--------|------|
| CREATE | `common/detect_xcode_mcp.py` |
| CREATE | `XcodeBuildTools/hooks/approve-xcode-mcp.sh` |
| MODIFY | `common/session-start.py` |
| MODIFY | `XcodeBuildTools/hooks/hooks.json` |
| MODIFY | `XcodeBuildTools/session-start.md` |
| MODIFY | 9 skill `SKILL.md` files |
| MODIFY | `info.json`, `plugin.json`, `marketplace.json` (version → 0.4.0) |
| MODIFY | `XcodeBuildTools/README.md` |

## Test Plan

- [x] Detection module returns correct results with Xcode open vs closed
- [x] Conditional block regex correctly processes all 3 scenarios (MCP detected, no MCP, no markers)
- [x] All JSON files validate without errors
- [x] Auto-approve lock file created on first run, second run exits instantly (0.075s)
- [x] End-to-end: new Claude Code session shows delegation rules from plugin (tested in repo with no CLAUDE.md MCP instructions)
- [ ] Verify other plugins (MarvinOutputStyle, iOSSimulator, etc.) session start unchanged