### PR TITLE
Add per-session build isolation sandbox (v0.5.0)

### DIFF
--- a/XcodeBuildTools/.claude-plugin/plugin.json
+++ b/XcodeBuildTools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "XcodeBuildTools",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Xcode development tools: build/test/run Swift packages, discover projects and schemes, build for simulator/device/macOS, run tests, manage device apps, capture simulator logs",
   "author": {
     "name": "Gustavo Ambrozio"

--- a/XcodeBuildTools/hooks/approve-xcode-mcp.sh
+++ b/XcodeBuildTools/hooks/approve-xcode-mcp.sh
@@ -4,31 +4,22 @@
 #
 # Runs as an async hook (async: true in hooks.json) so it doesn't block startup.
 #   1. Pre-checks: Xcode must be running and mcpbridge must exist
-#   2. Lock file prevents redundant runs for the same Xcode instance
-#   3. Checks Accessibility permissions (notifies + opens Settings if missing)
-#   4. Polls Xcode's windows for the auth dialog (up to 10 seconds)
-#   5. Clicks "Allow" when found, or exits silently on timeout
+#   2. Checks Accessibility permissions (notifies + opens Settings if missing)
+#   3. Polls Xcode's windows for the auth dialog (up to 15 seconds)
+#   4. Clicks "Allow" when found, or exits silently on timeout
 #
 # Prerequisite (one-time):
 #   System Settings > Privacy & Security > Accessibility
 #   → Add your terminal app (Terminal.app, iTerm2, etc.)
 
 # --- Pre-checks: bail early if Xcode or mcpbridge aren't available ---
-XCODE_PID=$(pgrep -x Xcode 2>/dev/null)
-if [[ -z "$XCODE_PID" ]]; then
+if ! pgrep -x Xcode &>/dev/null; then
     exit 0
 fi
 
 if ! xcrun --find mcpbridge &>/dev/null; then
     exit 0
 fi
-
-# --- Lock file keyed on Xcode PID (prevents re-runs for same instance) ---
-LOCK_FILE="${TMPDIR:-/tmp}/xcode-mcp-approve-${XCODE_PID}.lock"
-if [[ -f "$LOCK_FILE" ]]; then
-    exit 0
-fi
-touch "$LOCK_FILE"
 
 # --- Check Accessibility permissions ---
 if ! osascript -e 'tell application "System Events" to get name of first process' &>/dev/null; then
@@ -38,18 +29,17 @@ if ! osascript -e 'tell application "System Events" to get name of first process
             subtitle "Missing Accessibility permissions"
     '
     open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
-    rm -f "$LOCK_FILE"
     exit 0
 fi
 
 # --- Give MCP bridge time to connect and trigger the dialog ---
 sleep 2
 
-# --- Poll for up to 10s for the MCP auth dialog and click Allow ---
+# --- Poll for up to 15s for the MCP auth dialog and click Allow ---
 osascript <<'APPLESCRIPT' >/dev/null 2>&1
 tell application "System Events"
     tell process "Xcode"
-        repeat 10 times
+        repeat 15 times
             repeat with xcodeWindow in windows
                 try
                     repeat with dialogText in static texts of xcodeWindow

--- a/XcodeBuildTools/hooks/hooks.json
+++ b/XcodeBuildTools/hooks/hooks.json
@@ -13,6 +13,10 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/setup-sandbox.sh"
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/approve-xcode-mcp.sh",
             "async": true
           }

