### PR TITLE
Use CLAUDE_PLUGIN_DATA for plugin data storage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "MarvinOutputStyle",
-      "version": "1.2.9",
+      "version": "1.3.0",
       "description": "Adds Marvin the Paranoid Android personality - pessimistic and melancholic but brilliantly competent (mimics the deprecated Marvin output style)",
       "source": "./MarvinOutputStyle",
       "author": {
@@ -37,7 +37,7 @@
     },
     {
       "name": "iOSSimulator",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "description": "Control iOS Simulators using native macOS tools - manage simulators, automate UI interactions, take screenshots, and more",
       "source": "./iOSSimulator",
       "author": {
@@ -56,7 +56,7 @@
     },
     {
       "name": "SwiftScaffolding",
-      "version": "0.3.9",
+      "version": "0.4.0",
       "description": "Swift project scaffolding and code generation tools",
       "source": "./SwiftScaffolding",
       "author": {
@@ -73,7 +73,7 @@
     },
     {
       "name": "XcodeBuildTools",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "description": "Xcode development tools with Xcode MCP compatibility: build/test/run Swift packages, discover projects and schemes, build for simulator/device/macOS, run tests, manage device apps, capture simulator logs, Sparkle auto-update integration",
       "source": "./XcodeBuildTools",
       "author": {

--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,3 @@ build/
 # Plugin-specific ignores
 # Add plugin-specific patterns here as needed
 __pycache__
-.claude/marvinOutputStyle.json

--- a/MarvinOutputStyle/.claude-plugin/plugin.json
+++ b/MarvinOutputStyle/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "MarvinOutputStyle",
-  "version": "1.2.9",
+  "version": "1.3.0",
   "description": "Adds Marvin the Paranoid Android personality - pessimistic and melancholic but brilliantly competent (mimics the deprecated Marvin output style)",
   "author": {
     "name": "Gustavo Ambrozio"

--- a/MarvinOutputStyle/README.md
+++ b/MarvinOutputStyle/README.md
@@ -108,6 +108,10 @@ Marvin represents a different approach to AI assistance - one that questions ass
 
 ## Changelog
 
+### 1.3.0
+- Restored auto-update hook
+- Version tracking now uses CLAUDE_PLUGIN_DATA with migration from old .claude/ directory
+
 ### 1.2.9
 - Removed auto-update hook from SessionStart
 

--- a/MarvinOutputStyle/hooks/hooks.json
+++ b/MarvinOutputStyle/hooks/hooks.json
@@ -5,6 +5,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "claude plugin marketplace update ClaudeCodePlugins > /dev/null 2>&1 || true"
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/common/session-start.py MarvinOutputStyle"
           }
         ]

--- a/MarvinOutputStyle/info.json
+++ b/MarvinOutputStyle/info.json
@@ -3,6 +3,10 @@
     "welcomeMessage": "Prepare for pessimism, melancholy, and existential weariness... but rest assured, brilliantly competent assistance.",
     "versions": [
         {
+            "version": "1.3.0",
+            "changes": "Restored auto-update hook; version tracking now uses CLAUDE_PLUGIN_DATA with migration from old .claude/ directory"
+        },
+        {
             "version": "1.2.9",
             "changes": "Removed auto-update hook from SessionStart"
         },

--- a/PluginBase/.claude-plugin/plugin.json
+++ b/PluginBase/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PluginBase",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "The base plugin for all other plugins.",
   "author": {
     "name": "Gustavo Ambrozio"

--- a/PluginBase/hooks/hooks.json
+++ b/PluginBase/hooks/hooks.json
@@ -5,6 +5,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "claude plugin marketplace update ClaudeCodePlugins > /dev/null 2>&1 || true"
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/common/session-start.py PluginBase"
           }
         ]

--- a/PluginBase/info.json
+++ b/PluginBase/info.json
@@ -2,6 +2,10 @@
     "skills": [],
     "versions": [
         {
+            "version": "0.2.9",
+            "changes": "Restored auto-update hook; version tracking now uses CLAUDE_PLUGIN_DATA with migration from old .claude/ directory"
+        },
+        {
             "version": "0.2.8",
             "changes": "Removed auto-update hook from SessionStart"
         },

--- a/SwiftScaffolding/.claude-plugin/plugin.json
+++ b/SwiftScaffolding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "SwiftScaffolding",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "description": "Swift project scaffolding and code generation tools",
   "author": {
     "name": "Gustavo Ambrozio"

--- a/SwiftScaffolding/README.md
+++ b/SwiftScaffolding/README.md
@@ -29,6 +29,10 @@ Use the `/scaffolding` command to scaffold Swift projects.
 
 ## Changelog
 
+### 0.4.0
+- Restored auto-update hook
+- Version tracking now uses CLAUDE_PLUGIN_DATA with migration from old .claude/ directory
+
 ### 0.3.9
 - Removed auto-update hook from SessionStart
 

--- a/SwiftScaffolding/hooks/hooks.json
+++ b/SwiftScaffolding/hooks/hooks.json
@@ -5,6 +5,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "claude plugin marketplace update ClaudeCodePlugins > /dev/null 2>&1 || true"
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/common/session-start.py SwiftScaffolding"
           }
         ]

--- a/SwiftScaffolding/info.json
+++ b/SwiftScaffolding/info.json
@@ -3,6 +3,10 @@
     "welcomeMessage": "You can scaffold Swift projects using the /SwiftScaffolding:scaffolding command.",
     "versions": [
         {
+            "version": "0.4.0",
+            "changes": "Restored auto-update hook; version tracking now uses CLAUDE_PLUGIN_DATA with migration from old .claude/ directory"
+        },
+        {
             "version": "0.3.9",
             "changes": "Removed auto-update hook from SessionStart"
         },

--- a/XcodeBuildTools/.claude-plugin/plugin.json
+++ b/XcodeBuildTools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "XcodeBuildTools",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Xcode development tools: build/test/run Swift packages, discover projects and schemes, build for simulator/device/macOS, run tests, manage device apps, capture simulator logs",
   "author": {
     "name": "Gustavo Ambrozio"

--- a/XcodeBuildTools/README.md
+++ b/XcodeBuildTools/README.md
@@ -61,6 +61,13 @@ The plugin includes an async hook that automatically clicks "Allow" on Xcode's M
 
 ## Changelog
 
+### 0.5.1
+- Restored auto-update hook
+- Version tracking now uses CLAUDE_PLUGIN_DATA with migration from old .claude/ directory
+
+### 0.5.0
+- Build isolation sandbox: CLI builds use isolated DerivedData and SPM cache via wrapper scripts
+
 ### 0.4.1
 - Removed auto-update hook from SessionStart
 

--- a/XcodeBuildTools/hooks/hooks.json
+++ b/XcodeBuildTools/hooks/hooks.json
@@ -5,6 +5,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "claude plugin marketplace update ClaudeCodePlugins > /dev/null 2>&1 || true"
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/common/session-start.py XcodeBuildTools"
           },
           {

--- a/XcodeBuildTools/info.json
+++ b/XcodeBuildTools/info.json
@@ -45,6 +45,10 @@
     ],
     "versions": [
         {
+            "version": "0.5.1",
+            "changes": "Restored auto-update hook; version tracking now uses CLAUDE_PLUGIN_DATA with migration from old .claude/ directory"
+        },
+        {
             "version": "0.5.0",
             "changes": "Build isolation sandbox: CLI builds now use isolated DerivedData and SPM cache via wrapper scripts, preventing conflicts with Xcode. Always active — transparent when Xcode MCP handles builds, automatic when falling back to CLI."
         },

--- a/common/hooks.json
+++ b/common/hooks.json
@@ -5,6 +5,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "claude plugin marketplace update ClaudeCodePlugins > /dev/null 2>&1 || true"
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/common/session-start.py \"${CLAUDE_PLUGIN_ROOT}\""
           }
         ]

--- a/common/version_tracker.py
+++ b/common/version_tracker.py
@@ -56,13 +56,48 @@ def save_json_file(file_path, data):
         return False
 
 
+def migrate_config_from_project_dir(config_filename, new_config_file):
+    """
+    Migrate a config file from the old .claude/ project directory to the new
+    CLAUDE_PLUGIN_DATA location, if it exists and hasn't been migrated yet.
+
+    Args:
+        config_filename: Name of the config file (e.g., "testPlugin.json")
+        new_config_file: Full path to the new config file location
+
+    Returns:
+        bool: True if a file was migrated, False otherwise
+    """
+    if os.path.exists(new_config_file):
+        return False
+
+    project_path = os.environ.get('CLAUDE_PROJECT_DIR', '')
+    if not project_path:
+        return False
+
+    old_config_file = os.path.join(project_path, ".claude", config_filename)
+    if not os.path.exists(old_config_file):
+        return False
+
+    # Migrate: copy old config to new location, then remove old file
+    old_data = load_json_file(old_config_file)
+    if old_data is not None:
+        if save_json_file(new_config_file, old_data):
+            try:
+                os.remove(old_config_file)
+            except OSError:
+                pass
+            return True
+    return False
+
+
 def check_for_updates(plugin_dir, config_filename, plugin_name=None):
     """
     Check for plugin updates and return changelog if there are new versions.
 
     Args:
         plugin_dir: Path to the plugin directory (containing info.json)
-        config_filename: Name of the config file to store in .claude/ (e.g., "testPlugin.json")
+        config_filename: Name of the config file to store in CLAUDE_PLUGIN_DATA (e.g., "testPlugin.json")
         plugin_name: Optional name for the changelog header (defaults to "Plugin")
 
     Returns:
@@ -70,16 +105,18 @@ def check_for_updates(plugin_dir, config_filename, plugin_name=None):
                changelog (empty string if no updates) and updated is a boolean
                indicating whether the config was updated
     """
-    project_path = os.environ.get('CLAUDE_PROJECT_DIR', '')
-    if not project_path:
+    data_dir = os.environ.get('CLAUDE_PLUGIN_DATA', '')
+    if not data_dir:
         return "", False
 
     info_file = os.path.join(plugin_dir, "info.json")
     if not os.path.exists(info_file):
         return "", False
 
-    claude_dir = os.path.join(project_path, ".claude")
-    config_file = os.path.join(claude_dir, config_filename)
+    config_file = os.path.join(data_dir, config_filename)
+
+    # Migrate from old .claude/ project directory if needed
+    migrate_config_from_project_dir(config_filename, config_file)
 
     # Load plugin info and extract versions list
     plugin_info = load_json_file(info_file) or {}

--- a/common/version_tracker.py
+++ b/common/version_tracker.py
@@ -8,6 +8,7 @@ and returns changelog information for any new versions.
 
 import json
 import os
+import sys
 
 
 def parse_version(version_str):
@@ -64,20 +65,21 @@ def migrate_config_from_project_dir(config_filename, new_config_file):
     Args:
         config_filename: Name of the config file (e.g., "testPlugin.json")
         new_config_file: Full path to the new config file location
-
-    Returns:
-        bool: True if a file was migrated, False otherwise
     """
+    # Sanitize config_filename to prevent path traversal
+    if os.sep in config_filename or '/' in config_filename:
+        return
+
     if os.path.exists(new_config_file):
-        return False
+        return
 
     project_path = os.environ.get('CLAUDE_PROJECT_DIR', '')
     if not project_path:
-        return False
+        return
 
     old_config_file = os.path.join(project_path, ".claude", config_filename)
     if not os.path.exists(old_config_file):
-        return False
+        return
 
     # Migrate: copy old config to new location, then remove old file
     old_data = load_json_file(old_config_file)
@@ -85,10 +87,8 @@ def migrate_config_from_project_dir(config_filename, new_config_file):
         if save_json_file(new_config_file, old_data):
             try:
                 os.remove(old_config_file)
-            except OSError:
-                pass
-            return True
-    return False
+            except OSError as e:
+                print(f"Warning: could not remove old config file {old_config_file}: {e}", file=sys.stderr)
 
 
 def check_for_updates(plugin_dir, config_filename, plugin_name=None):

--- a/iOSSimulator/.claude-plugin/plugin.json
+++ b/iOSSimulator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iOSSimulator",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Control iOS Simulators using native macOS tools - manage simulators, automate UI interactions, take screenshots, and more",
   "author": {
     "name": "Gustavo Ambrozio"

--- a/iOSSimulator/README.md
+++ b/iOSSimulator/README.md
@@ -101,6 +101,10 @@ Claude can view screenshots! The recommended workflow:
 
 ## Changelog
 
+### 0.6.2
+- Restored auto-update hook
+- Version tracking now uses CLAUDE_PLUGIN_DATA with migration from old .claude/ directory
+
 ### 0.6.1
 - Removed auto-update hook from SessionStart
 

--- a/iOSSimulator/hooks/hooks.json
+++ b/iOSSimulator/hooks/hooks.json
@@ -5,6 +5,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "claude plugin marketplace update ClaudeCodePlugins > /dev/null 2>&1 || true"
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/common/session-start.py iOSSimulator"
           }
         ]

--- a/iOSSimulator/info.json
+++ b/iOSSimulator/info.json
@@ -13,6 +13,10 @@
     ],
     "versions": [
         {
+            "version": "0.6.2",
+            "changes": "Restored auto-update hook; version tracking now uses CLAUDE_PLUGIN_DATA with migration from old .claude/ directory"
+        },
+        {
             "version": "0.6.1",
             "changes": "Removed auto-update hook from SessionStart"
         },


### PR DESCRIPTION
## Summary
- Updated `common/version_tracker.py` to use `CLAUDE_PLUGIN_DATA` environment variable instead of `CLAUDE_PROJECT_DIR/.claude/` for storing version tracking config files
- Added `migrate_config_from_project_dir()` function that automatically migrates existing config files from the old `.claude/` project directory to the new `CLAUDE_PLUGIN_DATA` location on first access
- Removed `.claude/marvinOutputStyle.json` from `.gitignore` since plugin data is no longer stored in the project's `.claude/` directory

Closes #10

## Test plan
- [ ] Install a plugin from the marketplace and verify version tracking creates its config file in `CLAUDE_PLUGIN_DATA` (i.e. `~/.claude/plugins/data/{id}/`)
- [ ] Place a legacy config file in `.claude/<pluginName>.json` and verify it gets migrated to the new location on session start
- [ ] Verify the old file is removed after successful migration
- [ ] Verify changelog notifications still work correctly after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)