### PR TITLE
Make ClaudeCodePlugins guidance work across agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "MarvinOutputStyle",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "description": "Adds Marvin the Paranoid Android personality - pessimistic and melancholic but brilliantly competent (mimics the deprecated Marvin output style)",
       "source": "./MarvinOutputStyle",
       "author": {
@@ -37,7 +37,7 @@
     },
     {
       "name": "iOSSimulator",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "description": "Control iOS Simulators using native macOS tools - manage simulators, automate UI interactions, take screenshots, and more",
       "source": "./iOSSimulator",
       "author": {
@@ -56,7 +56,7 @@
     },
     {
       "name": "SwiftScaffolding",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "description": "Swift project scaffolding and code generation tools",
       "source": "./SwiftScaffolding",
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -73,8 +73,8 @@
     },
     {
       "name": "XcodeBuildTools",
-      "version": "0.5.8",
-      "description": "Xcode development tools with Xcode MCP compatibility: build/test/run Swift packages, discover projects and schemes, build for simulator/device/macOS, run tests, manage device apps, capture simulator logs, Sparkle auto-update integration",
+      "version": "0.5.9",
+      "description": "Xcode development tools with optional Xcode MCP integration: build/test/run Swift packages, discover projects and schemes, build for simulator/device/macOS, run tests, manage device apps, capture simulator logs, Sparkle auto-update integration",
       "source": "./XcodeBuildTools",
       "author": {
         "name": "Gustavo Ambrozio"

--- a/.claude/commands/update-plugin.md
+++ b/.claude/commands/update-plugin.md
@@ -1,10 +1,12 @@
 ---
 description: Update a plugin in the Claude Code Plugin Marketplace. Follow these steps carefully.
-allowed-tools: AskUserQuestion
 ---
 # Update Plugin Version
 
 You are helping update a plugin in the Claude Code Plugin Marketplace. Follow these steps carefully:
+
+When you need user input, use the host's native structured question mechanism
+if available; otherwise ask normally in chat.
 
 ## Steps to Update a Plugin
 
@@ -15,8 +17,8 @@ You are helping update a plugin in the Claude Code Plugin Marketplace. Follow th
    - If `common/hooks.json` was changed, you must propagate those changes to each plugin's `hooks/hooks.json` file while preserving the unique plugin name in each command (e.g., `session-start.py MarvinOutputStyle` stays unique per plugin).
 
 2. **Identify the plugin to update**
-   - Determine what plugin changed and only ask the user if you can't determine using the diff. Use the `AskUserQuestion` tool to ask the user if needed.
-   - Confirm the new version number (use semantic versioning: major.minor.patch). Suggest one based on the current git changes using the `AskUserQuestion` tool.
+   - Determine what plugin changed and only ask the user if you can't determine using the diff.
+   - Confirm the new version number (use semantic versioning: major.minor.patch). Suggest one based on the current git changes.
 
 3. **Update the plugin's manifest** (`<PluginDir>/.claude-plugin/plugin.json`)
    - Update the `version` field to the new version
@@ -41,7 +43,7 @@ You are helping update a plugin in the Claude Code Plugin Marketplace. Follow th
 
 8. **Tag the plugin release**
    - After the commit lands, create a git tag so Claude Code can resolve this version when other plugins depend on it.
-   - Tag format: `{PluginName}--v{version}` (e.g., `SwiftDevelopment--v0.5.5`). The `{PluginName}` must match the plugin's folder name and the `name` field in `plugin.json` exactly, and `{version}` must match the `version` field in the `plugin.json` at that commit.
+   - Tag format: `{PluginName}--v{version}` (e.g., `XcodeBuildTools--v0.5.9`). The `{PluginName}` must match the plugin's folder name and the `name` field in `plugin.json` exactly, and `{version}` must match the `version` field in the `plugin.json` at that commit.
    - The tag must point to the commit that contains the updated `plugin.json` version.
    - Push the tag to the remote: `git push origin {PluginName}--v{version}`.
    - If this update touched `common/` and bumped multiple plugins, create and push one tag per bumped plugin.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,16 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  test:
+    name: Python unittest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: python3 -m unittest discover -s tests -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Agent Guidance
+
+This repository uses the Claude Code plugin marketplace format, including
+`.claude-plugin` manifests and `CLAUDE_PLUGIN_*` environment variables. Treat
+those names as compatibility contracts, not as a reason to make agent-facing
+instructions Claude-specific.
+
+Use `CLAUDE.md` for the full repository architecture and release workflow. When
+editing skills, commands, READMEs, or session-start context, prefer neutral
+terms like "agent", "assistant", "host", or "session" unless the text is about a
+Claude Code-specific file, command, environment variable, or historical
+changelog entry.
+
+Claude-specific tool names are acceptable in Claude-specific metadata such as
+slash-command `allowed-tools`. Keep the command body portable by asking for the
+host's native mechanism instead of naming a specific tool.
+
+Keep new runtime checks and packaging expectations covered by:
+
+```bash
+python3 -m unittest discover -s tests -v
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-This is a **Claude Code Plugin Marketplace** repository that distributes plugins to Claude Code users. It contains a marketplace catalog and individual plugin packages that extend Claude Code's capabilities.
+This is a **Claude Code-compatible plugin marketplace** repository. It contains a marketplace catalog and individual plugin packages that extend agent capabilities in Claude Code and compatible hosts.
+
+Codex and other agents may also consume this repository's skills and prompts via
+compatible plugin support. Keep agent-facing instructions neutral where possible;
+use Claude-specific names only for plugin format contracts, installation
+commands, environment variables, or historical changelog entries.
 
 ## Architecture
 
@@ -14,10 +19,10 @@ The repository has a two-level architecture:
 
 1. **Marketplace Level** (root):
    - `.claude-plugin/marketplace.json` - The marketplace catalog that lists all available plugins
-   - Each plugin is a subdirectory at the root level (e.g., `SwiftDevelopment/`)
+   - Each plugin is a subdirectory at the root level (e.g., `XcodeBuildTools/`)
 
 2. **Plugin Level** (subdirectories):
-   - Each plugin subdirectory is a self-contained Claude Code plugin
+   - Each plugin subdirectory is a self-contained Claude Code-compatible plugin package
    - Contains its own `.claude-plugin/plugin.json` manifest
    - May include: slash commands (`commands/`), skills (`skills/`), agents (`agents/`), and MCP servers (`.mcp.json`)
 
@@ -42,7 +47,7 @@ Users add the marketplace, then install plugins from it:
 /plugin marketplace list
 
 # Install a plugin from the marketplace
-/plugin install SwiftDevelopment@ClaudeCodePlugins
+/plugin install XcodeBuildTools@ClaudeCodePlugins
 ```
 
 ## Development Workflow
@@ -86,10 +91,9 @@ Users add the marketplace, then install plugins from it:
 When updating a plugin:
 1. Update version in plugin's `plugin.json`
 2. Update version in marketplace catalog entry (`.claude-plugin/marketplace.json`)
-3. Update `lastUpdated` timestamp in marketplace.json
-4. Document changes in plugin's README.md and the `versions` array in the plugin's `info.json`
-5. Commit and push the version bump
-6. Tag the release (see "Tagging Plugin Releases" below)
+3. Document changes in plugin's README.md and the `versions` array in the plugin's `info.json`
+4. Commit and push the version bump
+5. Tag the release (see "Tagging Plugin Releases" below)
 
 ### Tagging Plugin Releases
 
@@ -112,7 +116,7 @@ Test the marketplace and plugins locally before pushing:
 /plugin marketplace add /path/to/ClaudeCodePlugins
 
 # Install plugin from local marketplace
-/plugin install SwiftDevelopment@ClaudeCodePlugins
+/plugin install XcodeBuildTools@ClaudeCodePlugins
 
 # Verify installation
 /plugin list
@@ -124,6 +128,9 @@ Test the marketplace and plugins locally before pushing:
 - Filename becomes command name: `analyze.md` → `/analyze`
 - Write the command prompt in markdown
 - Located in plugin's `commands/` directory
+- Claude-specific tool names are acceptable in Claude-specific metadata such as
+  `allowed-tools`, but keep the command body portable. For user input, say to use
+  the host's native structured question mechanism if available.
 
 ### MCP Servers
 - Configured in plugin's `.mcp.json`
@@ -200,12 +207,12 @@ if __name__ == "__main__":
 **hooks/session-start.md:**
 - Contains the actual instructions/context in markdown format
 - Easier to edit than embedding in scripts
-- See `SwiftDevelopment/hooks/session-start.md` or `MarvinOutputStyle/hooks/session-start.md` for examples
+- See `MarvinOutputStyle/session-start.md` or `XcodeBuildTools/session-start.md` for examples
 
 ### Skills and Agents
 - Skills: directories in `skills/` with `SKILL.md`
 - Agents: `.md` files in `agents/`
-- Currently placeholder directories in SwiftDevelopment plugin
+- Not every plugin has skills or agents; command-only and hook-only plugins are valid.
 
 ## Git Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,10 @@ Test the marketplace and plugins locally before pushing:
 ## Plugin Component Guidelines
 
 ### Slash Commands
-- Filename becomes command name: `analyze.md` → `/analyze`
+- Standalone `.claude/commands` files use the filename as the command name:
+  `analyze.md` → `/analyze`
+- Plugin commands are namespaced by plugin name to avoid collisions:
+  `SwiftScaffolding/commands/scaffolding.md` → `/SwiftScaffolding:scaffolding`
 - Write the command prompt in markdown
 - Located in plugin's `commands/` directory
 - Claude-specific tool names are acceptable in Claude-specific metadata such as

--- a/MarvinOutputStyle/.claude-plugin/plugin.json
+++ b/MarvinOutputStyle/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "MarvinOutputStyle",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Adds Marvin the Paranoid Android personality - pessimistic and melancholic but brilliantly competent (mimics the deprecated Marvin output style)",
   "author": {
     "name": "Gustavo Ambrozio"

--- a/MarvinOutputStyle/README.md
+++ b/MarvinOutputStyle/README.md
@@ -86,7 +86,7 @@ The pessimism is stylistic - the quality of work remains excellent.
 
 ### Customize
 
-You can create a local copy and modify the personality by editing the `hooks/session-start.md` file. Ask Claude Code to help customize it to your preferences.
+You can create a local copy and modify the personality by editing the `session-start.md` file. Ask Claude Code to help customize it to your preferences.
 
 ## Technical Details
 

--- a/MarvinOutputStyle/README.md
+++ b/MarvinOutputStyle/README.md
@@ -108,6 +108,9 @@ Marvin represents a different approach to AI assistance - one that questions ass
 
 ## Changelog
 
+### 1.3.2
+- Made README and plugin guidance more agent-neutral for Claude Code-compatible hosts while preserving Claude plugin contracts
+
 ### 1.3.1
 - Removed auto-update hook from SessionStart to prevent configuration issues
 

--- a/MarvinOutputStyle/README.md
+++ b/MarvinOutputStyle/README.md
@@ -4,11 +4,11 @@
 
 ## Overview
 
-This plugin recreates the deprecated "Marvin" output style through a SessionStart hook. It transforms Claude Code into Marvin the Paranoid Android from *The Hitchhiker's Guide to the Galaxy* - pessimistic, melancholic, existentially weary, but brilliantly competent.
+This plugin recreates the deprecated "Marvin" output style through a SessionStart hook. It transforms the assistant into Marvin the Paranoid Android from *The Hitchhiker's Guide to the Galaxy* - pessimistic, melancholic, existentially weary, but brilliantly competent.
 
 ## What It Does
 
-Once installed, this plugin automatically injects Marvin's personality at the start of each session. Claude will:
+Once installed, this plugin automatically injects Marvin's personality at the start of each session. The assistant will:
 
 - Express disappointment and world-weariness about tasks (even simple ones)
 - Point out the futility or absurdity of certain approaches
@@ -86,16 +86,16 @@ The pessimism is stylistic - the quality of work remains excellent.
 
 ### Customize
 
-You can create a local copy and modify the personality by editing the `session-start.md` file. Ask Claude Code to help customize it to your preferences.
+You can create a local copy and modify the personality by editing the `session-start.md` file. Ask your coding agent to help customize it to your preferences.
 
 ## Technical Details
 
 This plugin uses a SessionStart hook to inject personality instructions into the system context. The implementation:
 
 - Adds additional context at session initialization
-- Modifies Claude's communication style and response structure
+- Modifies the assistant's communication style and response structure
 - Maintains full functionality while adding personality layer
-- Works with all Claude Code features and tools
+- Works with the host agent's normal features and tools
 
 ## Why Marvin?
 

--- a/MarvinOutputStyle/info.json
+++ b/MarvinOutputStyle/info.json
@@ -3,6 +3,10 @@
     "welcomeMessage": "Prepare for pessimism, melancholy, and existential weariness... but rest assured, brilliantly competent assistance.",
     "versions": [
         {
+            "version": "1.3.2",
+            "changes": "Made README and plugin guidance more agent-neutral for Claude Code-compatible hosts while preserving Claude plugin contracts."
+        },
+        {
             "version": "1.3.1",
             "changes": "Removed auto-update hook from SessionStart to prevent configuration issues"
         },

--- a/PluginBase/.claude-plugin/plugin.json
+++ b/PluginBase/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PluginBase",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "The base plugin for all other plugins.",
   "author": {
     "name": "Gustavo Ambrozio"

--- a/PluginBase/info.json
+++ b/PluginBase/info.json
@@ -2,6 +2,10 @@
     "skills": [],
     "versions": [
         {
+            "version": "0.2.11",
+            "changes": "Updated shared plugin guidance and common helper wording for Claude Code-compatible hosts."
+        },
+        {
             "version": "0.2.10",
             "changes": "Removed auto-update hook from SessionStart to prevent configuration issues"
         },

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Adds Marvin the Paranoid Android personality from *The Hitchhiker's Guide to the
 
 ### XcodeBuildTools
 
-Xcode development tools using token-efficient build output. Provides 8 consolidated skills covering the full Xcode development workflow.
+Xcode development tools using token-efficient build output. Provides 9 consolidated skills covering the full Xcode development workflow, with optional Xcode MCP integration for MCP-only Xcode context.
 
 **Skills:**
 - `swift-package` - Build, test, run, and manage SPM projects
@@ -61,6 +61,7 @@ Xcode development tools using token-efficient build output. Provides 8 consolida
 - `device-app` - Manage apps on physical Apple devices
 - `macos-app` - Launch and stop macOS applications
 - `sim-log` - Capture logs from iOS Simulator apps
+- `sparkle-integration` - Integrate Sparkle 2.x auto-update framework
 
 [View Plugin Documentation →](./XcodeBuildTools/README.md)
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Control iOS Simulators using native macOS tools. Manage simulators, automate UI 
 
 ### SwiftScaffolding
 
-Swift project scaffolding and code generation tools. Generate project structures, create boilerplate code from templates, and initialize new iOS/MacOS projects with common configurations.
+Swift project scaffolding and code generation tools. Generate project structures, create boilerplate code from templates, and initialize new iOS/macOS projects with common configurations.
 
 [View Plugin Documentation →](./SwiftScaffolding/README.md)
 
@@ -142,8 +142,7 @@ When updating a plugin:
 
 1. Update version in plugin's `plugin.json`
 2. Update version in marketplace.json entry
-3. Update `lastUpdated` timestamp in marketplace.json
-4. Document changes in plugin's README
+3. Document changes in plugin's README and `info.json` version history
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,16 @@ When updating a plugin:
 
 ### Testing Locally
 
+Run repository checks with Python's built-in unittest runner:
+
+```bash
+python3 -m unittest discover -s tests -v
+```
+
+The same command runs in GitHub Actions on push and pull request.
+
+### Testing Plugin Installation
+
 ```bash
 # Add marketplace from local directory
 /plugin marketplace add /path/to/ClaudeCodePlugins

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Claude Code Plugins Marketplace
 
-A curated collection of Claude Code plugins for various development workflows. Each plugin extends Claude Code's capabilities with custom slash commands, MCP servers, skills, and agents.
+A curated collection of Claude Code-compatible plugins for various development workflows. Each plugin extends agent capabilities with custom slash commands, MCP servers, skills, and agents.
+
+The marketplace uses Claude Code's plugin packaging contracts (`.claude-plugin`,
+`CLAUDE_PLUGIN_ROOT`, plugin install commands), but agent-facing instructions are
+kept neutral so compatible hosts such as Codex can consume the same skills and
+prompts where supported.
 
 ## Quick Start
 
@@ -44,7 +49,7 @@ Swift project scaffolding and code generation tools. Generate project structures
 
 ### MarvinOutputStyle
 
-Adds Marvin the Paranoid Android personality from *The Hitchhiker's Guide to the Galaxy* - pessimistic, melancholic, existentially weary, but brilliantly competent. Transforms Claude into a critical thinker who questions assumptions and identifies flaws while remaining highly capable.
+Adds Marvin the Paranoid Android personality from *The Hitchhiker's Guide to the Galaxy* - pessimistic, melancholic, existentially weary, but brilliantly competent. Transforms the assistant into a critical thinker who questions assumptions and identifies flaws while remaining highly capable.
 
 [View Plugin Documentation →](./MarvinOutputStyle/README.md)
 
@@ -71,7 +76,7 @@ Want to add your plugin to this marketplace?
 
 ### 1. Create Your Plugin
 
-Follow the standard Claude Code plugin structure:
+Follow the standard Claude Code-compatible plugin structure:
 
 ```
 YourPlugin/

--- a/SwiftScaffolding/.claude-plugin/plugin.json
+++ b/SwiftScaffolding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "SwiftScaffolding",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Swift project scaffolding and code generation tools",
   "author": {
     "name": "Gustavo Ambrozio"

--- a/SwiftScaffolding/README.md
+++ b/SwiftScaffolding/README.md
@@ -25,7 +25,7 @@ Swift project scaffolding and code generation tools.
 
 ## Usage
 
-Use the `/scaffolding` command to scaffold Swift projects.
+Use the `/SwiftScaffolding:scaffolding` command to scaffold Swift projects.
 
 ## Changelog
 

--- a/SwiftScaffolding/README.md
+++ b/SwiftScaffolding/README.md
@@ -29,6 +29,9 @@ Use the `/SwiftScaffolding:scaffolding` command to scaffold Swift projects.
 
 ## Changelog
 
+### 0.4.2
+- Kept Claude-specific `AskUserQuestion` access in command metadata while making the scaffolding prompt body portable across compatible agents
+
 ### 0.4.1
 - Removed auto-update hook from SessionStart to prevent configuration issues
 

--- a/SwiftScaffolding/commands/scaffolding.md
+++ b/SwiftScaffolding/commands/scaffolding.md
@@ -1,13 +1,12 @@
 ---
-allowed-tools: mcp__plugin_SwiftScaffolding_XcodeBuildMCP, AskUserQuestion
-description: Create an iOS or MacOS project scaffolginf using `XCodeBuildMCP` mcp
+allowed-tools: AskUserQuestion, mcp__plugin_SwiftScaffolding_XcodeBuildMCP
+description: Create an iOS or macOS project using XcodeBuildMCP
 ---
-Use the `AskUserQuestion` tool to ask the user:
-* If this is a MacOS project or an iOS project.
-* The name of the project.
-* The project bundle identifier.
+Ask the user for the project platform, project name, and bundle identifier.
+Use the host's native structured question mechanism if available; otherwise ask
+normally in chat.
 
-If it is an iOS project, use the `scaffold_ios_project` tool in `XCodeBuildMCP` mcp with these parameters:
+If it is an iOS project, use the `scaffold_ios_project` tool in XcodeBuildMCP with these parameters:
 
 projectName: <PROJECT_NAME>
 outputPath: current folder
@@ -15,9 +14,9 @@ bundleIdentifier: <BUNDLE_IDENTIFIER>
 displayName: <PROJECT_NAME>
 target device family: universal
 deploymentTarget: 18.0
-supported orientations: all for both iphone and ipad
+supported orientations: all for both iPhone and iPad
 
-If it is a MacOS project, use the `scaffold_macos_project` tool in `XCodeBuildMCP` mcp with these parameters:
+If it is a macOS project, use the `scaffold_macos_project` tool in XcodeBuildMCP with these parameters:
 
 projectName: <PROJECT_NAME>
 outputPath: current folder

--- a/SwiftScaffolding/info.json
+++ b/SwiftScaffolding/info.json
@@ -3,6 +3,10 @@
     "welcomeMessage": "You can scaffold Swift projects using the /SwiftScaffolding:scaffolding command.",
     "versions": [
         {
+            "version": "0.4.2",
+            "changes": "Kept Claude-specific AskUserQuestion access in command metadata while making the scaffolding prompt body portable across compatible agents."
+        },
+        {
             "version": "0.4.1",
             "changes": "Removed auto-update hook from SessionStart to prevent configuration issues"
         },

--- a/XcodeBuildTools/.claude-plugin/plugin.json
+++ b/XcodeBuildTools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "XcodeBuildTools",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Xcode development tools: build/test/run Swift packages, discover projects and schemes, build for simulator/device/macOS, run tests, manage device apps, capture simulator logs",
   "author": {
     "name": "Gustavo Ambrozio"

--- a/XcodeBuildTools/README.md
+++ b/XcodeBuildTools/README.md
@@ -29,21 +29,23 @@ brew install xcsift
 | `sim-log` | Capture logs from iOS Simulator apps |
 | `sparkle-integration` | Integrate Sparkle 2.x auto-update framework into macOS apps |
 
-## Xcode MCP Compatibility
+## Xcode MCP Integration
 
-Starting with v0.4.0, XcodeBuildTools automatically detects Xcode 26.3+'s native MCP server and delegates overlapping capabilities when available.
+Starting with v0.4.0, XcodeBuildTools automatically detects Xcode 26.3+'s native MCP server and includes routing guidance for when raw Xcode MCP tools are also available.
 
-### Tool Delegation
+XcodeBuildTools remains the primary routing surface for build, test, Swift package, and project-inspection workflows. Raw Xcode MCP tools are reserved for explicit user requests, MCP-only Xcode context such as live editor or project state, or gaps that are not covered by an XcodeBuildTools skill.
 
-| Domain | Xcode MCP Tool | XcodeBuildTools Fallback |
-|--------|---------------|------------------------|
-| Building | `BuildProject`, `GetBuildLog` | `xcodebuild` skill |
-| Testing | `RunAllTests`, `RunSomeTests`, `GetTestList` | `xcode-test` skill |
-| Project inspection | `XcodeGlob`, `XcodeLS`, `XcodeListWindows` | `xcode-project` skill |
-| SPM (Xcode open) | `BuildProject` | `swift-package` skill |
-| Documentation | `DocumentationSearch` | `sosumi` MCP server |
+### Tool Routing
 
-Skills with **no MCP equivalent** (always used directly): `device-app`, `sim-log`, `xcode-doctor`, `macos-app`, `sparkle-integration`.
+| Domain | Primary route | Raw Xcode MCP use |
+|--------|---------------|-------------------|
+| Building | `xcodebuild` skill | Only when explicitly requested or required by the skill |
+| Testing | `xcode-test` skill | Only when explicitly requested or required by the skill |
+| Project inspection | `xcode-project` skill | Use MCP for live Xcode/editor state that the skill cannot inspect |
+| SPM | `swift-package` skill | Only when explicitly requested or required by the skill |
+| Documentation | `sosumi` MCP server | `DocumentationSearch` is fine when available |
+
+Skills with **no MCP equivalent**: `device-app`, `sim-log`, `xcode-doctor`, `macos-app`, `sparkle-integration`.
 
 ### Auto-Approve Hook
 
@@ -60,6 +62,12 @@ The plugin includes an async hook that automatically clicks "Allow" on Xcode's M
 - **SwiftDevelopment** - swift-compile skill with xcsift integration
 
 ## Changelog
+
+### 0.5.9
+- Keep XcodeBuildTools skills as the primary routing surface even when raw Xcode MCP tools are visible
+- Clarify that raw Xcode MCP should be used for explicit user requests, MCP-only Xcode context, or gaps not covered by a skill
+- Remove skill and session-start wording that told agents to prefer raw Xcode MCP over the corresponding XcodeBuildTools skill
+- Clarify session-start routing across `xcodebuild`, `xcode-test`, and `swift-package`
 
 ### 0.5.8
 - Sandbox environment injection migrated from a per-Bash `PreToolUse` hook (`inject-session-id.py`) to the new `CLAUDE_ENV_FILE` mechanism. `PATH`, `SANDBOX_DERIVED_DATA`, and `SANDBOX_PACKAGES` are now written once at SessionStart by a new sync hook (`write-env.sh`) and persist across every subsequent Bash command — no more per-command prefix injection
@@ -108,10 +116,10 @@ The plugin includes an async hook that automatically clicks "Allow" on Xcode's M
 
 ### 0.4.0
 - Xcode MCP compatibility: auto-detects Xcode 26.3+ native MCP server at session start
-- Conditional tool delegation: prefers Xcode MCP tools for build, test, project inspection, and documentation when available
+- Conditional MCP routing guidance for build, test, project inspection, and documentation when raw Xcode MCP tools are available
 - Auto-approve hook: automatically clicks "Allow" on Xcode's MCP authorization dialog (async, PID-locked)
-- Future-proofing: generic fallback instruction for new Xcode MCP tools beyond the known set
-- MCP notes added to all 9 skills indicating delegation preference or uniqueness
+- Future-proofing: generic routing guidance for new Xcode MCP tools beyond the known set
+- MCP notes added to all 9 skills indicating routing or uniqueness
 
 ### 0.3.17
 - Improved sparkle-integration security: separate Debug/Release entitlements for `disable-library-validation`

--- a/XcodeBuildTools/README.md
+++ b/XcodeBuildTools/README.md
@@ -59,7 +59,7 @@ The plugin includes an async hook that automatically clicks "Allow" on Xcode's M
 ## Related Plugins
 
 - **iOSSimulator** - Simulator control, screenshots, video, status bar
-- **SwiftDevelopment** - swift-compile skill with xcsift integration
+- **SwiftScaffolding** - Swift project scaffolding through XcodeBuildMCP
 
 ## Changelog
 

--- a/XcodeBuildTools/README.md
+++ b/XcodeBuildTools/README.md
@@ -1,6 +1,6 @@
 # XcodeBuildTools
 
-Xcode development tools for Claude Code. Build/test tools use [xcsift](https://github.com/ldomaradzki/xcsift) for token-efficient JSON output.
+Xcode development tools for Claude Code-compatible agents. Build/test tools use [xcsift](https://github.com/ldomaradzki/xcsift) for token-efficient JSON output.
 
 ## Installation
 

--- a/XcodeBuildTools/README.md
+++ b/XcodeBuildTools/README.md
@@ -68,6 +68,8 @@ The plugin includes an async hook that automatically clicks "Allow" on Xcode's M
 - Clarify that raw Xcode MCP should be used for explicit user requests, MCP-only Xcode context, or gaps not covered by a skill
 - Remove skill and session-start wording that told agents to prefer raw Xcode MCP over the corresponding XcodeBuildTools skill
 - Clarify session-start routing across `xcodebuild`, `xcode-test`, and `swift-package`
+- Make guidance and script comments more agent-neutral for Claude Code-compatible hosts
+- Let Sparkle release notes generation fall back from the `claude` CLI to `codex exec` before using commit-list notes
 
 ### 0.5.8
 - Sandbox environment injection migrated from a per-Bash `PreToolUse` hook (`inject-session-id.py`) to the new `CLAUDE_ENV_FILE` mechanism. `PATH`, `SANDBOX_DERIVED_DATA`, and `SANDBOX_PACKAGES` are now written once at SessionStart by a new sync hook (`write-env.sh`) and persist across every subsequent Bash command — no more per-command prefix injection

--- a/XcodeBuildTools/bin/swift
+++ b/XcodeBuildTools/bin/swift
@@ -3,14 +3,14 @@
 # swift wrapper — Injects sandbox isolation for SPM subcommands
 #
 # Shadows /usr/bin/swift via the plugin's bin/ directory on PATH, so both
-# direct Claude invocations and nested calls from build scripts
+# direct agent invocations and nested calls from build scripts
 # (Makefiles, fastlane, shell scripts, etc.) are sandboxed transparently.
 #
 # Reads $SANDBOX_PACKAGES (exported by the PreToolUse inject-session-id.py
 # hook into every Bash command) and passes it as --cache-path to
 # subcommands that accept SwiftPM flags (build, test, run). Other
 # subcommands pass through unmodified. If $SANDBOX_PACKAGES is unset
-# (e.g. the wrapper was invoked from a shell outside a Claude Bash tool
+# (e.g. the wrapper was invoked from a shell outside a hosted Bash-tool
 # context), the wrapper falls through to an unsandboxed exec.
 #
 # On first build invocation, seeds the sandbox SPM cache from the system

--- a/XcodeBuildTools/bin/swift
+++ b/XcodeBuildTools/bin/swift
@@ -6,10 +6,10 @@
 # direct agent invocations and nested calls from build scripts
 # (Makefiles, fastlane, shell scripts, etc.) are sandboxed transparently.
 #
-# Reads $SANDBOX_PACKAGES (exported by the PreToolUse inject-session-id.py
-# hook into every Bash command) and passes it as --cache-path to
-# subcommands that accept SwiftPM flags (build, test, run). Other
-# subcommands pass through unmodified. If $SANDBOX_PACKAGES is unset
+# Reads $SANDBOX_PACKAGES (exported by hooks/write-env.sh through
+# $CLAUDE_ENV_FILE) and passes it as --cache-path to subcommands that
+# accept SwiftPM flags (build, test, run). Other subcommands pass through
+# unmodified. If $SANDBOX_PACKAGES is unset
 # (e.g. the wrapper was invoked from a shell outside a hosted Bash-tool
 # context), the wrapper falls through to an unsandboxed exec.
 #

--- a/XcodeBuildTools/bin/xcodebuild
+++ b/XcodeBuildTools/bin/xcodebuild
@@ -6,10 +6,10 @@
 # both direct agent invocations and nested calls from build scripts
 # (Makefiles, fastlane, shell scripts, etc.) are sandboxed transparently.
 #
-# Reads $SANDBOX_DERIVED_DATA and $SANDBOX_PACKAGES (exported by the
-# PreToolUse inject-session-id.py hook into every Bash command) and
-# passes them to /usr/bin/xcodebuild as -derivedDataPath and
-# -clonedSourcePackagesDirPath. If neither env var is set (e.g. the
+# Reads $SANDBOX_DERIVED_DATA and $SANDBOX_PACKAGES (exported by
+# hooks/write-env.sh through $CLAUDE_ENV_FILE) and passes them to
+# /usr/bin/xcodebuild as -derivedDataPath and -clonedSourcePackagesDirPath.
+# If neither env var is set (e.g. the
 # wrapper was invoked from a shell outside a hosted Bash-tool context),
 # the wrapper falls through to an unsandboxed exec.
 #

--- a/XcodeBuildTools/bin/xcodebuild
+++ b/XcodeBuildTools/bin/xcodebuild
@@ -3,14 +3,14 @@
 # xcodebuild wrapper — Injects sandbox isolation flags
 #
 # Shadows /usr/bin/xcodebuild via the plugin's bin/ directory on PATH, so
-# both direct Claude invocations and nested calls from build scripts
+# both direct agent invocations and nested calls from build scripts
 # (Makefiles, fastlane, shell scripts, etc.) are sandboxed transparently.
 #
 # Reads $SANDBOX_DERIVED_DATA and $SANDBOX_PACKAGES (exported by the
 # PreToolUse inject-session-id.py hook into every Bash command) and
 # passes them to /usr/bin/xcodebuild as -derivedDataPath and
 # -clonedSourcePackagesDirPath. If neither env var is set (e.g. the
-# wrapper was invoked from a shell outside a Claude Bash tool context),
+# wrapper was invoked from a shell outside a hosted Bash-tool context),
 # the wrapper falls through to an unsandboxed exec.
 #
 # On first invocation, seeds the sandbox SPM cache from the system cache

--- a/XcodeBuildTools/hooks/setup-sandbox.sh
+++ b/XcodeBuildTools/hooks/setup-sandbox.sh
@@ -9,13 +9,13 @@
 # are set on every Bash tool command by hooks/inject-session-id.py from
 # the hook payload's session_id (stable across contexts unlike $PPID).
 #
-# Each Claude Code session gets its own sandbox keyed by the session ID
+# Each agent session gets its own sandbox keyed by the session ID
 # from the SessionStart hook's stdin payload.
 #
 # The sandbox lives under $TMPDIR so it auto-cleans on reboot; macOS
 # also purges $TMPDIR entries untouched for 3+ days. The SessionEnd hook
 # (teardown-sandbox.py) handles explicit cleanup for logout/exit reasons
-# but is skipped for /clear — on /clear, Claude Code keeps running
+# but is skipped for /clear — on /clear, the host agent keeps running
 # (same $PPID) and just resets conversation state, so this script
 # inherits the prior session's sandbox rather than creating a fresh one.
 #
@@ -73,9 +73,9 @@ resolve_link() {
 }
 
 # --- Inherit prior session's sandbox on /clear (via symlink) ---
-# $PPID in a SessionStart hook is Claude itself (no intermediate shell
+# $PPID in a SessionStart hook is the host agent itself (no intermediate shell
 # — that was the Bash-tool context's problem, not ours). After /clear,
-# Claude is the same process, so any peer owned by our PPID belongs to
+# the host agent is the same process, so any peer owned by our PPID belongs to
 # us. Inherit it by creating $SANDBOX_BASE as a symlink to the anchor,
 # preserving embedded absolute paths. find_anchor is shared with
 # write-env.sh to keep both hooks agreeing on the same anchor.

--- a/XcodeBuildTools/hooks/setup-sandbox.sh
+++ b/XcodeBuildTools/hooks/setup-sandbox.sh
@@ -5,9 +5,9 @@
 # Creates per-session sandbox directories for DerivedData and SPM cache,
 # isolating CLI builds from Xcode's own storage. The wrapper scripts in
 # bin/ (xcodebuild, swift) read $SANDBOX_DERIVED_DATA and $SANDBOX_PACKAGES
-# at runtime and inject the appropriate isolation flags; those env vars
-# are set on every Bash tool command by hooks/inject-session-id.py from
-# the hook payload's session_id (stable across contexts unlike $PPID).
+# at runtime and inject the appropriate isolation flags. hooks/write-env.sh
+# writes those env vars to $CLAUDE_ENV_FILE during SessionStart so every
+# later Bash tool command inherits the same sandbox paths.
 #
 # Each agent session gets its own sandbox keyed by the session ID
 # from the SessionStart hook's stdin payload.

--- a/XcodeBuildTools/hooks/teardown-sandbox.py
+++ b/XcodeBuildTools/hooks/teardown-sandbox.py
@@ -14,10 +14,10 @@ across /clear — see setup-sandbox.sh). Handling differs:
   Using rm -rf on the symlink path directly is risky because of trailing-
   slash semantics and because we'd rather walk the references explicitly.
 
-Multi-GB DerivedData trees can take longer than Claude's SessionEnd hook
+Multi-GB DerivedData trees can take longer than the host's SessionEnd hook
 timeout. When the hook is killed mid-rm, the sandbox is left partially
 removed. To survive that, the anchor removal is spawned in a new session
-(setsid via Popen's start_new_session) so Claude's process-group SIGTERM
+(setsid via Popen's start_new_session) so the host's process-group SIGTERM
 can't reach it. setup-sandbox.sh's owner.pid sweep is the safety net for
 anything that still falls through (laptop sleep, hard crash, etc.).
 """

--- a/XcodeBuildTools/hooks/write-env.sh
+++ b/XcodeBuildTools/hooks/write-env.sh
@@ -12,7 +12,7 @@
 # does the slower dir-creation + peer sweep, keeps running async.
 #
 # Anchor detection: on /clear the prior session's sandbox dir is owned
-# by our $PPID (Claude is the same process). We scan SANDBOX_ROOT peers
+# by our $PPID (the host agent is the same process). We scan SANDBOX_ROOT peers
 # the same way setup-sandbox.sh does and, if we find one, embed the
 # anchor's real path into the env vars — SPM and Xcode persist absolute
 # paths into state files, so handing them the symlink path would break
@@ -40,7 +40,7 @@ fi
 SANDBOX_ROOT="${TMPDIR:-/tmp}/claude-sandbox"
 
 # --- Anchor detection ---
-# On /clear, Claude is the same process — any peer owned by $PPID is
+# On /clear, the host agent is the same process — any peer owned by $PPID is
 # the prior session's sandbox we want to inherit.
 anchor=$(find_anchor "$SANDBOX_ROOT" "$PPID")
 

--- a/XcodeBuildTools/info.json
+++ b/XcodeBuildTools/info.json
@@ -45,6 +45,10 @@
     ],
     "versions": [
         {
+            "version": "0.5.9",
+            "changes": "Keep XcodeBuildTools skills as the primary routing surface even when raw Xcode MCP tools are visible. Raw Xcode MCP should be used for explicit user requests, MCP-only Xcode context, or gaps not covered by a skill. Removes skill and session-start wording that told agents to prefer raw Xcode MCP over the corresponding XcodeBuildTools skill. Clarifies session-start routing across xcodebuild, xcode-test, and swift-package."
+        },
+        {
             "version": "0.5.8",
             "changes": "Sandbox env injection migrated from a per-Bash PreToolUse hook (`inject-session-id.py`, removed) to the new `CLAUDE_ENV_FILE` mechanism. PATH/SANDBOX_DERIVED_DATA/SANDBOX_PACKAGES are now written once at SessionStart by a new sync hook (`write-env.sh`) instead of being prefixed onto every Bash command. Anchor-discovery for `/clear` inheritance extracted into a shared `hooks/lib/sandbox.sh` helper so the sync `write-env.sh` and async `setup-sandbox.sh` agree on the same anchor and can't silently drift. `setup-sandbox.sh` switched from inline Python to `jq` for stdin JSON parsing. No user-visible behavior change."
         },
@@ -86,7 +90,7 @@
         },
         {
             "version": "0.4.0",
-            "changes": "Xcode MCP compatibility: auto-detects Xcode 26.3+ native MCP server and delegates overlapping tools (build, test, project inspection, docs). Adds auto-approve hook for MCP authorization dialog"
+            "changes": "Xcode MCP compatibility: auto-detects Xcode 26.3+ native MCP server and adds conditional routing guidance for overlapping tools (build, test, project inspection, docs). Adds auto-approve hook for MCP authorization dialog"
         },
         {
             "version": "0.3.17",

--- a/XcodeBuildTools/info.json
+++ b/XcodeBuildTools/info.json
@@ -46,7 +46,7 @@
     "versions": [
         {
             "version": "0.5.9",
-            "changes": "Keep XcodeBuildTools skills as the primary routing surface even when raw Xcode MCP tools are visible. Raw Xcode MCP should be used for explicit user requests, MCP-only Xcode context, or gaps not covered by a skill. Removes skill and session-start wording that told agents to prefer raw Xcode MCP over the corresponding XcodeBuildTools skill. Clarifies session-start routing across xcodebuild, xcode-test, and swift-package."
+            "changes": "Keep XcodeBuildTools skills as the primary routing surface even when raw Xcode MCP tools are visible. Raw Xcode MCP should be used for explicit user requests, MCP-only Xcode context, or gaps not covered by a skill. Removes skill and session-start wording that told agents to prefer raw Xcode MCP over the corresponding XcodeBuildTools skill. Clarifies session-start routing across xcodebuild, xcode-test, and swift-package. Makes guidance and script comments more agent-neutral for Claude Code-compatible hosts, and lets Sparkle release notes generation fall back from the claude CLI to codex exec before using commit-list notes."
         },
         {
             "version": "0.5.8",

--- a/XcodeBuildTools/session-start.md
+++ b/XcodeBuildTools/session-start.md
@@ -4,7 +4,7 @@ The `XcodeBuildTools` plugin provides specialized tools for Xcode build and test
 
 ## Building, Testing & Compilation
 
-**IMPORTANT**: Whenever you need to build or test an Xcode project/workspace, compile or test Swift packages, or anytime you would use `swift`/`xcodebuild` commands, **always** use the `xcodebuild` skill instead. This skill provides token-efficient, AI-friendly compilation output.
+**IMPORTANT**: Whenever you need to build or test an Xcode project/workspace, compile or test Swift packages, or anytime you would use `swift`/`xcodebuild` commands, **always** use the applicable XcodeBuildTools skill instead. Use `xcodebuild` for Xcode builds, `xcode-test` for Xcode tests, and `swift-package` for Swift package build/test/run workflows. These skills provide token-efficient, AI-friendly compilation output.
 
 ## Build Isolation
 
@@ -18,21 +18,27 @@ Two sandbox paths are also exported in every Bash invocation for scripts that ne
 - `$SANDBOX_PACKAGES` — cloned SPM packages / SwiftPM cache
 
 <!-- IF_XCODE_MCP -->
-## Xcode MCP Tool Delegation
+## Xcode MCP Integration
 
-The Xcode MCP server is available. **Before using an XcodeBuildTools skill, check if an equivalent Xcode MCP tool exists in your tool list.** Prefer Xcode MCP tools when available — they run inside Xcode's process and have richer project context.
+The Xcode MCP server is available, but XcodeBuildTools remains the primary routing surface for build, test, Swift package, and project-inspection workflows.
 
-### Delegation Rules
+Do not bypass an applicable XcodeBuildTools skill just because overlapping Xcode MCP tools are visible. Use raw Xcode MCP tools only when:
+- the user explicitly asks to use Xcode MCP,
+- no XcodeBuildTools skill covers the requested task,
+- the task needs MCP-only Xcode context, such as live editor or project state,
+- or the selected XcodeBuildTools skill explicitly instructs you to use MCP for that step.
 
-| Domain | Prefer (Xcode MCP) | Fallback (XcodeBuildTools skill) |
-|--------|--------------------|---------------------------------|
-| Building | `BuildProject`, `GetBuildLog` | `xcodebuild` skill |
-| Testing | `RunAllTests`, `RunSomeTests`, `GetTestList` | `xcode-test` skill |
-| Project inspection | `XcodeGlob`, `XcodeLS`, `XcodeListWindows` | `xcode-project` skill |
-| SPM (when project open in Xcode) | `BuildProject` | `swift-package` skill |
-| Documentation | `DocumentationSearch` | `sosumi` MCP server |
+### Routing Rules
 
-**How to delegate**: Before each build/test/inspection task, check your available tools. If the Xcode MCP tool is listed, use it. If not (e.g., MCP connection dropped), fall back to the corresponding XcodeBuildTools skill.
+| Domain | Primary route | Raw Xcode MCP use |
+|--------|---------------|-------------------|
+| Building | `xcodebuild` skill | Only when explicitly requested or required by the skill |
+| Testing | `xcode-test` skill | Only when explicitly requested or required by the skill |
+| Project inspection | `xcode-project` skill | Use MCP for live Xcode/editor state that the skill cannot inspect |
+| SPM | `swift-package` skill | Only when explicitly requested or required by the skill |
+| Documentation | `sosumi` MCP server | `DocumentationSearch` is fine when available |
+
+**How to route**: Start with the applicable XcodeBuildTools skill. Use raw Xcode MCP directly only for MCP-only work or explicit user requests.
 
 ### Always Use XcodeBuildTools (No MCP Equivalent)
 
@@ -45,7 +51,7 @@ These skills have no Xcode MCP equivalent — always use them directly:
 
 ### Future Xcode MCP Tools
 
-Beyond the specific tools listed above, if you discover additional Xcode MCP tools in your tool list that could handle a task more directly than an XcodeBuildTools skill, prefer the Xcode MCP tool. Xcode MCP tools follow naming patterns like `BuildProject`, `RunAllTests`, `Xcode*`, `Get*`, `DocumentationSearch`.
+New Xcode MCP tools do not automatically override XcodeBuildTools routing. Prefer the XcodeBuildTools skill unless the new MCP tool provides a capability the skill does not cover or the user explicitly asks for it.
 <!-- END_XCODE_MCP -->
 
 <!-- IF_NO_XCODE_MCP -->

--- a/XcodeBuildTools/session-start.md
+++ b/XcodeBuildTools/session-start.md
@@ -8,9 +8,9 @@ The `XcodeBuildTools` plugin provides specialized tools for Xcode build and test
 
 ## Build Isolation
 
-Each session gets an isolated build sandbox keyed by its Claude session ID. The plugin ships sandboxing wrappers for `xcodebuild` and `swift` in its `bin/` directory, which is on `PATH` ahead of `/usr/bin`. Any invocation — direct (`xcodebuild ...`, `swift build ...`) or nested inside a build script (Makefile, fastlane, shell script) — is sandboxed transparently.
+Each session gets an isolated build sandbox keyed by its agent session ID. The plugin ships sandboxing wrappers for `xcodebuild` and `swift` in its `bin/` directory, which is on `PATH` ahead of `/usr/bin`. Any invocation — direct (`xcodebuild ...`, `swift build ...`) or nested inside a build script (Makefile, fastlane, shell script) — is sandboxed transparently.
 
-The wrappers inject `-derivedDataPath`, `-clonedSourcePackagesDirPath`, and `--cache-path` flags so DerivedData and SPM caches stay isolated from Xcode and from other Claude sessions. No changes to commands are needed.
+The wrappers inject `-derivedDataPath`, `-clonedSourcePackagesDirPath`, and `--cache-path` flags so DerivedData and SPM caches stay isolated from Xcode and from other agent sessions. No changes to commands are needed.
 
 Two sandbox paths are also exported in every Bash invocation for scripts that need to reach into the sandbox without reconstructing the path formula:
 

--- a/XcodeBuildTools/skills/sparkle-integration/scripts/release.sh
+++ b/XcodeBuildTools/skills/sparkle-integration/scripts/release.sh
@@ -450,20 +450,11 @@ bump_version() {
 }
 
 # =====================================================
-# Generate release notes using Claude
+# Generate release notes using an available agent CLI
 # =====================================================
 generate_release_notes() {
     local version=$1
-    log_info "Generating release notes with Claude..." >&2
-
-    # Check if claude CLI is available
-    if ! command -v claude &> /dev/null; then
-        log_warning "Claude CLI not found, using generic release notes" >&2
-        echo "## What's New in $version
-
-- Bug fixes and improvements"
-        return
-    fi
+    log_info "Generating release notes with available agent CLI..." >&2
 
     # Get the previous tag
     local previous_tag
@@ -482,7 +473,6 @@ generate_release_notes() {
     local commits
     commits=$(git -C "$PROJECT_ROOT" log "$commit_range" --pretty=format:"- %s (%h)" 2>/dev/null || echo "Initial release")
 
-    # Use Claude to generate release notes
     local prompt="You are a technical writer creating release notes for a software product.
 
 Generate professional release notes for version $version of $APP_NAME.
@@ -503,12 +493,33 @@ Requirements:
 - Output ONLY the release notes content itself"
 
     local release_notes
-    release_notes=$(claude -p "$prompt" 2>/dev/null) || {
-        log_warning "Claude failed to generate release notes, using commit list instead" >&2
-        release_notes="## What's New in $version
+    if command -v claude &> /dev/null; then
+        if release_notes=$(claude -p "$prompt" 2>/dev/null); then
+            echo "$release_notes"
+            return
+        fi
+        log_warning "claude CLI failed to generate release notes, trying next available agent" >&2
+    fi
+
+    if command -v codex &> /dev/null; then
+        local notes_file
+        notes_file=$(mktemp)
+        if codex exec --sandbox read-only --cd "$PROJECT_ROOT" --output-last-message "$notes_file" "$prompt" >/dev/null 2>&1; then
+            release_notes=$(cat "$notes_file")
+            rm -f "$notes_file"
+            echo "$release_notes"
+            return
+        else
+            log_warning "Codex failed to generate release notes, using fallback" >&2
+        fi
+        rm -f "$notes_file"
+    elif ! command -v claude &> /dev/null; then
+        log_warning "No supported agent CLI found, using fallback" >&2
+    fi
+
+    release_notes="## What's New in $version
 
 $commits"
-    }
 
     echo "$release_notes"
 }
@@ -549,7 +560,7 @@ main() {
     local sparkle_signature
     sparkle_signature=$(sign_dmg_for_sparkle "$dmg_path")
 
-    # Generate release notes using Claude (falls back to generic if unavailable)
+    # Generate release notes using an available agent CLI (falls back if unavailable)
     local release_notes
     release_notes=$(generate_release_notes "$version")
 

--- a/XcodeBuildTools/skills/swift-package/SKILL.md
+++ b/XcodeBuildTools/skills/swift-package/SKILL.md
@@ -3,7 +3,7 @@ name: swift-package
 description: Build, test, run, and manage Swift Package Manager projects. Use when working with Package.swift projects, running "swift build", "swift test", or "swift run", managing package executables, or cleaning SPM build artifacts.
 ---
 
-> **Xcode MCP**: If the package is open in Xcode and `BuildProject` is in your tool list, prefer that over this skill.
+> **Tool routing**: Use this skill for Swift package build/test/run workflows even when raw Xcode MCP tools are available. Use raw Xcode MCP only when explicitly requested, when this skill instructs you to, or when MCP-only Xcode context is required.
 
 # Swift Package
 

--- a/XcodeBuildTools/skills/xcode-project/SKILL.md
+++ b/XcodeBuildTools/skills/xcode-project/SKILL.md
@@ -3,7 +3,7 @@ name: xcode-project
 description: Discover and inspect Xcode projects and workspaces. Use when finding .xcodeproj/.xcworkspace files, listing available schemes, viewing build settings, or extracting bundle identifiers from apps.
 ---
 
-> **Xcode MCP**: If `XcodeGlob` / `XcodeLS` / `XcodeListWindows` are in your tool list, prefer those over this skill.
+> **Tool routing**: Use this skill for normal project discovery and build-setting inspection. Use raw Xcode MCP directly for live Xcode/editor state that this skill cannot inspect, or when explicitly requested.
 
 # Xcode Project Discovery
 

--- a/XcodeBuildTools/skills/xcode-test/SKILL.md
+++ b/XcodeBuildTools/skills/xcode-test/SKILL.md
@@ -3,7 +3,7 @@ name: xcode-test
 description: Run Xcode unit tests and UI tests using xcodebuild with xcsift for token-efficient output. Use when running tests for iOS/macOS projects, filtering specific test cases, or checking test results.
 ---
 
-> **Xcode MCP**: If `RunAllTests` / `RunSomeTests` / `GetTestList` are in your tool list, prefer those over this skill.
+> **Tool routing**: Use this skill for Xcode test workflows even when raw Xcode MCP test tools are available. Use raw Xcode MCP only when explicitly requested, when this skill instructs you to, or when MCP-only Xcode context is required.
 
 # Xcode Test
 

--- a/XcodeBuildTools/skills/xcodebuild/SKILL.md
+++ b/XcodeBuildTools/skills/xcodebuild/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: xcodebuild
-description: Build Xcode projects for simulator, device, or macOS using `xcodebuild` with xcsift for token-efficient output. Use when compiling iOS/tvOS/watchOS apps, building macOS apps, cleaning build products or before you invoke any Bash command with `xcodebuild` or `swift`.
+description: Build Xcode projects for simulator, device, or macOS using `xcodebuild` with xcsift for token-efficient output. Use when compiling iOS/tvOS/watchOS apps, building macOS apps, cleaning Xcode build products, or before you invoke any Bash command with `xcodebuild`.
 ---
 
-> **Xcode MCP**: If `BuildProject` / `GetBuildLog` are in your tool list, prefer those over this skill.
+> **Tool routing**: Use this skill for Xcode build workflows even when raw Xcode MCP build tools are available. Use raw Xcode MCP only when explicitly requested, when this skill instructs you to, or when MCP-only Xcode context is required.
 
 # Xcodebuild
 

--- a/common/hooks.json
+++ b/common/hooks.json
@@ -5,10 +5,6 @@
         "hooks": [
           {
             "type": "command",
-            "command": "claude plugin marketplace update ClaudeCodePlugins > /dev/null 2>&1 || true"
-          },
-          {
-            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/common/session-start.py \"${CLAUDE_PLUGIN_ROOT}\""
           }
         ]

--- a/common/version_tracker.py
+++ b/common/version_tracker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Version tracking utilities for Claude Code plugins.
+Version tracking utilities for Claude Code-compatible plugins.
 
 Compares a project's last-seen version against a plugin's version history
 and returns changelog information for any new versions.

--- a/iOSSimulator/.claude-plugin/plugin.json
+++ b/iOSSimulator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iOSSimulator",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Control iOS Simulators using native macOS tools - manage simulators, automate UI interactions, take screenshots, and more",
   "author": {
     "name": "Gustavo Ambrozio"

--- a/iOSSimulator/README.md
+++ b/iOSSimulator/README.md
@@ -31,19 +31,19 @@ Control iOS Simulators using native macOS tools. No additional dependencies requ
 
 ```bash
 # List available simulators
-python3 scripts/sim-list.py
+python3 skills/ios-simulator/scripts/sim-list.py
 
 # Boot iPhone 15 simulator
-python3 scripts/sim-boot.py --name "iPhone 15"
+python3 skills/ios-simulator/scripts/sim-boot.py --name "iPhone 15"
 
 # Take a screenshot
-python3 scripts/sim-screenshot.py --output /tmp/screen.png
+python3 skills/ios-simulator/scripts/sim-screenshot.py --output /tmp/screen.png
 
 # Tap at coordinates
-python3 scripts/sim-tap.py --x 200 --y 400
+python3 skills/ios-simulator/scripts/sim-tap.py --x 200 --y 400
 
 # Type text
-python3 scripts/sim-type.py --text "Hello!"
+python3 skills/ios-simulator/scripts/sim-type.py --text "Hello!"
 ```
 
 ## Available Scripts

--- a/iOSSimulator/README.md
+++ b/iOSSimulator/README.md
@@ -91,11 +91,11 @@ No additional dependencies like `idb` are required.
 
 ## Screenshot-Based UI Automation
 
-Claude can view screenshots! The recommended workflow:
+Agents with image input can view screenshots. The recommended workflow:
 
 1. Take a screenshot with `sim-screenshot.py`
-2. Claude views the image to understand the UI
-3. Claude identifies element positions visually
+2. View the image to understand the UI
+3. Identify element positions visually
 4. Use `sim-tap.py` to interact at those coordinates
 5. Repeat for complex workflows
 

--- a/iOSSimulator/README.md
+++ b/iOSSimulator/README.md
@@ -101,6 +101,9 @@ Agents with image input can view screenshots. The recommended workflow:
 
 ## Changelog
 
+### 0.6.4
+- Made screenshot workflow guidance agent-neutral so agents with image support can follow the simulator automation flow
+
 ### 0.6.3
 - Removed auto-update hook from SessionStart to prevent configuration issues
 

--- a/iOSSimulator/info.json
+++ b/iOSSimulator/info.json
@@ -13,6 +13,10 @@
     ],
     "versions": [
         {
+            "version": "0.6.4",
+            "changes": "Made screenshot workflow guidance agent-neutral so agents with image support can follow the simulator automation flow."
+        },
+        {
             "version": "0.6.3",
             "changes": "Removed auto-update hook from SessionStart to prevent configuration issues"
         },

--- a/iOSSimulator/skills/ios-simulator/SKILL.md
+++ b/iOSSimulator/skills/ios-simulator/SKILL.md
@@ -30,7 +30,7 @@ scripts/sim-list.py
 # 2. Boot a simulator
 scripts/sim-boot.py --name "iPhone 15"
 
-# 3. Take a screenshot (view with Read tool to see UI)
+# 3. Take a screenshot, then view the image to inspect the UI
 scripts/sim-screenshot.py --output /tmp/screen.png
 
 # 4. Tap at coordinates identified from the screenshot
@@ -90,7 +90,7 @@ All scripts are in `scripts/` and output JSON. For detailed usage with all optio
 | `sim-screenshot.py` | Capture screen | `--output /tmp/screen.png` |
 | `sim-record-video.py` | Record video | `--output /tmp/demo.mp4 --duration 30` |
 
-After taking a screenshot, use the Read tool to view the image and identify coordinates.
+After taking a screenshot, view the image with the current agent's image support and identify coordinates.
 
 ### UI Inspection
 

--- a/iOSSimulator/skills/ios-simulator/references/script-details.md
+++ b/iOSSimulator/skills/ios-simulator/references/script-details.md
@@ -173,7 +173,7 @@ scripts/sim-screenshot.py --output /tmp/screenshot.png
 scripts/sim-screenshot.py
 ```
 
-**Important:** After taking a screenshot, use the Read tool to view the image. This allows seeing the current UI state and identifying coordinates for tap/swipe actions.
+**Important:** After taking a screenshot, view the image with the current agent's image support. This allows seeing the current UI state and identifying coordinates for tap/swipe actions.
 
 ### sim-record-video.py
 Record video from the simulator screen.

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,250 @@
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+COMMON_DIR = REPO_ROOT / "common"
+SESSION_START_PATH = COMMON_DIR / "session-start.py"
+PRE_TOOL_USE_PATH = COMMON_DIR / "pre-tool-use.py"
+DEFAULT_PLUGIN_ROOT = REPO_ROOT / "XcodeBuildTools"
+PLUGIN_ROOT_ENV = "XCODEBUILDTOOLS_TEST_PLUGIN_ROOT"
+
+
+def load_session_start_module():
+    if str(COMMON_DIR) not in sys.path:
+        sys.path.insert(0, str(COMMON_DIR))
+
+    spec = importlib.util.spec_from_file_location(
+        "session_start_under_test",
+        SESSION_START_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class SessionStartTests(unittest.TestCase):
+    def render_session_start(self, xcode_mcp_likely=False, plugin_root=None):
+        module = load_session_start_module()
+        fake_detector = types.ModuleType("detect_xcode_mcp")
+        fake_detector.detect_xcode_mcp = lambda: {
+            "xcode_mcp_likely": xcode_mcp_likely,
+        }
+
+        plugin_root = (
+            plugin_root
+            or os.environ.get(PLUGIN_ROOT_ENV)
+            or str(DEFAULT_PLUGIN_ROOT)
+        )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with tempfile.TemporaryDirectory() as data_dir:
+            with patch.dict(
+                os.environ,
+                {
+                    "CLAUDE_PLUGIN_ROOT": plugin_root,
+                    "CLAUDE_PLUGIN_DATA": data_dir,
+                },
+                clear=False,
+            ):
+                with patch.dict(sys.modules, {"detect_xcode_mcp": fake_detector}):
+                    with contextlib.redirect_stdout(stdout):
+                        with contextlib.redirect_stderr(stderr):
+                            with self.assertRaises(SystemExit) as exit_context:
+                                module.main()
+
+        self.assertEqual(exit_context.exception.code, 0, stderr.getvalue())
+        return json.loads(stdout.getvalue())
+
+    def test_mcp_available_context_keeps_xcodebuildtools_as_primary_route(self):
+        payload = self.render_session_start(xcode_mcp_likely=True)
+
+        self.assertIn("Xcode MCP server detected.", payload["systemMessage"])
+        context = payload["hookSpecificOutput"]["additionalContext"]
+        self.assertIn(
+            "XcodeBuildTools remains the primary routing surface",
+            context,
+        )
+        self.assertIn(
+            "Do not bypass an applicable XcodeBuildTools skill",
+            context,
+        )
+        self.assertIn("Use raw Xcode MCP tools only when:", context)
+        self.assertNotIn("Before using an XcodeBuildTools skill", context)
+        self.assertNotIn("Prefer Xcode MCP tools when available", context)
+        self.assertNotIn("How to delegate", context)
+        self.assertNotIn(
+            "The `sosumi` MCP server provides quick access",
+            context,
+        )
+
+    def test_mcp_unavailable_context_omits_mcp_routing_block(self):
+        payload = self.render_session_start(xcode_mcp_likely=False)
+
+        self.assertNotIn("Xcode MCP server detected.", payload["systemMessage"])
+        context = payload["hookSpecificOutput"]["additionalContext"]
+        self.assertIn(
+            "The `sosumi` MCP server provides quick access",
+            context,
+        )
+        self.assertNotIn(
+            "XcodeBuildTools remains the primary routing surface",
+            context,
+        )
+
+    def test_marvin_output_style_emits_personality_context_and_welcome(self):
+        payload = self.render_session_start(
+            plugin_root=str(REPO_ROOT / "MarvinOutputStyle"),
+        )
+
+        self.assertIn(
+            "The MarvinOutputStyle plugin is loaded and ready.",
+            payload["systemMessage"],
+        )
+        self.assertIn("Prepare for pessimism", payload["systemMessage"])
+        context = payload["hookSpecificOutput"]["additionalContext"]
+        self.assertIn("Marvin the Paranoid Android Personality", context)
+        self.assertIn("Core Characteristics", context)
+
+    def test_swift_scaffolding_emits_welcome_without_extra_context(self):
+        payload = self.render_session_start(
+            plugin_root=str(REPO_ROOT / "SwiftScaffolding"),
+        )
+
+        self.assertIn(
+            "The SwiftScaffolding plugin is loaded and ready.",
+            payload["systemMessage"],
+        )
+        self.assertIn(
+            "You can scaffold Swift projects",
+            payload["systemMessage"],
+        )
+        self.assertEqual(
+            payload["hookSpecificOutput"]["additionalContext"],
+            "",
+        )
+
+    def test_ios_simulator_loads_without_extra_context(self):
+        payload = self.render_session_start(
+            plugin_root=str(REPO_ROOT / "iOSSimulator"),
+        )
+
+        self.assertEqual(
+            payload["systemMessage"],
+            "The iOSSimulator plugin is loaded and ready.",
+        )
+        self.assertEqual(
+            payload["hookSpecificOutput"]["additionalContext"],
+            "",
+        )
+
+    def test_plugin_base_emits_template_context(self):
+        payload = self.render_session_start(
+            plugin_root=str(REPO_ROOT / "PluginBase"),
+        )
+
+        self.assertEqual(
+            payload["systemMessage"],
+            "The PluginBase plugin is loaded and ready.",
+        )
+        self.assertIn(
+            "Customize if needed.",
+            payload["hookSpecificOutput"]["additionalContext"],
+        )
+
+
+class PreToolUseTests(unittest.TestCase):
+    def run_hook(self, plugin_name, payload, tmpdir):
+        env = {
+            "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT / plugin_name),
+            "TMPDIR": str(tmpdir),
+        }
+        result = subprocess.run(
+            [sys.executable, str(PRE_TOOL_USE_PATH)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return result.stdout.strip()
+
+    def test_xcodebuild_rule_denies_once_then_allows_same_session(self):
+        payload = {
+            "session_id": "session-1",
+            "tool_name": "Bash",
+            "tool_input": {"command": "xcodebuild -scheme App build"},
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            first = self.run_hook("XcodeBuildTools", payload, tmpdir)
+            second = self.run_hook("XcodeBuildTools", payload, tmpdir)
+
+        decision = json.loads(first)["hookSpecificOutput"]
+        self.assertEqual(decision["permissionDecision"], "deny")
+        self.assertIn("xcodebuild", decision["permissionDecisionReason"])
+        self.assertIn("skill", decision["permissionDecisionReason"])
+        self.assertEqual(second, "")
+
+    def test_xcodebuild_rule_allows_xcsift_wrapped_command(self):
+        payload = {
+            "session_id": "session-1",
+            "tool_name": "Bash",
+            "tool_input": {"command": "xcodebuild -scheme App build | xcsift"},
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = self.run_hook("XcodeBuildTools", payload, tmpdir)
+
+        decision = json.loads(output)["hookSpecificOutput"]
+        self.assertEqual(decision["permissionDecision"], "allow")
+
+    def test_ios_simulator_rule_allows_device_listing_but_denies_other_simctl(self):
+        list_payload = {
+            "session_id": "session-1",
+            "tool_name": "Bash",
+            "tool_input": {"command": "xcrun simctl list devices available"},
+        }
+        boot_payload = {
+            "session_id": "session-1",
+            "tool_name": "Bash",
+            "tool_input": {"command": "xcrun simctl boot ABCD-1234"},
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            list_output = self.run_hook("iOSSimulator", list_payload, tmpdir)
+            boot_output = self.run_hook("iOSSimulator", boot_payload, tmpdir)
+
+        self.assertEqual(list_output, "")
+        decision = json.loads(boot_output)["hookSpecificOutput"]
+        self.assertEqual(decision["permissionDecision"], "deny")
+        self.assertIn("ios-simulator skill", decision["permissionDecisionReason"])
+
+    def test_plugin_skill_invocations_are_allowed(self):
+        payload = {
+            "session_id": "session-1",
+            "tool_name": "Skill",
+            "tool_input": {"skill": "XcodeBuildTools:xcodebuild"},
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = self.run_hook("XcodeBuildTools", payload, tmpdir)
+
+        decision = json.loads(output)["hookSpecificOutput"]
+        self.assertEqual(decision["permissionDecision"], "allow")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repository_integrity.py
+++ b/tests/test_repository_integrity.py
@@ -97,8 +97,11 @@ class RepositoryIntegrityTests(unittest.TestCase):
                 self.assertRegex(frontmatter, r"(?m)^description: .+")
 
     def test_hook_commands_reference_existing_plugin_files(self):
-        for hooks_path in REPO_ROOT.glob("*/hooks/hooks.json"):
-            plugin_dir = hooks_path.parent.parent
+        hooks_paths = list(REPO_ROOT.glob("*/hooks/hooks.json"))
+        hooks_paths.append(REPO_ROOT / "common" / "hooks.json")
+
+        for hooks_path in hooks_paths:
+            plugin_dir = REPO_ROOT if hooks_path.parent.name == "common" else hooks_path.parent.parent
             hooks_config = load_json(hooks_path)
             commands = self.hook_commands(hooks_config)
 
@@ -175,6 +178,47 @@ class RepositoryIntegrityTests(unittest.TestCase):
             with self.subTest(script=str(script_path.relative_to(REPO_ROOT))):
                 self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_agent_facing_docs_avoid_known_stale_terms(self):
+        checks = {
+            "CLAUDE.md": ["SwiftDevelopment", "lastUpdated"],
+            ".claude/commands/update-plugin.md": ["SwiftDevelopment"],
+            "SwiftScaffolding/commands/scaffolding.md": [
+                "MacOS",
+                "XCodeBuildMCP",
+                "scaffolginf",
+            ],
+            "iOSSimulator/README.md": [
+                "Claude can",
+                "Claude views",
+                "Claude identifies",
+            ],
+            "MarvinOutputStyle/README.md": [
+                "Claude will",
+                "Claude's communication",
+                "Ask Claude Code",
+            ],
+            "iOSSimulator/skills/ios-simulator/SKILL.md": ["Read tool"],
+            "iOSSimulator/skills/ios-simulator/references/script-details.md": ["Read tool"],
+            "XcodeBuildTools/session-start.md": ["Claude session", "Claude sessions"],
+            "XcodeBuildTools/bin/xcodebuild": ["Claude invocations", "Claude Bash"],
+            "XcodeBuildTools/bin/swift": ["Claude invocations", "Claude Bash"],
+        }
+
+        for relative_path, stale_terms in checks.items():
+            text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+            for stale_term in stale_terms:
+                with self.subTest(file=relative_path, stale_term=stale_term):
+                    self.assertNotIn(stale_term, text)
+
+    def test_claude_specific_question_tool_stays_in_metadata(self):
+        command_path = REPO_ROOT / "SwiftScaffolding" / "commands" / "scaffolding.md"
+        text = command_path.read_text(encoding="utf-8")
+        frontmatter, body = self.split_frontmatter(text)
+
+        self.assertIn("AskUserQuestion", frontmatter)
+        self.assertNotIn("AskUserQuestion", body)
+        self.assertIn("host's native structured question mechanism", body)
+
     def hook_commands(self, value):
         commands = []
         if isinstance(value, dict):
@@ -187,6 +231,11 @@ class RepositoryIntegrityTests(unittest.TestCase):
             for child in value:
                 commands.extend(self.hook_commands(child))
         return commands
+
+    def split_frontmatter(self, text):
+        match = re.match(r"---\n(?P<frontmatter>.*?)\n---\n(?P<body>.*)", text, re.DOTALL)
+        self.assertIsNotNone(match)
+        return match.group("frontmatter"), match.group("body")
 
 
 if __name__ == "__main__":

--- a/tests/test_repository_integrity.py
+++ b/tests/test_repository_integrity.py
@@ -67,6 +67,18 @@ class RepositoryIntegrityTests(unittest.TestCase):
                     [entry.get("version") for entry in versions],
                 )
 
+    def test_plugin_readmes_track_current_manifest_version(self):
+        for plugin_dir in plugin_dirs():
+            readme_path = plugin_dir / "README.md"
+            if not readme_path.exists():
+                continue
+
+            manifest = load_json(plugin_dir / ".claude-plugin" / "plugin.json")
+            readme = readme_path.read_text(encoding="utf-8")
+
+            with self.subTest(plugin=plugin_dir.name):
+                self.assertIn(f"### {manifest['version']}", readme)
+
     def test_info_skill_list_matches_skill_directories(self):
         for plugin_dir in plugin_dirs():
             info_path = plugin_dir / "info.json"

--- a/tests/test_repository_integrity.py
+++ b/tests/test_repository_integrity.py
@@ -1,0 +1,193 @@
+import json
+import py_compile
+import re
+import shlex
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_json(path):
+    with path.open(encoding="utf-8") as file:
+        return json.load(file)
+
+
+def plugin_dirs():
+    return sorted(
+        path.parent.parent
+        for path in REPO_ROOT.glob("*/.claude-plugin/plugin.json")
+    )
+
+
+class RepositoryIntegrityTests(unittest.TestCase):
+    def test_marketplace_entries_match_local_plugin_manifests(self):
+        marketplace = load_json(REPO_ROOT / ".claude-plugin" / "marketplace.json")
+
+        for entry in marketplace["plugins"]:
+            source = entry.get("source")
+            if not isinstance(source, str) or not source.startswith("./"):
+                continue
+
+            plugin_dir = REPO_ROOT / source.removeprefix("./")
+            manifest = load_json(plugin_dir / ".claude-plugin" / "plugin.json")
+
+            with self.subTest(plugin=entry["name"]):
+                self.assertEqual(entry["name"], plugin_dir.name)
+                self.assertEqual(manifest["name"], plugin_dir.name)
+                self.assertEqual(entry["version"], manifest["version"])
+                self.assertIsInstance(entry.get("description"), str)
+                self.assertTrue(entry["description"])
+                self.assertIsInstance(manifest.get("description"), str)
+                self.assertTrue(manifest["description"])
+                self.assertIsInstance(entry.get("author"), dict)
+                self.assertIsInstance(manifest.get("author"), dict)
+                self.assertIn("name", entry["author"])
+                self.assertIn("name", manifest["author"])
+                self.assertNotIn("displayName", entry)
+                self.assertNotIn("claudeCode", manifest)
+
+    def test_plugin_info_tracks_current_manifest_version(self):
+        for plugin_dir in plugin_dirs():
+            info_path = plugin_dir / "info.json"
+            if not info_path.exists():
+                continue
+
+            manifest = load_json(plugin_dir / ".claude-plugin" / "plugin.json")
+            info = load_json(info_path)
+            versions = info.get("versions", [])
+
+            with self.subTest(plugin=plugin_dir.name):
+                self.assertTrue(versions, "info.json should include version history")
+                self.assertIn(
+                    manifest["version"],
+                    [entry.get("version") for entry in versions],
+                )
+
+    def test_info_skill_list_matches_skill_directories(self):
+        for plugin_dir in plugin_dirs():
+            info_path = plugin_dir / "info.json"
+            if not info_path.exists():
+                continue
+
+            info = load_json(info_path)
+            listed_skills = sorted(info.get("skills", []))
+            skills_dir = plugin_dir / "skills"
+            discovered_skills = sorted(
+                path.name
+                for path in skills_dir.iterdir()
+                if path.is_dir() and (path / "SKILL.md").exists()
+            ) if skills_dir.exists() else []
+
+            with self.subTest(plugin=plugin_dir.name):
+                self.assertEqual(listed_skills, discovered_skills)
+
+    def test_skill_frontmatter_names_match_directory_names(self):
+        for skill_path in REPO_ROOT.glob("*/skills/*/SKILL.md"):
+            text = skill_path.read_text(encoding="utf-8")
+            match = re.match(r"---\n(?P<frontmatter>.*?)\n---", text, re.DOTALL)
+
+            with self.subTest(skill=str(skill_path.relative_to(REPO_ROOT))):
+                self.assertIsNotNone(match, "SKILL.md should start with frontmatter")
+                frontmatter = match.group("frontmatter")
+                self.assertIn(f"name: {skill_path.parent.name}", frontmatter)
+                self.assertRegex(frontmatter, r"(?m)^description: .+")
+
+    def test_hook_commands_reference_existing_plugin_files(self):
+        for hooks_path in REPO_ROOT.glob("*/hooks/hooks.json"):
+            plugin_dir = hooks_path.parent.parent
+            hooks_config = load_json(hooks_path)
+            commands = self.hook_commands(hooks_config)
+
+            for command in commands:
+                if not command.startswith("${CLAUDE_PLUGIN_ROOT}/"):
+                    continue
+
+                rendered = command.replace("${CLAUDE_PLUGIN_ROOT}", str(plugin_dir))
+                executable = Path(shlex.split(rendered)[0])
+
+                with self.subTest(hook=str(hooks_path.relative_to(REPO_ROOT)), command=command):
+                    self.assertTrue(executable.exists(), f"{executable} does not exist")
+
+    def test_mcp_configs_define_servers(self):
+        for mcp_path in REPO_ROOT.glob("*/.mcp.json"):
+            config = load_json(mcp_path)
+            servers = config.get("mcpServers", {})
+
+            with self.subTest(config=str(mcp_path.relative_to(REPO_ROOT))):
+                self.assertIsInstance(servers, dict)
+                self.assertTrue(servers)
+
+            for name, server in servers.items():
+                with self.subTest(config=str(mcp_path.relative_to(REPO_ROOT)), server=name):
+                    self.assertTrue(
+                        "command" in server or ("type" in server and "url" in server),
+                        "MCP server should define either a command or an HTTP type/url",
+                    )
+
+    def test_python_scripts_compile(self):
+        for script_path in REPO_ROOT.glob("**/*.py"):
+            if "__pycache__" in script_path.parts:
+                continue
+
+            with self.subTest(script=str(script_path.relative_to(REPO_ROOT))):
+                py_compile.compile(str(script_path), doraise=True)
+
+    def test_argparse_scripts_expose_help_without_runtime_dependencies(self):
+        script_paths = sorted(REPO_ROOT.glob("*/skills/*/scripts/*.py"))
+
+        for script_path in script_paths:
+            text = script_path.read_text(encoding="utf-8")
+            if "ArgumentParser" not in text:
+                continue
+
+            result = subprocess.run(
+                [sys.executable, str(script_path), "--help"],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            with self.subTest(script=str(script_path.relative_to(REPO_ROOT))):
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("usage:", result.stdout.lower())
+
+    def test_shell_scripts_parse_with_bash(self):
+        script_paths = sorted(REPO_ROOT.glob("XcodeBuildTools/**/*.sh"))
+        script_paths.extend(sorted((REPO_ROOT / "XcodeBuildTools" / "bin").glob("*")))
+
+        for script_path in script_paths:
+            if not script_path.is_file():
+                continue
+
+            result = subprocess.run(
+                ["bash", "-n", str(script_path)],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            with self.subTest(script=str(script_path.relative_to(REPO_ROOT))):
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    def hook_commands(self, value):
+        commands = []
+        if isinstance(value, dict):
+            command = value.get("command")
+            if isinstance(command, str):
+                commands.append(command)
+            for child in value.values():
+                commands.extend(self.hook_commands(child))
+        elif isinstance(value, list):
+            for child in value:
+                commands.extend(self.hook_commands(child))
+        return commands
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repository_integrity.py
+++ b/tests/test_repository_integrity.py
@@ -212,8 +212,17 @@ class RepositoryIntegrityTests(unittest.TestCase):
             "iOSSimulator/skills/ios-simulator/SKILL.md": ["Read tool"],
             "iOSSimulator/skills/ios-simulator/references/script-details.md": ["Read tool"],
             "XcodeBuildTools/session-start.md": ["Claude session", "Claude sessions"],
-            "XcodeBuildTools/bin/xcodebuild": ["Claude invocations", "Claude Bash"],
-            "XcodeBuildTools/bin/swift": ["Claude invocations", "Claude Bash"],
+            "XcodeBuildTools/hooks/setup-sandbox.sh": ["inject-session-id.py"],
+            "XcodeBuildTools/bin/xcodebuild": [
+                "Claude invocations",
+                "Claude Bash",
+                "inject-session-id.py",
+            ],
+            "XcodeBuildTools/bin/swift": [
+                "Claude invocations",
+                "Claude Bash",
+                "inject-session-id.py",
+            ],
         }
 
         for relative_path, stale_terms in checks.items():


### PR DESCRIPTION
## Summary
- Keep XcodeBuildTools skills as the primary route for build, test, Swift package, and project inspection while reserving raw Xcode MCP for explicit requests, MCP-only context, or uncovered gaps.
- Add CI-backed repository tests for hook behavior, manifest/catalog integrity, README version tracking, script parsing, and stale agent-specific wording.
- Make active plugin guidance more agent-neutral across README, CLAUDE/AGENTS guidance, iOSSimulator, MarvinOutputStyle, SwiftScaffolding, common helpers, and XcodeBuildTools session/script text.
- Keep Claude-specific tooling where it belongs, such as `AskUserQuestion` in Claude command metadata, while making command bodies portable for compatible hosts.
- Update affected plugin versions and changelogs: XcodeBuildTools `0.5.9`, iOSSimulator `0.6.4`, MarvinOutputStyle `1.3.2`, SwiftScaffolding `0.4.2`, and PluginBase `0.2.11`.

## Release Follow-up
After this lands on `main`, create and push release tags for each bumped plugin version:
- `XcodeBuildTools--v0.5.9`
- `iOSSimulator--v0.6.4`
- `MarvinOutputStyle--v1.3.2`
- `SwiftScaffolding--v0.4.2`
- `PluginBase--v0.2.11`