--- a/XcodeBuildTools/hooks/setup-sandbox.sh
+++ b/XcodeBuildTools/hooks/setup-sandbox.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+#
+# setup-sandbox.sh — Create isolated Xcode build environment (per-session)
+#
+# Creates wrapper scripts for xcodebuild and swift that transparently inject
+# -derivedDataPath / -clonedSourcePackagesDirPath / --cache-path flags,
+# isolating CLI builds from Xcode's own DerivedData and SPM cache.
+#
+# Each Claude Code session gets its own sandbox keyed by PPID (the Claude
+# process PID). Multiple sessions can build concurrently without conflicts.
+#
+# The sandbox lives inside Xcode's DerivedData directory so that nuking
+# DerivedData also cleans up all sandbox state — matching developer expectations.
+#
+# Runs as a SessionStart hook; outputs JSON for Claude Code.
+
+set -euo pipefail
+
+# --- Locate Xcode's DerivedData ---
+# Respect custom DerivedData location if the developer configured one.
+CUSTOM_DD=$(defaults read com.apple.dt.Xcode IDECustomDerivedDataLocation 2>/dev/null || echo "")
+if [[ -n "$CUSTOM_DD" ]]; then
+    DERIVED_DATA="$CUSTOM_DD"
+else
+    DERIVED_DATA="$HOME/Library/Developer/Xcode/DerivedData"
+fi
+
+# --- Per-session sandbox paths ---
+SESSION_PID="${PPID:-$$}"
+SANDBOX_ROOT="$DERIVED_DATA/claude-sandbox"
+SANDBOX_BASE="$SANDBOX_ROOT/$SESSION_PID"
+SANDBOX_BUILD="$SANDBOX_BASE/build"
+SANDBOX_PKGS="$SANDBOX_BASE/packages"
+SANDBOX_BIN="$SANDBOX_BASE/bin"
+
+# --- Clean up stale sessions ---
+# Iterate all PID dirs under claude-sandbox/. If the owning process is dead
+# (or the PID was reused by a non-Claude process), remove that session's sandbox.
+if [[ -d "$SANDBOX_ROOT" ]]; then
+    for session_dir in "$SANDBOX_ROOT"/*/; do
+        [[ -d "$session_dir" ]] || continue
+        pid=$(basename "$session_dir")
+        # Skip non-numeric directory names
+        [[ "$pid" =~ ^[0-9]+$ ]] || continue
+        # Skip our own session
+        [[ "$pid" == "$SESSION_PID" ]] && continue
+
+        is_alive=false
+        if kill -0 "$pid" 2>/dev/null; then
+            pid_cmd=$(ps -o command= -p "$pid" 2>/dev/null || echo "")
+            if [[ "$pid_cmd" == *claude* || "$pid_cmd" == *node* ]]; then
+                is_alive=true
+            fi
+        fi
+
+        if [[ "$is_alive" == "false" ]]; then
+            rm -rf "$session_dir"
+            rm -f "/tmp/claude-sandbox-$pid"
+        fi
+    done
+fi
+
+# --- Create sandbox directories ---
+mkdir -p "$SANDBOX_BUILD" "$SANDBOX_PKGS" "$SANDBOX_BIN"
+
+# --- Write path file for skill file discovery ---
+# Skill files use $(cat /tmp/claude-sandbox-$(echo $PPID)) to find the sandbox.
+# This indirection lets the hook respect custom DerivedData locations while
+# keeping skill file paths stable.
+echo "$SANDBOX_BASE" > "/tmp/claude-sandbox-$SESSION_PID"
+
+# --- APFS clone system SPM cache if sandbox packages dir is empty ---
+# cp -c creates instant copy-on-write clones on APFS: zero extra disk until
+# writes diverge. Falls back to regular copy on non-APFS volumes.
+if [[ -z "$(ls -A "$SANDBOX_PKGS" 2>/dev/null)" ]]; then
+    system_spm="$HOME/Library/Caches/org.swift.swiftpm"
+    if [[ -d "$system_spm" ]]; then
+        cp -cpR "$system_spm/" "$SANDBOX_PKGS/" 2>/dev/null || true
+    fi
+fi
+
+# --- Create xcodebuild wrapper ---
+# Injects -derivedDataPath and -clonedSourcePackagesDirPath so CLI builds
+# use isolated storage instead of Xcode's default DerivedData.
+cat > "$SANDBOX_BIN/xcodebuild" << WRAPPER
+#!/bin/bash
+exec /usr/bin/xcodebuild \\
+    -derivedDataPath "$SANDBOX_BUILD" \\
+    -clonedSourcePackagesDirPath "$SANDBOX_PKGS" \\
+    "\$@"
+WRAPPER
+chmod +x "$SANDBOX_BIN/xcodebuild"
+
+# --- Create swift wrapper (subcommand-aware) ---
+# Only injects --cache-path for subcommands that accept SwiftPM flags
+# (build, test, run). Other subcommands (package, repl, --version) pass through.
+cat > "$SANDBOX_BIN/swift" << WRAPPER
+#!/bin/bash
+case "\${1:-}" in
+    build|test|run)
+        exec /usr/bin/swift "\$@" \\
+            --cache-path "$SANDBOX_PKGS"
+        ;;
+    *)
+        exec /usr/bin/swift "\$@"
+        ;;
+esac
+WRAPPER
+chmod +x "$SANDBOX_BIN/swift"
+
+# --- Output hook response ---
+printf '{"systemMessage":""}\n'

--- a/XcodeBuildTools/hooks/setup-sandbox.sh
+++ b/XcodeBuildTools/hooks/setup-sandbox.sh
@@ -71,21 +71,30 @@ mkdir -p "$SANDBOX_BUILD" "$SANDBOX_PKGS" "$SANDBOX_BIN"
 # keeping skill file paths stable.
 echo "$SANDBOX_BASE" > "/tmp/claude-sandbox-$SESSION_PID"
 
-# --- APFS clone system SPM cache if sandbox packages dir is empty ---
-# cp -c creates instant copy-on-write clones on APFS: zero extra disk until
-# writes diverge. Falls back to regular copy on non-APFS volumes.
-if [[ -z "$(ls -A "$SANDBOX_PKGS" 2>/dev/null)" ]]; then
+# --- Lazy SPM cache seeding helper ---
+# Written into wrapper scripts so the APFS clone only runs on first build,
+# not on every session start. cp -c creates copy-on-write clones on APFS
+# (zero extra disk until writes diverge); silently skipped on non-APFS volumes.
+SEED_SPM_SNIPPET=$(cat << 'SEED'
+if [[ ! -f "SANDBOX_PKGS/.seeded" ]]; then
     system_spm="$HOME/Library/Caches/org.swift.swiftpm"
     if [[ -d "$system_spm" ]]; then
-        cp -cpR "$system_spm/" "$SANDBOX_PKGS/" 2>/dev/null || true
+        cp -cpR "$system_spm/" "SANDBOX_PKGS/" 2>/dev/null || true
     fi
+    touch "SANDBOX_PKGS/.seeded"
 fi
+SEED
+)
+# Substitute the actual sandbox packages path into the snippet
+SEED_SPM_SNIPPET="${SEED_SPM_SNIPPET//SANDBOX_PKGS/$SANDBOX_PKGS}"
 
 # --- Create xcodebuild wrapper ---
 # Injects -derivedDataPath and -clonedSourcePackagesDirPath so CLI builds
 # use isolated storage instead of Xcode's default DerivedData.
+# Seeds SPM cache from system cache on first invocation.
 cat > "$SANDBOX_BIN/xcodebuild" << WRAPPER
 #!/bin/bash
+$SEED_SPM_SNIPPET
 exec /usr/bin/xcodebuild \\
     -derivedDataPath "$SANDBOX_BUILD" \\
     -clonedSourcePackagesDirPath "$SANDBOX_PKGS" \\
@@ -96,10 +105,12 @@ chmod +x "$SANDBOX_BIN/xcodebuild"
 # --- Create swift wrapper (subcommand-aware) ---
 # Only injects --cache-path for subcommands that accept SwiftPM flags
 # (build, test, run). Other subcommands (package, repl, --version) pass through.
+# Seeds SPM cache from system cache on first build invocation.
 cat > "$SANDBOX_BIN/swift" << WRAPPER
 #!/bin/bash
 case "\${1:-}" in
     build|test|run)
+        $SEED_SPM_SNIPPET
         exec /usr/bin/swift "\$@" \\
             --cache-path "$SANDBOX_PKGS"
         ;;

--- a/XcodeBuildTools/hooks/setup-sandbox.sh
+++ b/XcodeBuildTools/hooks/setup-sandbox.sh
@@ -9,10 +9,10 @@
 # Each Claude Code session gets its own sandbox keyed by PPID (the Claude
 # process PID). Multiple sessions can build concurrently without conflicts.
 #
-# The sandbox lives inside Xcode's DerivedData directory so that nuking
-# DerivedData also cleans up all sandbox state — matching developer expectations.
+# The sandbox lives under $TMPDIR so it auto-cleans on reboot — no stale
+# build artifacts survive a restart even if PID-based cleanup misses them.
 #
-# Runs as a SessionStart hook; outputs JSON for Claude Code.
+# Runs as a SessionStart hook.
 
 set -euo pipefail
 
@@ -27,7 +27,7 @@ fi
 
 # --- Per-session sandbox paths ---
 SESSION_PID="${PPID:-$$}"
-SANDBOX_ROOT="$DERIVED_DATA/claude-sandbox"
+SANDBOX_ROOT="${TMPDIR:-/tmp}/claude-sandbox"
 SANDBOX_BASE="$SANDBOX_ROOT/$SESSION_PID"
 SANDBOX_BUILD="$SANDBOX_BASE/build"
 SANDBOX_PKGS="$SANDBOX_BASE/packages"
@@ -55,7 +55,7 @@ if [[ -d "$SANDBOX_ROOT" ]]; then
 
         if [[ "$is_alive" == "false" ]]; then
             rm -rf "$session_dir"
-            rm -f "/tmp/claude-sandbox-$pid"
+            rm -f "${TMPDIR:-/tmp}/claude-sandbox-$pid"
         fi
     done
 fi
@@ -64,12 +64,12 @@ fi
 mkdir -p "$SANDBOX_BUILD" "$SANDBOX_PKGS" "$SANDBOX_BIN"
 
 # --- Write path file for skill file discovery ---
-# Skill files use $(cat /tmp/claude-sandbox-$(echo $PPID)) to find the sandbox.
+# Skill files use $(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID)) to find the sandbox.
 # NOTE: $(echo $PPID) instead of bare $PPID is intentional — $PPID expands to
 # empty in command position when used with pipes in Claude Code's zsh eval.
 # This indirection lets the hook respect custom DerivedData locations while
 # keeping skill file paths stable.
-echo "$SANDBOX_BASE" > "/tmp/claude-sandbox-$SESSION_PID"
+echo "$SANDBOX_BASE" > "${TMPDIR:-/tmp}/claude-sandbox-$SESSION_PID"
 
 # --- Lazy SPM cache seeding helper ---
 # Written into wrapper scripts so the APFS clone only runs on first build,
@@ -121,5 +121,3 @@ esac
 WRAPPER
 chmod +x "$SANDBOX_BIN/swift"
 
-# --- Output hook response ---
-printf '{"systemMessage":""}\n'

--- a/XcodeBuildTools/hooks/setup-sandbox.sh
+++ b/XcodeBuildTools/hooks/setup-sandbox.sh
@@ -65,6 +65,8 @@ mkdir -p "$SANDBOX_BUILD" "$SANDBOX_PKGS" "$SANDBOX_BIN"
 
 # --- Write path file for skill file discovery ---
 # Skill files use $(cat /tmp/claude-sandbox-$(echo $PPID)) to find the sandbox.
+# NOTE: $(echo $PPID) instead of bare $PPID is intentional — $PPID expands to
+# empty in command position when used with pipes in Claude Code's zsh eval.
 # This indirection lets the hook respect custom DerivedData locations while
 # keeping skill file paths stable.
 echo "$SANDBOX_BASE" > "/tmp/claude-sandbox-$SESSION_PID"

--- a/XcodeBuildTools/info.json
+++ b/XcodeBuildTools/info.json
@@ -45,6 +45,10 @@
     ],
     "versions": [
         {
+            "version": "0.5.0",
+            "changes": "Build isolation sandbox: CLI builds now use isolated DerivedData and SPM cache via wrapper scripts, preventing conflicts with Xcode. Always active — transparent when Xcode MCP handles builds, automatic when falling back to CLI."
+        },
+        {
             "version": "0.4.0",
             "changes": "Xcode MCP compatibility: auto-detects Xcode 26.3+ native MCP server and delegates overlapping tools (build, test, project inspection, docs). Adds auto-approve hook for MCP authorization dialog"
         },

--- a/XcodeBuildTools/session-start.md
+++ b/XcodeBuildTools/session-start.md
@@ -8,11 +8,11 @@ The `XcodeBuildTools` plugin provides specialized tools for Xcode build and test
 
 ## Build Isolation
 
-Each session gets an isolated build sandbox inside Xcode's DerivedData, keyed by `$PPID`. **Always use the sandbox wrappers** instead of bare `xcodebuild` or `swift` commands:
+Each session gets an isolated build sandbox keyed by `$PPID`. **Always use the sandbox wrappers** instead of bare `xcodebuild` or `swift` commands:
 
 ```
-$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild ...
-$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/swift build ...
+$(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID))/bin/xcodebuild ...
+$(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID))/bin/swift build ...
 ```
 
 This ensures DerivedData and SPM caches are isolated from Xcode and from other Claude sessions. The sandbox wrappers transparently inject `-derivedDataPath`, `-clonedSourcePackagesDirPath`, and `--cache-path` flags — no other changes to your commands are needed.

--- a/XcodeBuildTools/session-start.md
+++ b/XcodeBuildTools/session-start.md
@@ -6,6 +6,17 @@ The `XcodeBuildTools` plugin provides specialized tools for Xcode build and test
 
 **IMPORTANT**: Whenever you need to build or test an Xcode project/workspace, compile or test Swift packages, or anytime you would use `swift`/`xcodebuild` commands, **always** use the `xcodebuild` skill instead. This skill provides token-efficient, AI-friendly compilation output.
 
+## Build Isolation
+
+Each session gets an isolated build sandbox inside Xcode's DerivedData, keyed by `$PPID`. **Always use the sandbox wrappers** instead of bare `xcodebuild` or `swift` commands:
+
+```
+$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild ...
+$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/swift build ...
+```
+
+This ensures DerivedData and SPM caches are isolated from Xcode and from other Claude sessions. The sandbox wrappers transparently inject `-derivedDataPath`, `-clonedSourcePackagesDirPath`, and `--cache-path` flags — no other changes to your commands are needed.
+
 <!-- IF_XCODE_MCP -->
 ## Xcode MCP Tool Delegation
 

--- a/XcodeBuildTools/skills/swift-package/SKILL.md
+++ b/XcodeBuildTools/skills/swift-package/SKILL.md
@@ -50,7 +50,7 @@ scripts/swift-package-stop.py --pid <pid> [--force]
 
 ```bash
 # Clean build artifacts
-swift package clean
+$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/swift package clean
 
 # Or remove .build directory directly
 rm -rf /path/to/package/.build

--- a/XcodeBuildTools/skills/swift-package/SKILL.md
+++ b/XcodeBuildTools/skills/swift-package/SKILL.md
@@ -15,7 +15,7 @@ For build/test output parsing: `brew install xcsift`
 
 ## Build & Test (with xcsift)
 
-Always use the sandbox wrapper to isolate the SPM cache from Xcode:
+**Always use the sandbox** Use `$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/swift` instead of bare `swift`. This isolates DerivedData and SPM caches from Xcode.
 
 ```bash
 cd /path/to/package

--- a/XcodeBuildTools/skills/swift-package/SKILL.md
+++ b/XcodeBuildTools/skills/swift-package/SKILL.md
@@ -15,22 +15,22 @@ For build/test output parsing: `brew install xcsift`
 
 ## Build & Test (with xcsift)
 
-**Always use the sandbox** Use `$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/swift` instead of bare `swift`. This isolates DerivedData and SPM caches from Xcode.
+**Always use the sandbox** Use `$(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID))/bin/swift` instead of bare `swift`. This isolates DerivedData and SPM caches from Xcode.
 
 ```bash
 cd /path/to/package
 
 # Build
-$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/swift build 2>&1 | tee /tmp/build.log | xcsift --format toon --warnings
+$(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID))/bin/swift build 2>&1 | tee ${TMPDIR:-/tmp}/build.log | xcsift --format toon --warnings
 
 # Build release
-$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/swift build -c release 2>&1 | tee /tmp/build.log | xcsift --format toon --warnings
+$(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID))/bin/swift build -c release 2>&1 | tee ${TMPDIR:-/tmp}/build.log | xcsift --format toon --warnings
 
 # Test
-$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/swift test 2>&1 | tee /tmp/test.log | xcsift --format toon --warnings
+$(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID))/bin/swift test 2>&1 | tee ${TMPDIR:-/tmp}/test.log | xcsift --format toon --warnings
 
 # Test with filter
-$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/swift test --filter "testLogin" 2>&1 | tee /tmp/test.log | xcsift --format toon --warnings
+$(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID))/bin/swift test --filter "testLogin" 2>&1 | tee ${TMPDIR:-/tmp}/test.log | xcsift --format toon --warnings
 ```
 
 ## Run & Process Management
@@ -50,7 +50,7 @@ scripts/swift-package-stop.py --pid <pid> [--force]
 
 ```bash
 # Clean build artifacts
-$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/swift package clean
+$(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID))/bin/swift package clean
 
 # Or remove .build directory directly
 rm -rf /path/to/package/.build

--- a/XcodeBuildTools/skills/swift-package/SKILL.md
+++ b/XcodeBuildTools/skills/swift-package/SKILL.md
@@ -15,20 +15,22 @@ For build/test output parsing: `brew install xcsift`
 
 ## Build & Test (with xcsift)
 
+Always use the sandbox wrapper to isolate the SPM cache from Xcode:
+
 ```bash
 cd /path/to/package
 
 # Build
-swift build 2>&1 | tee /tmp/build.log | xcsift --format toon --warnings
+$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/swift build 2>&1 | tee /tmp/build.log | xcsift --format toon --warnings
 
 # Build release
-swift build -c release 2>&1 | tee /tmp/build.log | xcsift --format toon --warnings
+$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/swift build -c release 2>&1 | tee /tmp/build.log | xcsift --format toon --warnings
 
 # Test
-swift test 2>&1 | tee /tmp/test.log | xcsift --format toon --warnings
+$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/swift test 2>&1 | tee /tmp/test.log | xcsift --format toon --warnings
 
 # Test with filter
-swift test --filter "testLogin" 2>&1 | tee /tmp/test.log | xcsift --format toon --warnings
+$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/swift test --filter "testLogin" 2>&1 | tee /tmp/test.log | xcsift --format toon --warnings
 ```
 
 ## Run & Process Management

--- a/XcodeBuildTools/skills/xcode-test/SKILL.md
+++ b/XcodeBuildTools/skills/xcode-test/SKILL.md
@@ -19,27 +19,28 @@ Ensure `xcsift` is installed and up to date: `brew install xcsift` (or `brew upg
 2. **Always add** `-skipMacroValidation -skipPackagePluginValidation`
 3. **Single line commands** Do not use line continuation characters (backslashes) to split commands across multiple lines. Keep each command on a single line.
 4. **Use workspace when available** If the project has a corresponding `xcworkspace` always use the `-workspace` flag to compile, never `-project`
+5. **Always use the sandbox** Use `$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild` instead of bare `xcodebuild`. This isolates DerivedData and SPM caches from Xcode.
 
 ## Test Commands
 
 ### iOS Simulator Tests
 ```bash
-xcodebuild -workspace MyApp.xcworkspace -scheme MyAppTests -destination 'id=<simulator-uuid>' -skipMacroValidation -skipPackagePluginValidation test 2>&1 | tee /tmp/test.log | xcsift --format toon --warnings
+$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyAppTests -destination 'id=<simulator-uuid>' -skipMacroValidation -skipPackagePluginValidation test 2>&1 | tee /tmp/test.log | xcsift --format toon --warnings
 ```
 
 ### macOS Tests
 ```bash
-xcodebuild -workspace MyApp.xcworkspace -scheme MyAppTests -destination 'platform=macOS' -skipMacroValidation -skipPackagePluginValidation test 2>&1 | tee /tmp/test.log | xcsift --format toon --warnings
+$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyAppTests -destination 'platform=macOS' -skipMacroValidation -skipPackagePluginValidation test 2>&1 | tee /tmp/test.log | xcsift --format toon --warnings
 ```
 
 ### Run Specific Tests
 ```bash
-xcodebuild -workspace MyApp.xcworkspace -scheme MyAppTests -destination 'id=<simulator-uuid>' -only-testing:MyAppTests/LoginTests/testLoginSuccess test 2>&1 | tee /tmp/test.log | xcsift --format toon --warnings
+$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyAppTests -destination 'id=<simulator-uuid>' -only-testing:MyAppTests/LoginTests/testLoginSuccess test 2>&1 | tee /tmp/test.log | xcsift --format toon --warnings
 ```
 
 ### Skip Specific Tests
 ```bash
-xcodebuild ... -skip-testing:MyAppTests/SlowTests test 2>&1 | xcsift --format toon --warnings
+$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild ... -skip-testing:MyAppTests/SlowTests test 2>&1 | xcsift --format toon --warnings
 ```
 
 ## Test Specification Format

--- a/XcodeBuildTools/skills/xcode-test/SKILL.md
+++ b/XcodeBuildTools/skills/xcode-test/SKILL.md
@@ -19,28 +19,28 @@ Ensure `xcsift` is installed and up to date: `brew install xcsift` (or `brew upg
 2. **Always add** `-skipMacroValidation -skipPackagePluginValidation`
 3. **Single line commands** Do not use line continuation characters (backslashes) to split commands across multiple lines. Keep each command on a single line.
 4. **Use workspace when available** If the project has a corresponding `xcworkspace` always use the `-workspace` flag to compile, never `-project`
-5. **Always use the sandbox** Use `$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild` instead of bare `xcodebuild`. This isolates DerivedData and SPM caches from Xcode.
+5. **Always use the sandbox** Use `$(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID))/bin/xcodebuild` instead of bare `xcodebuild`. This isolates DerivedData and SPM caches from Xcode.
 
 ## Test Commands
 
 ### iOS Simulator Tests
 ```bash
-$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyAppTests -destination 'id=<simulator-uuid>' -skipMacroValidation -skipPackagePluginValidation test 2>&1 | tee /tmp/test.log | xcsift --format toon --warnings
+$(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyAppTests -destination 'id=<simulator-uuid>' -skipMacroValidation -skipPackagePluginValidation test 2>&1 | tee ${TMPDIR:-/tmp}/test.log | xcsift --format toon --warnings
 ```
 
 ### macOS Tests
 ```bash
-$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyAppTests -destination 'platform=macOS' -skipMacroValidation -skipPackagePluginValidation test 2>&1 | tee /tmp/test.log | xcsift --format toon --warnings
+$(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyAppTests -destination 'platform=macOS' -skipMacroValidation -skipPackagePluginValidation test 2>&1 | tee ${TMPDIR:-/tmp}/test.log | xcsift --format toon --warnings
 ```
 
 ### Run Specific Tests
 ```bash
-$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyAppTests -destination 'id=<simulator-uuid>' -only-testing:MyAppTests/LoginTests/testLoginSuccess test 2>&1 | tee /tmp/test.log | xcsift --format toon --warnings
+$(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyAppTests -destination 'id=<simulator-uuid>' -only-testing:MyAppTests/LoginTests/testLoginSuccess test 2>&1 | tee ${TMPDIR:-/tmp}/test.log | xcsift --format toon --warnings
 ```
 
 ### Skip Specific Tests
 ```bash
-$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild ... -skip-testing:MyAppTests/SlowTests test 2>&1 | xcsift --format toon --warnings
+$(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID))/bin/xcodebuild ... -skip-testing:MyAppTests/SlowTests test 2>&1 | xcsift --format toon --warnings
 ```
 
 ## Test Specification Format
@@ -49,4 +49,4 @@ $(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild ... -skip-testing:MyAppT
 - Test class: `MyAppTests/LoginTests`
 - Test method: `MyAppTests/LoginTests/testLoginSuccess`
 
-Output shows test results, errors, and failures. Check `/tmp/test.log` for details.
+Output shows test results, errors, and failures. Check `${TMPDIR:-/tmp}/test.log` for details.

--- a/XcodeBuildTools/skills/xcodebuild/SKILL.md
+++ b/XcodeBuildTools/skills/xcodebuild/SKILL.md
@@ -24,7 +24,7 @@ Ensure `xcsift` is installed and up to date: `brew install xcsift` (or `brew upg
 5. **Single line commands** Do not use line continuation characters (backslashes) to split commands across multiple lines. Keep each command on a single line.
 6. **Capture full output just in case** `xcsift` only outputs the most important build information but in some cases you might need to inspect the full output of `xcodebuild`. When using `xcsift` always `tee` to a temporary file and use it if `xcsift`'s output is not enough. In the examples below the path to the temporary file is an example, use what you think is the most appropriate location.
 7. **Always use workspace when building** Always use the `-workspace` flag to build, never `-project`
-8. **Always use the sandbox** Use `$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild` instead of bare `xcodebuild`. This isolates DerivedData and SPM caches from Xcode.
+8. **Always use the sandbox** Use `$(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID))/bin/xcodebuild` instead of bare `xcodebuild`. This isolates DerivedData and SPM caches from Xcode.
 
 ## Build Command Examples
 
@@ -36,24 +36,24 @@ These are examples of common operation. Feel free to change them but always reme
 xcrun simctl list devices available
 
 # Build
-$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -destination 'id=<simulator-uuid>' -skipMacroValidation -skipPackagePluginValidation build 2>&1 | tee /tmp/build.log | xcsift --format toon --warnings --executable
+$(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -destination 'id=<simulator-uuid>' -skipMacroValidation -skipPackagePluginValidation build 2>&1 | tee ${TMPDIR:-/tmp}/build.log | xcsift --format toon --warnings --executable
 ```
 
 ### Physical Device
 ```bash
-$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -destination 'id=<device-udid>' -skipMacroValidation -skipPackagePluginValidation build 2>&1 | tee /tmp/build.log | xcsift --format toon --warnings --executable
+$(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -destination 'id=<device-udid>' -skipMacroValidation -skipPackagePluginValidation build 2>&1 | tee ${TMPDIR:-/tmp}/build.log | xcsift --format toon --warnings --executable
 ```
 
 ### macOS
 ```bash
-$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -destination 'platform=macOS' -skipMacroValidation -skipPackagePluginValidation build 2>&1 | tee /tmp/build.log | xcsift --format toon --warnings --executable
+$(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -destination 'platform=macOS' -skipMacroValidation -skipPackagePluginValidation build 2>&1 | tee ${TMPDIR:-/tmp}/build.log | xcsift --format toon --warnings --executable
 ```
 
 ### Clean
 ```bash
-$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyApp clean 2>&1 | xcsift --format toon
+$(cat ${TMPDIR:-/tmp}/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyApp clean 2>&1 | xcsift --format toon
 ```
 
 ## Output
 
-`xcsift --format toon --warnings --executable` returns token-optimized output with errors, warnings, and notes. Check `/tmp/build.log` for full output if needed.
+`xcsift --format toon --warnings --executable` returns token-optimized output with errors, warnings, and notes. Check `${TMPDIR:-/tmp}/build.log` for full output if needed.

--- a/XcodeBuildTools/skills/xcodebuild/SKILL.md
+++ b/XcodeBuildTools/skills/xcodebuild/SKILL.md
@@ -24,6 +24,7 @@ Ensure `xcsift` is installed and up to date: `brew install xcsift` (or `brew upg
 5. **Single line commands** Do not use line continuation characters (backslashes) to split commands across multiple lines. Keep each command on a single line.
 6. **Capture full output just in case** `xcsift` only outputs the most important build information but in some cases you might need to inspect the full output of `xcodebuild`. When using `xcsift` always `tee` to a temporary file and use it if `xcsift`'s output is not enough. In the examples below the path to the temporary file is an example, use what you think is the most appropriate location.
 7. **Always use workspace when building** Always use the `-workspace` flag to build, never `-project`
+8. **Always use the sandbox** Use `$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild` instead of bare `xcodebuild`. This isolates DerivedData and SPM caches from Xcode.
 
 ## Build Command Examples
 
@@ -35,22 +36,22 @@ These are examples of common operation. Feel free to change them but always reme
 xcrun simctl list devices available
 
 # Build
-xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -destination 'id=<simulator-uuid>' -skipMacroValidation -skipPackagePluginValidation build 2>&1 | tee /tmp/build.log | xcsift --format toon --warnings --executable
+$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -destination 'id=<simulator-uuid>' -skipMacroValidation -skipPackagePluginValidation build 2>&1 | tee /tmp/build.log | xcsift --format toon --warnings --executable
 ```
 
 ### Physical Device
 ```bash
-xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -destination 'id=<device-udid>' -skipMacroValidation -skipPackagePluginValidation build 2>&1 | tee /tmp/build.log | xcsift --format toon --warnings --executable
+$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -destination 'id=<device-udid>' -skipMacroValidation -skipPackagePluginValidation build 2>&1 | tee /tmp/build.log | xcsift --format toon --warnings --executable
 ```
 
 ### macOS
 ```bash
-xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -destination 'platform=macOS' -skipMacroValidation -skipPackagePluginValidation build 2>&1 | tee /tmp/build.log | xcsift --format toon --warnings --executable
+$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -destination 'platform=macOS' -skipMacroValidation -skipPackagePluginValidation build 2>&1 | tee /tmp/build.log | xcsift --format toon --warnings --executable
 ```
 
 ### Clean
 ```bash
-xcodebuild -workspace MyApp.xcworkspace -scheme MyApp clean 2>&1 | xcsift --format toon
+$(cat /tmp/claude-sandbox-$(echo $PPID))/bin/xcodebuild -workspace MyApp.xcworkspace -scheme MyApp clean 2>&1 | xcsift --format toon
 ```
 
 ## Output


### PR DESCRIPTION
## Summary

When Claude Code falls back to CLI `xcodebuild`/`swift` (Xcode MCP unavailable), builds write directly into Xcode's DerivedData and SPM cache. This corrupts Xcode's state and causes SPM resolution failures.

This PR adds a **SessionStart hook** that creates per-session sandboxed build environments, completely isolating CLI builds from Xcode and from each other.

## What it does

- **Per-session sandbox** inside Xcode's DerivedData, keyed by `$PPID` (the Claude Code process PID). Multiple concurrent sessions build without conflicts.
- **Wrapper scripts** for `xcodebuild` and `swift` that transparently inject `-derivedDataPath`, `-clonedSourcePackagesDirPath`, and `--cache-path` flags — no user-facing command changes needed.
- **APFS clone** of the system SPM cache (`cp -cpR`) for instant cold starts with zero extra disk on APFS volumes.
- **Stale session cleanup** on startup — checks PID liveness with reuse protection (verifies the process is actually Claude/Node, not a recycled PID).
- **Custom DerivedData support** — respects `IDECustomDerivedDataLocation` via path file indirection at `/tmp/claude-sandbox-$PPID`.
- **Transparent when Xcode MCP is active** — the wrappers are only used when builds fall back to CLI.

## Design decisions

**Sandbox inside DerivedData**: Developers routinely `rm -rf DerivedData` to clean up. Housing sandboxes inside DerivedData means existing cleanup workflows just work.

**`$(echo $PPID)` in skill files**: Claude Code's Bash tool uses `zsh -c eval ...` which has a quirk where `$PPID` expands to empty in command position when pipes are present. `$(echo $PPID)` forces expansion via command substitution before pipeline setup. This is documented in the code.

**Path file indirection**: The hook writes the sandbox path to `/tmp/claude-sandbox-$PPID`. Skill files read from this file instead of hardcoding a DerivedData path. This decouples skills from the actual DerivedData location (default or custom).

## Files changed

| File | Change |
|------|--------|
| `hooks/setup-sandbox.sh` | New — core sandbox creation, wrapper generation, cleanup |
| `hooks/hooks.json` | Add sandbox hook to SessionStart |
| `session-start.md` | Document sandbox wrapper usage |
| `skills/xcodebuild/SKILL.md` | Update all examples to use sandbox wrappers |
| `skills/xcode-test/SKILL.md` | Update all examples to use sandbox wrappers |
| `skills/swift-package/SKILL.md` | Update all examples to use sandbox wrappers |
| `.claude-plugin/plugin.json` | Version bump 0.4.0 → 0.5.0 |
| `info.json` | Add 0.5.0 changelog entry |

## Testing

- Verified sandbox creation on session start (hook runs, wrappers generated, path file written)
- Built a real iOS app through the sandbox — BUILD SUCCEEDED
- Ran **two concurrent builds** in separate sandboxes simultaneously — both succeeded with fully isolated DerivedData (~7 GB each)
- Verified stale session cleanup removes dead sessions on next startup
- Verified `swift package clean` works through the wrapper (passes through to bare swift for non-build subcommands)