### PR TITLE
Add OpenCode plugin support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "MarvinOutputStyle",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "description": "Adds Marvin the Paranoid Android personality - pessimistic and melancholic but brilliantly competent (mimics the deprecated Marvin output style)",
       "source": "./MarvinOutputStyle",
       "author": {
@@ -37,7 +37,7 @@
     },
     {
       "name": "iOSSimulator",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "description": "Control iOS Simulators using native macOS tools - manage simulators, automate UI interactions, take screenshots, and more",
       "source": "./iOSSimulator",
       "author": {
@@ -56,7 +56,7 @@
     },
     {
       "name": "SwiftScaffolding",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "description": "Swift project scaffolding and code generation tools",
       "source": "./SwiftScaffolding",
       "author": {
@@ -73,7 +73,7 @@
     },
     {
       "name": "XcodeBuildTools",
-      "version": "0.5.10",
+      "version": "0.5.11",
       "description": "Xcode development tools with optional Xcode MCP integration: build/test/run Swift packages, discover projects and schemes, build for simulator/device/macOS, run tests, manage device apps, capture simulator logs, Sparkle auto-update integration",
       "source": "./XcodeBuildTools",
       "author": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,16 @@ Users add the marketplace, then install plugins from it:
    - `agents/` - Custom agents (`.md` files)
    - `hooks/` - Lifecycle hooks and related scripts
    - `.mcp.json` - MCP server configurations
-   - `opencode-plugin.js` - OpenCode entry point that imports `./common/opencode-plugin.js`
+5. Create `YourPlugin/opencode-plugin.js` with an ID that exactly matches the plugin folder:
+   ```js
+   import { createOpenCodePlugin } from "./common/opencode-plugin.js";
+
+   export default {
+     id: "YourPlugin",
+     server: createOpenCodePlugin(new URL(".", import.meta.url)),
+   };
+   ```
+6. Run `python3 scripts/sync-plugin-common.py` to generate the plugin's self-contained `common/` helpers, including `common/opencode-plugin.js`.
 
 ### Updating Plugins
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a **Claude Code-compatible plugin marketplace** repository. It contains a marketplace catalog and individual plugin packages that extend agent capabilities in Claude Code and compatible hosts.
 
-Codex and other agents may also consume this repository's skills and prompts via
+OpenCode, Codex, and other agents may also consume this repository's skills and prompts via
 compatible plugin support. Keep agent-facing instructions neutral where possible;
 use Claude-specific names only for plugin format contracts, installation
 commands, environment variables, or historical changelog entries.
@@ -24,6 +24,7 @@ The repository has a two-level architecture:
 2. **Plugin Level** (subdirectories):
    - Each plugin subdirectory is a self-contained Claude Code-compatible plugin package
    - Contains its own `.claude-plugin/plugin.json` manifest
+   - Contains an `opencode-plugin.js` entry point for OpenCode local plugin installs
    - May include: skills (`skills/`), agents (`agents/`), hooks (`hooks/`), and MCP servers (`.mcp.json`)
 
 ### Key Schema Requirements
@@ -85,6 +86,7 @@ Users add the marketplace, then install plugins from it:
    - `agents/` - Custom agents (`.md` files)
    - `hooks/` - Lifecycle hooks and related scripts
    - `.mcp.json` - MCP server configurations
+   - `opencode-plugin.js` - OpenCode entry point that imports `./common/opencode-plugin.js`
 
 ### Updating Plugins
 
@@ -113,6 +115,8 @@ The `update-plugin` skill automates these steps end-to-end.
 
 Test the marketplace and plugins locally before pushing:
 
+Claude Code:
+
 ```bash
 # Add local marketplace
 /plugin marketplace add /path/to/ClaudeCodePlugins
@@ -123,6 +127,19 @@ Test the marketplace and plugins locally before pushing:
 # Verify installation
 /plugin list
 ```
+
+OpenCode:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    "/path/to/ClaudeCodePlugins/XcodeBuildTools/opencode-plugin.js"
+  ]
+}
+```
+
+Restart OpenCode after changing config.
 
 ## Plugin Component Guidelines
 

--- a/MarvinOutputStyle/.claude-plugin/plugin.json
+++ b/MarvinOutputStyle/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "MarvinOutputStyle",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Adds Marvin the Paranoid Android personality - pessimistic and melancholic but brilliantly competent (mimics the deprecated Marvin output style)",
   "author": {
     "name": "Gustavo Ambrozio"

--- a/MarvinOutputStyle/README.md
+++ b/MarvinOutputStyle/README.md
@@ -46,6 +46,8 @@ Assuming you still want to proceed with this questionable venture..."
 
 ## Installation
 
+Claude Code:
+
 ```bash
 # Add the marketplace (if you haven't already)
 /plugin marketplace add gpambrozio/ClaudeCodePlugins
@@ -53,6 +55,19 @@ Assuming you still want to proceed with this questionable venture..."
 # Install the Marvin plugin
 /plugin install MarvinOutputStyle@ClaudeCodePlugins
 ```
+
+OpenCode:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    "/path/to/ClaudeCodePlugins/MarvinOutputStyle/opencode-plugin.js"
+  ]
+}
+```
+
+Restart OpenCode after changing config. The OpenCode entry point injects the Marvin session context through OpenCode's system prompt transform hook.
 
 ## Important Considerations
 
@@ -107,6 +122,10 @@ Marvin represents a different approach to AI assistance - one that questions ass
 - Adding some personality to long coding sessions
 
 ## Changelog
+
+### 1.3.4
+- Added `opencode-plugin.js` for OpenCode users
+- The OpenCode entry point injects the Marvin session-start context through OpenCode's system prompt transform hook
 
 ### 1.3.3
 - Released self-contained common helper copies so the plugin package no longer depends on repository-level symlinks, while keeping hook configuration in `hooks/hooks.json` instead of generated `common/hooks.json` templates

--- a/MarvinOutputStyle/common/opencode-plugin.js
+++ b/MarvinOutputStyle/common/opencode-plugin.js
@@ -271,7 +271,7 @@ function applyPreToolUseRules(state, input, output) {
     if (decision === "deny") throw new Error(message);
 
     const ruleName = typeof rule.name === "string" && rule.name ? rule.name : matchPattern;
-    const key = `${input.sessionID ?? "global"}:${ruleName}`;
+    const key = `${safeSessionID(input.sessionID ?? "global")}:${ruleName}`;
     if (state.deniedOnce.has(key)) continue;
 
     state.deniedOnce.add(key);

--- a/MarvinOutputStyle/common/opencode-plugin.js
+++ b/MarvinOutputStyle/common/opencode-plugin.js
@@ -85,7 +85,10 @@ export function createOpenCodePlugin(pluginRootUrl) {
     const mcpContext = {
       pluginRoot,
       pluginData: () => pluginDataDirectory(pluginRoot, state),
-      projectDir: input?.worktree || input?.directory,
+      projectDir:
+        input?.worktree !== "/" || input?.project?.vcs === "git"
+          ? input?.worktree || input?.directory
+          : input?.directory || input?.worktree,
     };
 
     return {

--- a/MarvinOutputStyle/common/opencode-plugin.js
+++ b/MarvinOutputStyle/common/opencode-plugin.js
@@ -17,6 +17,9 @@ const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9
 const PROCESS_START_OUTPUT_MAX_CHARS = 256;
 const PROCESS_START_TIMEOUT_MS = 5_000;
 const PROCESS_TERMINATION_GRACE_MS = 250;
+const SYSTEM_EXECUTABLE_PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+const SYSTEM_PGREP = "/usr/bin/pgrep";
+const SYSTEM_XCRUN = "/usr/bin/xcrun";
 const XCODE_MCP_CACHE_TTL_MS = 30_000;
 const XCRUN_OPTIONS_WITH_VALUE = new Set([
   "--sdk",
@@ -75,6 +78,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       deniedOnce: new Set(),
       xcodeMcpCache: new Map(),
       xcodeMcpApprovalSessions: new Set(),
+      xcodeMcpApprovalHelpers: new Map(),
       sandboxRoot: null,
       ownedSandboxes: new Map(),
       ownedSandboxIdentities: new Map(),
@@ -127,6 +131,8 @@ export function createOpenCodePlugin(pluginRootUrl) {
       },
 
       dispose: async () => {
+        state.disposed = true;
+        await stopAllXcodeMcpApprovals(state);
         await detachOwnedSandboxes(state);
       },
     };
@@ -353,8 +359,11 @@ async function appendSystemContext(pluginRoot, state, input, output) {
   const pluginName = state.pluginJson.name ?? path.basename(pluginRoot);
   const welcomeMessage = typeof state.infoJson.welcomeMessage === "string" ? state.infoJson.welcomeMessage : "";
   const sessionID = safeSessionID(input?.sessionID ?? "global");
-  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state, sessionID);
-  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state, sessionID);
+  let xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state, sessionID);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) xcodeMcpLikely = false;
+  if (xcodeMcpLikely && !xcodeMcpLifecycleCancelled(state, sessionID)) {
+    startXcodeMcpApproval(pluginRoot, state, sessionID);
+  }
   const sessionStart = renderSessionStart(pluginRoot, xcodeMcpLikely);
 
   let systemMessage = `The ${pluginName} plugin is loaded and ready.`;
@@ -386,6 +395,7 @@ function processConditionalBlocks(content, xcodeMcpLikely) {
 }
 
 async function getXcodeMcpLikely(pluginName, state, sessionID) {
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
   if (pluginName !== "XcodeBuildTools") return false;
   if (!hasConfiguredMcpbridge(state.config)) {
     state.xcodeMcpCache.delete(sessionID);
@@ -396,17 +406,26 @@ async function getXcodeMcpLikely(pluginName, state, sessionID) {
   const cached = state.xcodeMcpCache.get(sessionID);
   if (cached && now - cached.checkedAt < XCODE_MCP_CACHE_TTL_MS) return cached.value;
 
-  const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
+  const installed = await commandSucceeds(SYSTEM_XCRUN, ["--find", "mcpbridge"], 5000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
   if (!installed) {
     state.xcodeMcpCache.set(sessionID, { checkedAt: now, value: false });
     return false;
   }
 
-  const xcodeRunning = await commandSucceeds("pgrep", ["-x", "Xcode"], 3000);
-  const bridgeRunning = await commandSucceeds("pgrep", ["-f", "mcpbridge"], 3000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
+  const xcodeRunning = await commandSucceeds(SYSTEM_PGREP, ["-x", "Xcode"], 3000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
+  const bridgeRunning = await commandSucceeds(SYSTEM_PGREP, ["-f", "mcpbridge"], 3000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
   const value = xcodeRunning || bridgeRunning;
   state.xcodeMcpCache.set(sessionID, { checkedAt: now, value });
   return value;
+}
+
+function xcodeMcpLifecycleCancelled(state, sessionID) {
+  return state.disposed || state.deletedSandboxSessions.has(sessionID);
 }
 
 function hasConfiguredMcpbridge(config) {
@@ -453,30 +472,148 @@ function xcrunToolBasename(args) {
 }
 
 function startXcodeMcpApproval(pluginRoot, state, sessionID) {
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return;
   if (state.xcodeMcpApprovalSessions.has(sessionID)) return;
 
-  const runner = path.join(pluginRoot, "hooks", "run-background.sh");
-  const target = path.join("hooks", "approve-xcode-mcp.sh");
-  if (!fs.existsSync(runner)) return;
+  const helper = path.join(pluginRoot, "hooks", "approve-xcode-mcp.sh");
+  if (!fs.existsSync(helper)) return;
 
   try {
+    if (xcodeMcpLifecycleCancelled(state, sessionID)) return;
     state.xcodeMcpApprovalSessions.add(sessionID);
-    const child = spawn(runner, [target], {
+    const child = spawn(helper, [], {
       cwd: pluginRoot,
       detached: true,
       env: {
         ...process.env,
+        PATH: SYSTEM_EXECUTABLE_PATH,
         CLAUDE_HOOK_OWNER_PID: String(process.pid),
         CLAUDE_PLUGIN_ROOT: pluginRoot,
       },
       stdio: "ignore",
     });
-    child.on("error", () => state.xcodeMcpApprovalSessions.delete(sessionID));
+    trackXcodeMcpApprovalHelper(state, sessionID, child);
     child.unref();
   } catch {
     state.xcodeMcpApprovalSessions.delete(sessionID);
     // Auto-approval is best-effort; users can still approve Xcode manually.
   }
+}
+
+function trackXcodeMcpApprovalHelper(state, sessionID, child) {
+  let resolveDone;
+  const record = {
+    child,
+    done: new Promise((resolve) => {
+      resolveDone = resolve;
+    }),
+    pending: true,
+    terminating: false,
+    terminationPromise: null,
+    finish: null,
+    removeFromState: null,
+  };
+
+  const removeFromState = () => {
+    if (state.xcodeMcpApprovalHelpers.get(sessionID) === record) {
+      state.xcodeMcpApprovalHelpers.delete(sessionID);
+    }
+  };
+  const onError = () => finish(true);
+  const onExit = () => finish(false);
+  const finish = (allowRetry) => {
+    if (!record.pending) return;
+    record.pending = false;
+    child.removeListener?.("error", onError);
+    child.removeListener?.("exit", onExit);
+    if (!record.terminating) removeFromState();
+    if (allowRetry) state.xcodeMcpApprovalSessions.delete(sessionID);
+    resolveDone();
+  };
+  record.finish = finish;
+  record.removeFromState = removeFromState;
+
+  state.xcodeMcpApprovalHelpers.set(sessionID, record);
+  child.on("error", onError);
+  child.on("exit", onExit);
+}
+
+function stopXcodeMcpApproval(record) {
+  if (!record) return Promise.resolve();
+  if (!record.terminationPromise) {
+    record.terminating = true;
+    record.terminationPromise = terminateXcodeMcpApproval(record).finally(() => {
+      record.terminating = false;
+      record.removeFromState();
+    });
+  }
+  return record.terminationPromise;
+}
+
+async function terminateXcodeMcpApproval(record) {
+  if (!record.pending) return;
+
+  signalDetachedProcessGroup(record.child, "SIGTERM");
+  let forceKillTimer;
+  await new Promise((resolve) => {
+    let completed = false;
+    const complete = () => {
+      if (completed) return;
+      completed = true;
+      clearTimeout(forceKillTimer);
+      resolve();
+    };
+    const completeIfGroupExited = () => {
+      if (!detachedProcessGroupExists(record.child)) complete();
+    };
+
+    record.done.then(completeIfGroupExited);
+    if (!detachedProcessGroupExists(record.child)) {
+      record.finish(false);
+      complete();
+      return;
+    }
+
+    forceKillTimer = setTimeout(() => {
+      if (detachedProcessGroupExists(record.child)) {
+        signalDetachedProcessGroup(record.child, "SIGKILL");
+      }
+      record.finish(false);
+      complete();
+    }, PROCESS_TERMINATION_GRACE_MS);
+  });
+}
+
+function detachedProcessGroupExists(child) {
+  const pid = Number(child?.pid);
+  if (!Number.isSafeInteger(pid) || pid <= 0) return child != null;
+
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function signalDetachedProcessGroup(child, signal) {
+  const pid = Number(child?.pid);
+  try {
+    if (Number.isSafeInteger(pid) && pid > 0) {
+      process.kill(-pid, signal);
+    } else {
+      child?.kill?.(signal);
+    }
+  } catch {
+    // The helper may have exited between the lifecycle check and the signal.
+  }
+}
+
+async function stopAllXcodeMcpApprovals(state) {
+  const activeHelpers = [...state.xcodeMcpApprovalHelpers.values()];
+  state.xcodeMcpApprovalSessions.clear();
+  await Promise.all(activeHelpers.map((record) => stopXcodeMcpApproval(record)));
+  state.xcodeMcpApprovalHelpers.clear();
 }
 
 function commandSucceeds(command, args, timeoutMs) {
@@ -1002,6 +1139,8 @@ async function handlePluginEvent(state, event) {
   state.deletedSandboxSessions.add(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
+  const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
+  await stopXcodeMcpApproval(activeApproval);
   await removeOwnedSandbox(state, safeID);
 }
 
@@ -1044,6 +1183,7 @@ async function detachOwnedSandboxes(state) {
   state.ownedSandboxIdentities.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
+  state.xcodeMcpApprovalHelpers.clear();
   const cleanupTargets = await Promise.all(
     sandboxes.map(async ({ sandboxPath, sandboxIdentity }) => {
       if (!state.sandboxRoot || !sandboxIdentity) return null;

--- a/MarvinOutputStyle/common/opencode-plugin.js
+++ b/MarvinOutputStyle/common/opencode-plugin.js
@@ -183,6 +183,7 @@ function processConditionalBlocks(content, xcodeMcpLikely) {
 
 async function getXcodeMcpLikely(pluginName, state) {
   if (pluginName !== "XcodeBuildTools") return false;
+  if (state.xcodeMcpLikely !== undefined) return state.xcodeMcpLikely;
 
   const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
   if (!installed) {

--- a/MarvinOutputStyle/common/opencode-plugin.js
+++ b/MarvinOutputStyle/common/opencode-plugin.js
@@ -1,0 +1,361 @@
+// Generated from common/opencode-plugin.js by scripts/sync-plugin-common.py. Do not edit this copy; edit common/opencode-plugin.js and rerun scripts/sync-plugin-common.py.
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+export function createOpenCodePlugin(pluginRootUrl) {
+  const pluginRoot = normalizePluginRoot(pluginRootUrl);
+  const state = {
+    pluginJson: null,
+    infoJson: null,
+    deniedOnce: new Set(),
+    xcodeMcpLikely: undefined,
+    xcodeMcpApprovalStarted: false,
+  };
+
+  return async () => ({
+    config: async (config) => {
+      loadMetadata(pluginRoot, state);
+      registerSkills(config, pluginRoot);
+      registerMcpServers(config, pluginRoot);
+    },
+
+    "experimental.chat.system.transform": async (_input, output) => {
+      try {
+        loadMetadata(pluginRoot, state);
+        await appendSystemContext(pluginRoot, state, output);
+      } catch {
+        // Fail open. Plugin context should never block a chat request.
+      }
+    },
+
+    "tool.execute.before": async (input, output) => {
+      loadMetadata(pluginRoot, state);
+      applyPreToolUseRules(state, input, output);
+    },
+
+    "shell.env": async (input, output) => {
+      try {
+        loadMetadata(pluginRoot, state);
+        configureShellEnvironment(pluginRoot, state, input, output);
+      } catch {
+        // Fail open. Shell commands should still run if setup is unavailable.
+      }
+    },
+  });
+}
+
+function normalizePluginRoot(pluginRootUrl) {
+  if (pluginRootUrl instanceof URL) {
+    return path.resolve(fileURLToPath(pluginRootUrl));
+  }
+
+  if (typeof pluginRootUrl === "string" && pluginRootUrl.startsWith("file:")) {
+    return path.resolve(fileURLToPath(pluginRootUrl));
+  }
+
+  return path.resolve(String(pluginRootUrl));
+}
+
+function loadMetadata(pluginRoot, state) {
+  if (!state.pluginJson) {
+    state.pluginJson = readJsonFile(path.join(pluginRoot, ".claude-plugin", "plugin.json")) ?? {};
+  }
+  if (!state.infoJson) {
+    state.infoJson = readJsonFile(path.join(pluginRoot, "info.json")) ?? {};
+  }
+}
+
+function registerSkills(config, pluginRoot) {
+  const skillsDir = path.join(pluginRoot, "skills");
+  if (!hasSkillDirectories(skillsDir)) return;
+
+  if (!isObject(config.skills)) config.skills = {};
+  if (!Array.isArray(config.skills.paths)) config.skills.paths = [];
+  if (!config.skills.paths.includes(skillsDir)) config.skills.paths.push(skillsDir);
+}
+
+function registerMcpServers(config, pluginRoot) {
+  const mcpConfig = readJsonFile(path.join(pluginRoot, ".mcp.json"));
+  const servers = mcpConfig?.mcpServers;
+  if (!isObject(servers)) return;
+
+  if (!isObject(config.mcp)) config.mcp = {};
+
+  for (const [name, server] of Object.entries(servers)) {
+    if (!isObject(server) || config.mcp[name]) continue;
+
+    const translated = translateMcpServer(server);
+    if (translated) config.mcp[name] = translated;
+  }
+}
+
+function translateMcpServer(server) {
+  if (typeof server.url === "string") {
+    const translated = {
+      type: "remote",
+      url: server.url,
+    };
+    copyOptionalFields(server, translated, ["enabled", "headers", "timeout"]);
+    return translated;
+  }
+
+  const command = normalizeCommand(server.command, server.args);
+  if (!command) return null;
+
+  const translated = {
+    type: "local",
+    command,
+  };
+  copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"]);
+
+  const environment = isObject(server.environment) ? server.environment : server.env;
+  if (isObject(environment)) translated.environment = stringifyRecord(environment);
+
+  return translated;
+}
+
+function normalizeCommand(command, args) {
+  if (Array.isArray(command) && command.every((item) => typeof item === "string")) {
+    return command;
+  }
+
+  if (typeof command !== "string") return null;
+
+  const result = [command];
+  if (Array.isArray(args)) {
+    for (const arg of args) {
+      if (typeof arg !== "string") return null;
+      result.push(arg);
+    }
+  }
+  return result;
+}
+
+function copyOptionalFields(source, target, keys) {
+  for (const key of keys) {
+    if (source[key] === undefined) continue;
+    target[key] = key === "headers" && isObject(source[key]) ? stringifyRecord(source[key]) : source[key];
+  }
+}
+
+async function appendSystemContext(pluginRoot, state, output) {
+  if (!Array.isArray(output.system)) output.system = [];
+
+  const pluginName = state.pluginJson.name ?? path.basename(pluginRoot);
+  const welcomeMessage = typeof state.infoJson.welcomeMessage === "string" ? state.infoJson.welcomeMessage : "";
+  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state);
+  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state);
+  const sessionStart = renderSessionStart(pluginRoot, xcodeMcpLikely);
+
+  let systemMessage = `The ${pluginName} plugin is loaded and ready.`;
+  if (xcodeMcpLikely) systemMessage += " Xcode MCP server detected.";
+  if (welcomeMessage) systemMessage += ` ${welcomeMessage}`;
+
+  output.system.push([systemMessage, sessionStart].filter(Boolean).join("\n\n"));
+}
+
+function renderSessionStart(pluginRoot, xcodeMcpLikely) {
+  const sessionStartPath = path.join(pluginRoot, "session-start.md");
+  const content = readTextFile(sessionStartPath);
+  if (!content) return "";
+  return processConditionalBlocks(content, xcodeMcpLikely);
+}
+
+function processConditionalBlocks(content, xcodeMcpLikely) {
+  if (xcodeMcpLikely) {
+    return content
+      .replace(/<!-- IF_XCODE_MCP -->\n?/g, "")
+      .replace(/<!-- END_XCODE_MCP -->\n?/g, "")
+      .replace(/<!-- IF_NO_XCODE_MCP -->[\s\S]*?<!-- END_NO_XCODE_MCP -->\n?/g, "");
+  }
+
+  return content
+    .replace(/<!-- IF_NO_XCODE_MCP -->\n?/g, "")
+    .replace(/<!-- END_NO_XCODE_MCP -->\n?/g, "")
+    .replace(/<!-- IF_XCODE_MCP -->[\s\S]*?<!-- END_XCODE_MCP -->\n?/g, "");
+}
+
+async function getXcodeMcpLikely(pluginName, state) {
+  if (pluginName !== "XcodeBuildTools") return false;
+
+  const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
+  if (!installed) {
+    state.xcodeMcpLikely = false;
+    return state.xcodeMcpLikely;
+  }
+
+  const xcodeRunning = await commandSucceeds("pgrep", ["-x", "Xcode"], 3000);
+  const bridgeRunning = await commandSucceeds("pgrep", ["-f", "mcpbridge"], 3000);
+  state.xcodeMcpLikely = xcodeRunning || bridgeRunning;
+  return state.xcodeMcpLikely;
+}
+
+function startXcodeMcpApproval(pluginRoot, state) {
+  if (state.xcodeMcpApprovalStarted) return;
+  state.xcodeMcpApprovalStarted = true;
+
+  const runner = path.join(pluginRoot, "hooks", "run-background.sh");
+  const target = path.join("hooks", "approve-xcode-mcp.sh");
+  if (!fs.existsSync(runner)) return;
+
+  try {
+    const child = spawn(runner, [target], {
+      cwd: pluginRoot,
+      detached: true,
+      env: {
+        ...process.env,
+        CLAUDE_HOOK_OWNER_PID: String(process.pid),
+        CLAUDE_PLUGIN_ROOT: pluginRoot,
+      },
+      stdio: "ignore",
+    });
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+    // Auto-approval is best-effort; users can still approve Xcode manually.
+  }
+}
+
+function commandSucceeds(command, args, timeoutMs) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const child = spawn(command, args, { stdio: "ignore" });
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish(false);
+    }, timeoutMs);
+
+    child.on("error", () => finish(false));
+    child.on("exit", (code) => finish(code === 0));
+
+    function finish(result) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    }
+  });
+}
+
+function applyPreToolUseRules(state, input, output) {
+  const tool = String(input.tool ?? "").toLowerCase();
+  if (tool !== "bash") return;
+
+  const command = output?.args?.command;
+  if (typeof command !== "string" || !command) return;
+
+  const rules = Array.isArray(state.infoJson["pre-tool-use-rules"])
+    ? state.infoJson["pre-tool-use-rules"]
+    : [];
+
+  for (const rule of rules) {
+    if (!isObject(rule)) continue;
+
+    const matchPattern = rule.match;
+    if (typeof matchPattern !== "string" || !regexMatches(matchPattern, command)) continue;
+
+    const notMatchPattern = rule.not_match;
+    if (typeof notMatchPattern === "string" && regexMatches(notMatchPattern, command)) continue;
+
+    const decision = rule.decision ?? "deny";
+    if (decision === "allow") return;
+
+    const message = typeof rule.message === "string" ? rule.message : "Command denied by plugin rule";
+    if (decision === "deny") throw new Error(message);
+
+    const ruleName = typeof rule.name === "string" && rule.name ? rule.name : matchPattern;
+    const key = `${input.sessionID ?? "global"}:${ruleName}`;
+    if (state.deniedOnce.has(key)) continue;
+
+    state.deniedOnce.add(key);
+    throw new Error(message);
+  }
+}
+
+function configureShellEnvironment(pluginRoot, state, input, output) {
+  if (!isObject(output.env)) output.env = {};
+
+  const binDir = path.join(pluginRoot, "bin");
+  if (fs.existsSync(binDir)) {
+    output.env.PATH = prependPath(binDir, output.env.PATH ?? process.env.PATH ?? "");
+  }
+
+  if (state.pluginJson.name !== "XcodeBuildTools") return;
+
+  const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
+  const sandboxBase = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox", sessionID);
+  const buildDir = path.join(sandboxBase, "build");
+  const packagesDir = path.join(sandboxBase, "packages");
+
+  fs.mkdirSync(buildDir, { recursive: true });
+  fs.mkdirSync(packagesDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(sandboxBase, "owner.pid"),
+    `${process.pid}\n${process.argv[0] ?? "opencode"}\n`,
+    "utf8",
+  );
+
+  output.env.SANDBOX_DERIVED_DATA = buildDir;
+  output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+function prependPath(entry, current) {
+  const parts = current.split(path.delimiter).filter(Boolean).filter((part) => part !== entry);
+  return [entry, ...parts].join(path.delimiter);
+}
+
+function safeSessionID(value) {
+  const raw = String(value ?? "");
+  if (SAFE_ID_RE.test(raw)) return raw;
+
+  const hash = createHash("sha256").update(raw || "default").digest("hex").slice(0, 16);
+  return `opencode-${hash}`;
+}
+
+function regexMatches(pattern, value) {
+  try {
+    return new RegExp(pattern).test(value);
+  } catch {
+    return false;
+  }
+}
+
+function hasSkillDirectories(skillsDir) {
+  try {
+    return fs.readdirSync(skillsDir, { withFileTypes: true }).some((entry) => {
+      return entry.isDirectory() && fs.existsSync(path.join(skillsDir, entry.name, "SKILL.md"));
+    });
+  } catch {
+    return false;
+  }
+}
+
+function readJsonFile(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function readTextFile(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function stringifyRecord(value) {
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, String(item)]));
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/MarvinOutputStyle/common/opencode-plugin.js
+++ b/MarvinOutputStyle/common/opencode-plugin.js
@@ -1,53 +1,71 @@
 // Generated from common/opencode-plugin.js by scripts/sync-plugin-common.py. Do not edit this copy; edit common/opencode-plugin.js and rerun scripts/sync-plugin-common.py.
 import { spawn } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const XCODE_MCP_CACHE_TTL_MS = 30_000;
+const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
 
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
-  const state = {
-    pluginJson: null,
-    infoJson: null,
-    deniedOnce: new Set(),
-    xcodeMcpLikely: undefined,
-    xcodeMcpApprovalStarted: false,
+  return async () => {
+    const state = {
+      pluginJson: null,
+      infoJson: null,
+      config: null,
+      instanceID: randomUUID(),
+      processStartToken: null,
+      deniedOnce: new Set(),
+      xcodeMcpCache: new Map(),
+      xcodeMcpApprovalSessions: new Set(),
+      ownedSandboxes: new Map(),
+      sandboxSweepDone: false,
+    };
+
+    return {
+      config: async (config) => {
+        loadMetadata(pluginRoot, state);
+        registerSkills(config, pluginRoot);
+        registerMcpServers(config, pluginRoot);
+        state.config = config;
+      },
+
+      "experimental.chat.system.transform": async (input, output) => {
+        try {
+          loadMetadata(pluginRoot, state);
+          await appendSystemContext(pluginRoot, state, input, output);
+        } catch {
+          // Fail open. Plugin context should never block a chat request.
+        }
+      },
+
+      "tool.execute.before": async (input, output) => {
+        loadMetadata(pluginRoot, state);
+        applyPreToolUseRules(state, input, output);
+      },
+
+      "shell.env": async (input, output) => {
+        try {
+          loadMetadata(pluginRoot, state);
+          await configureShellEnvironment(pluginRoot, state, input, output);
+        } catch {
+          // Fail open. Shell commands should still run if setup is unavailable.
+        }
+      },
+
+      event: async ({ event }) => {
+        await handlePluginEvent(state, event);
+      },
+
+      dispose: async () => {
+        await removeOwnedSandboxes(state);
+      },
+    };
   };
-
-  return async () => ({
-    config: async (config) => {
-      loadMetadata(pluginRoot, state);
-      registerSkills(config, pluginRoot);
-      registerMcpServers(config, pluginRoot);
-    },
-
-    "experimental.chat.system.transform": async (_input, output) => {
-      try {
-        loadMetadata(pluginRoot, state);
-        await appendSystemContext(pluginRoot, state, output);
-      } catch {
-        // Fail open. Plugin context should never block a chat request.
-      }
-    },
-
-    "tool.execute.before": async (input, output) => {
-      loadMetadata(pluginRoot, state);
-      applyPreToolUseRules(state, input, output);
-    },
-
-    "shell.env": async (input, output) => {
-      try {
-        loadMetadata(pluginRoot, state);
-        configureShellEnvironment(pluginRoot, state, input, output);
-      } catch {
-        // Fail open. Shell commands should still run if setup is unavailable.
-      }
-    },
-  });
 }
 
 function normalizePluginRoot(pluginRootUrl) {
@@ -144,13 +162,14 @@ function copyOptionalFields(source, target, keys) {
   }
 }
 
-async function appendSystemContext(pluginRoot, state, output) {
+async function appendSystemContext(pluginRoot, state, input, output) {
   if (!Array.isArray(output.system)) output.system = [];
 
   const pluginName = state.pluginJson.name ?? path.basename(pluginRoot);
   const welcomeMessage = typeof state.infoJson.welcomeMessage === "string" ? state.infoJson.welcomeMessage : "";
-  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state);
-  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state);
+  const sessionID = safeSessionID(input?.sessionID ?? "global");
+  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state, sessionID);
+  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state, sessionID);
   const sessionStart = renderSessionStart(pluginRoot, xcodeMcpLikely);
 
   let systemMessage = `The ${pluginName} plugin is loaded and ready.`;
@@ -181,31 +200,56 @@ function processConditionalBlocks(content, xcodeMcpLikely) {
     .replace(/<!-- IF_XCODE_MCP -->[\s\S]*?<!-- END_XCODE_MCP -->\n?/g, "");
 }
 
-async function getXcodeMcpLikely(pluginName, state) {
+async function getXcodeMcpLikely(pluginName, state, sessionID) {
   if (pluginName !== "XcodeBuildTools") return false;
-  if (state.xcodeMcpLikely !== undefined) return state.xcodeMcpLikely;
+  if (!hasConfiguredMcpbridge(state.config)) {
+    state.xcodeMcpCache.delete(sessionID);
+    return false;
+  }
+
+  const now = Date.now();
+  const cached = state.xcodeMcpCache.get(sessionID);
+  if (cached && now - cached.checkedAt < XCODE_MCP_CACHE_TTL_MS) return cached.value;
 
   const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
   if (!installed) {
-    state.xcodeMcpLikely = false;
-    return state.xcodeMcpLikely;
+    state.xcodeMcpCache.set(sessionID, { checkedAt: now, value: false });
+    return false;
   }
 
   const xcodeRunning = await commandSucceeds("pgrep", ["-x", "Xcode"], 3000);
   const bridgeRunning = await commandSucceeds("pgrep", ["-f", "mcpbridge"], 3000);
-  state.xcodeMcpLikely = xcodeRunning || bridgeRunning;
-  return state.xcodeMcpLikely;
+  const value = xcodeRunning || bridgeRunning;
+  state.xcodeMcpCache.set(sessionID, { checkedAt: now, value });
+  return value;
 }
 
-function startXcodeMcpApproval(pluginRoot, state) {
-  if (state.xcodeMcpApprovalStarted) return;
-  state.xcodeMcpApprovalStarted = true;
+function hasConfiguredMcpbridge(config) {
+  if (!isObject(config?.mcp)) return false;
+
+  return Object.values(config.mcp).some((server) => {
+    if (!isObject(server) || server.enabled === false || server.type !== "local") return false;
+
+    const command = Array.isArray(server.command) ? server.command : [server.command];
+    return command.some((part) => {
+      if (typeof part !== "string") return false;
+      return part
+        .trim()
+        .split(/\s+/)
+        .some((token) => path.basename(token.replace(/^['"]|['"]$/g, "")) === "mcpbridge");
+    });
+  });
+}
+
+function startXcodeMcpApproval(pluginRoot, state, sessionID) {
+  if (state.xcodeMcpApprovalSessions.has(sessionID)) return;
 
   const runner = path.join(pluginRoot, "hooks", "run-background.sh");
   const target = path.join("hooks", "approve-xcode-mcp.sh");
   if (!fs.existsSync(runner)) return;
 
   try {
+    state.xcodeMcpApprovalSessions.add(sessionID);
     const child = spawn(runner, [target], {
       cwd: pluginRoot,
       detached: true,
@@ -216,9 +260,10 @@ function startXcodeMcpApproval(pluginRoot, state) {
       },
       stdio: "ignore",
     });
-    child.on("error", () => {});
+    child.on("error", () => state.xcodeMcpApprovalSessions.delete(sessionID));
     child.unref();
   } catch {
+    state.xcodeMcpApprovalSessions.delete(sessionID);
     // Auto-approval is best-effort; users can still approve Xcode manually.
   }
 }
@@ -279,7 +324,7 @@ function applyPreToolUseRules(state, input, output) {
   }
 }
 
-function configureShellEnvironment(pluginRoot, state, input, output) {
+async function configureShellEnvironment(pluginRoot, state, input, output) {
   if (!isObject(output.env)) output.env = {};
 
   const binDir = path.join(pluginRoot, "bin");
@@ -290,7 +335,23 @@ function configureShellEnvironment(pluginRoot, state, input, output) {
   if (state.pluginJson.name !== "XcodeBuildTools") return;
 
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
-  const sandboxBase = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox", sessionID);
+  const sandboxRoot = path.join(os.tmpdir(), XCODE_SANDBOX_DIR);
+  // Plugin instances never reuse a sandbox path, so an older instance cannot
+  // delete a replacement instance's active sandbox after an ownership check.
+  const sandboxBase = path.join(sandboxRoot, `${sessionID}-${state.instanceID}`);
+  state.ownedSandboxes.set(sessionID, sandboxBase);
+
+  if (!state.processStartToken) {
+    state.processStartToken = await readProcessStartToken(process.pid);
+  }
+  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+
+  if (!state.sandboxSweepDone) {
+    await sweepStaleSandboxes(sandboxRoot);
+    state.sandboxSweepDone = true;
+  }
+  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+
   const buildDir = path.join(sandboxBase, "build");
   const packagesDir = path.join(sandboxBase, "packages");
 
@@ -298,12 +359,153 @@ function configureShellEnvironment(pluginRoot, state, input, output) {
   fs.mkdirSync(packagesDir, { recursive: true });
   fs.writeFileSync(
     path.join(sandboxBase, "owner.pid"),
-    `${process.pid}\n${process.argv[0] ?? "opencode"}\n`,
+    `${process.pid}\n${process.argv[0] ?? "opencode"}\n${state.processStartToken}\n${state.instanceID}\n`,
     "utf8",
   );
 
   output.env.SANDBOX_DERIVED_DATA = buildDir;
   output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+async function handlePluginEvent(state, event) {
+  if (event?.type !== "session.deleted") return;
+
+  const sessionID = event.properties?.info?.id;
+  if (typeof sessionID !== "string" || !sessionID) return;
+
+  const safeID = safeSessionID(sessionID);
+  state.xcodeMcpCache.delete(safeID);
+  state.xcodeMcpApprovalSessions.delete(safeID);
+  await removeOwnedSandbox(state, safeID);
+}
+
+async function removeOwnedSandbox(state, sessionID) {
+  const sandboxPath = state.ownedSandboxes.get(sessionID);
+  if (!sandboxPath) return;
+
+  state.ownedSandboxes.delete(sessionID);
+  await removeManagedSandbox(sandboxPath, state.instanceID);
+}
+
+async function removeOwnedSandboxes(state) {
+  const sandboxPaths = [...new Set(state.ownedSandboxes.values())];
+  state.ownedSandboxes.clear();
+  state.xcodeMcpCache.clear();
+  state.xcodeMcpApprovalSessions.clear();
+  await Promise.all(sandboxPaths.map((sandboxPath) => removeManagedSandbox(sandboxPath, state.instanceID)));
+}
+
+async function sweepStaleSandboxes(sandboxRoot) {
+  let entries;
+  try {
+    entries = await fs.promises.readdir(sandboxRoot, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.isDirectory() || !SAFE_ID_RE.test(entry.name)) return;
+
+      const sandboxPath = path.join(sandboxRoot, entry.name);
+      const owner = await readSandboxOwner(sandboxPath);
+      if (!owner || (await sandboxOwnerIsActive(owner))) return;
+
+      await removeManagedSandbox(sandboxPath);
+    }),
+  );
+}
+
+async function readSandboxOwner(sandboxPath) {
+  try {
+    const content = await fs.promises.readFile(path.join(sandboxPath, "owner.pid"), "utf8");
+    const lines = content.split(/\r?\n/);
+    const firstLine = lines[0];
+    if (!/^\d+$/.test(firstLine)) return null;
+
+    const pid = Number(firstLine);
+    if (!Number.isSafeInteger(pid) || pid <= 0) return null;
+
+    return {
+      pid,
+      processStartToken: lines[2] ?? "",
+      instanceID: lines[3] ?? "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+async function sandboxOwnerIsActive(owner) {
+  if (!processExists(owner.pid)) return false;
+  if (!owner.processStartToken) return true;
+
+  const currentStartToken = await readProcessStartToken(owner.pid);
+  if (!currentStartToken) return true;
+  return currentStartToken === owner.processStartToken;
+}
+
+function readProcessStartToken(pid) {
+  return new Promise((resolve) => {
+    let settled = false;
+    let stdout = "";
+    let child;
+
+    try {
+      child = spawn("ps", ["-p", String(pid), "-o", "lstart="], {
+        env: {
+          ...process.env,
+          LC_ALL: "C",
+          LANG: "C",
+          TZ: "UTC",
+        },
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+    } catch {
+      resolve("");
+      return;
+    }
+
+    child.stdout?.setEncoding?.("utf8");
+    child.stdout?.on?.("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.on("error", () => finish(""));
+    child.on("close", (code) => finish(code === 0 ? stdout.trim() : ""));
+
+    function finish(value) {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    }
+  });
+}
+
+async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
+  const sandboxRoot = path.resolve(os.tmpdir(), XCODE_SANDBOX_DIR);
+  const candidate = path.resolve(sandboxPath);
+  const relative = path.relative(sandboxRoot, candidate);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return;
+
+  if (expectedInstanceID) {
+    const owner = await readSandboxOwner(candidate);
+    if (!owner || owner.instanceID !== expectedInstanceID) return;
+  }
+
+  try {
+    await fs.promises.rm(candidate, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  } catch {
+    // Best-effort cleanup; the next plugin instance will retry through the stale-owner sweep.
+  }
 }
 
 function prependPath(entry, current) {

--- a/MarvinOutputStyle/common/opencode-plugin.js
+++ b/MarvinOutputStyle/common/opencode-plugin.js
@@ -7,8 +7,23 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const PROCESS_START_OUTPUT_MAX_CHARS = 256;
+const PROCESS_START_TIMEOUT_MS = 5_000;
 const XCODE_MCP_CACHE_TTL_MS = 30_000;
 const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
+const XCODE_SANDBOX_OWNER_GRACE_MS = 60_000;
+const XCODE_SANDBOX_OWNER_LOCK = ".owner.lock";
+const XCODE_SANDBOX_QUARANTINE_RE =
+  /^\.quarantine-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const XCODE_SANDBOX_PENDING_CLEANUPS_KEY = Symbol.for(
+  "opencode.xcodebuildtools.pending-cleanups",
+);
+const pendingSandboxCleanups =
+  globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] instanceof Set
+    ? globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY]
+    : new Set();
+globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] = pendingSandboxCleanups;
 
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
@@ -23,7 +38,9 @@ export function createOpenCodePlugin(pluginRootUrl) {
       xcodeMcpCache: new Map(),
       xcodeMcpApprovalSessions: new Set(),
       ownedSandboxes: new Map(),
+      deletedSandboxSessions: new Set(),
       sandboxSweepDone: false,
+      disposed: false,
     };
 
     return {
@@ -62,7 +79,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       },
 
       dispose: async () => {
-        await removeOwnedSandboxes(state);
+        await detachOwnedSandboxes(state);
       },
     };
   };
@@ -335,6 +352,7 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   if (state.pluginJson.name !== "XcodeBuildTools") return;
 
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
+  if (state.disposed || state.deletedSandboxSessions.has(sessionID)) return;
   const sandboxRoot = path.join(os.tmpdir(), XCODE_SANDBOX_DIR);
   // Plugin instances never reuse a sandbox path, so an older instance cannot
   // delete a replacement instance's active sandbox after an ownership check.
@@ -344,27 +362,201 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   if (!state.processStartToken) {
     state.processStartToken = await readProcessStartToken(process.pid);
   }
-  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+  if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
 
   if (!state.sandboxSweepDone) {
     await sweepStaleSandboxes(sandboxRoot);
     state.sandboxSweepDone = true;
   }
-  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+  if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
 
   const buildDir = path.join(sandboxBase, "build");
   const packagesDir = path.join(sandboxBase, "packages");
 
   fs.mkdirSync(buildDir, { recursive: true });
   fs.mkdirSync(packagesDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(sandboxBase, "owner.pid"),
-    `${process.pid}\n${process.argv[0] ?? "opencode"}\n${state.processStartToken}\n${state.instanceID}\n`,
-    "utf8",
-  );
+  writeSandboxOwner(sandboxBase, state.processStartToken, state.instanceID);
 
   output.env.SANDBOX_DERIVED_DATA = buildDir;
   output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+function sandboxSetupIsCancelled(state, sessionID, sandboxBase) {
+  return (
+    state.disposed ||
+    state.deletedSandboxSessions.has(sessionID) ||
+    state.ownedSandboxes.get(sessionID) !== sandboxBase
+  );
+}
+
+function writeSandboxOwner(sandboxBase, processStartToken, instanceID) {
+  const ownerPath = path.join(sandboxBase, "owner.pid");
+  const temporaryPath = path.join(sandboxBase, `owner.pid.${instanceID}.tmp`);
+  const content = `${process.pid}\n${process.argv[0] ?? "opencode"}\n${processStartToken}\n${instanceID}\n`;
+  const ownerLock = acquireSandboxOwnerLock(sandboxBase);
+  if (!ownerLock) throw new Error("Sandbox owner is being updated or removed");
+
+  try {
+    fs.writeFileSync(temporaryPath, content, "utf8");
+    if (!sandboxOwnerLockIsHeld(ownerLock)) {
+      throw new Error("Sandbox owner lock changed during update");
+    }
+    fs.renameSync(temporaryPath, ownerPath);
+  } catch (error) {
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch {
+      // The stale-sandbox sweep handles any temporary file left behind.
+    }
+    throw error;
+  } finally {
+    releaseSandboxOwnerLock(ownerLock);
+  }
+}
+
+function markSandboxCleanupPending(sandboxBase, instanceID, ownerLock) {
+  const ownerPath = path.join(sandboxBase, "owner.pid");
+  const temporaryPath = path.join(sandboxBase, `owner.pid.${instanceID}.cleanup.tmp`);
+  const content = `${process.pid}\ncleanup-pending\n\n${instanceID}\ncleanup-pending\n`;
+
+  try {
+    fs.writeFileSync(temporaryPath, content, "utf8");
+    if (!sandboxOwnerLockIsHeld(ownerLock)) return false;
+    fs.renameSync(temporaryPath, ownerPath);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch {
+      // A successful rename removes the temporary path.
+    }
+  }
+}
+
+function acquireSandboxOwnerLock(sandboxBase) {
+  const lockPath = path.join(sandboxBase, XCODE_SANDBOX_OWNER_LOCK);
+  const token = randomUUID();
+  const createdLock = createSandboxOwnerLock(lockPath, token);
+  if (createdLock) return createdLock;
+
+  const observedLock = readSandboxOwnerLock(lockPath);
+  if (!observedLock) return null;
+  if (Date.now() - observedLock.mtimeMs < XCODE_SANDBOX_OWNER_GRACE_MS) return null;
+
+  const claimedPath = `${lockPath}.${token}.stale`;
+  try {
+    fs.renameSync(lockPath, claimedPath);
+  } catch {
+    return null;
+  }
+
+  const claimedLock = readSandboxOwnerLock(claimedPath);
+  if (!sameSandboxOwnerLock(observedLock, claimedLock)) {
+    restoreClaimedSandboxOwnerLock(claimedPath, lockPath);
+    return null;
+  }
+
+  try {
+    fs.unlinkSync(claimedPath);
+  } catch {
+    restoreClaimedSandboxOwnerLock(claimedPath, lockPath);
+    return null;
+  }
+
+  return createSandboxOwnerLock(lockPath, token);
+}
+
+function createSandboxOwnerLock(lockPath, token) {
+  try {
+    fs.writeFileSync(lockPath, `${token}\n`, { encoding: "utf8", flag: "wx" });
+  } catch {
+    return null;
+  }
+
+  const ownerLock = readSandboxOwnerLock(lockPath);
+  if (!ownerLock || ownerLock.token !== token) return null;
+  return ownerLock;
+}
+
+function readSandboxOwnerLock(lockPath) {
+  try {
+    const before = fs.statSync(lockPath);
+    if (!before.isFile()) return null;
+    const beforeToken = fs.readFileSync(lockPath, "utf8").trim();
+    const after = fs.statSync(lockPath);
+    const afterToken = fs.readFileSync(lockPath, "utf8").trim();
+    if (!sameSandboxOwnerLockVersion(before, after) || beforeToken !== afterToken) return null;
+
+    return {
+      path: lockPath,
+      token: afterToken,
+      dev: after.dev,
+      ino: after.ino,
+      mtimeMs: after.mtimeMs,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function sameSandboxOwnerLockVersion(left, right) {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs &&
+    left.ctimeMs === right.ctimeMs
+  );
+}
+
+function sameSandboxOwnerLock(left, right) {
+  return Boolean(
+    left &&
+      right &&
+      left.dev === right.dev &&
+      left.ino === right.ino &&
+      left.token === right.token,
+  );
+}
+
+function sandboxOwnerLockIsHeld(ownerLock) {
+  return sameSandboxOwnerLock(ownerLock, readSandboxOwnerLock(ownerLock.path));
+}
+
+function restoreClaimedSandboxOwnerLock(claimedPath, lockPath) {
+  try {
+    // A hard link restores the claimed inode only when the lock path is still
+    // absent, without overwriting a lock another actor acquired meanwhile.
+    fs.linkSync(claimedPath, lockPath);
+    fs.unlinkSync(claimedPath);
+  } catch {
+    // Leave the uniquely named claim in place if ownership cannot be restored.
+  }
+}
+
+function releaseSandboxOwnerLock(ownerLock) {
+  if (!sandboxOwnerLockIsHeld(ownerLock)) return;
+
+  const claimedPath = `${ownerLock.path}.${randomUUID()}.release`;
+  try {
+    fs.renameSync(ownerLock.path, claimedPath);
+  } catch {
+    return;
+  }
+
+  const claimedLock = readSandboxOwnerLock(claimedPath);
+  if (!sameSandboxOwnerLock(ownerLock, claimedLock)) {
+    restoreClaimedSandboxOwnerLock(claimedPath, ownerLock.path);
+    return;
+  }
+
+  try {
+    fs.unlinkSync(claimedPath);
+  } catch {
+    // The sandbox may already have been removed with the lock inside it.
+  }
 }
 
 async function handlePluginEvent(state, event) {
@@ -374,6 +566,7 @@ async function handlePluginEvent(state, event) {
   if (typeof sessionID !== "string" || !sessionID) return;
 
   const safeID = safeSessionID(sessionID);
+  state.deletedSandboxSessions.add(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
   await removeOwnedSandbox(state, safeID);
@@ -383,16 +576,36 @@ async function removeOwnedSandbox(state, sessionID) {
   const sandboxPath = state.ownedSandboxes.get(sessionID);
   if (!sandboxPath) return;
 
+  markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.delete(sessionID);
-  await removeManagedSandbox(sandboxPath, state.instanceID);
+  const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+  await removeManagedSandbox(
+    quarantinedPath || sandboxPath,
+    quarantinedPath ? "" : state.instanceID,
+  );
 }
 
-async function removeOwnedSandboxes(state) {
+async function detachOwnedSandboxes(state) {
+  state.disposed = true;
   const sandboxPaths = [...new Set(state.ownedSandboxes.values())];
+  for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
-  await Promise.all(sandboxPaths.map((sandboxPath) => removeManagedSandbox(sandboxPath, state.instanceID)));
+  const cleanupTargets = await Promise.all(
+    sandboxPaths.map(async (sandboxPath) => {
+      const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+      return {
+        path: quarantinedPath || sandboxPath,
+        expectedInstanceID: quarantinedPath ? "" : state.instanceID,
+      };
+    }),
+  );
+  await Promise.all(
+    cleanupTargets.map(({ path: sandboxPath, expectedInstanceID }) =>
+      detachManagedSandbox(sandboxPath, expectedInstanceID),
+    ),
+  );
 }
 
 async function sweepStaleSandboxes(sandboxRoot) {
@@ -405,11 +618,43 @@ async function sweepStaleSandboxes(sandboxRoot) {
 
   await Promise.all(
     entries.map(async (entry) => {
-      if (!entry.isDirectory() || !SAFE_ID_RE.test(entry.name)) return;
+      const isQuarantine = XCODE_SANDBOX_QUARANTINE_RE.test(entry.name);
+      if (!entry.isDirectory() || (!SAFE_ID_RE.test(entry.name) && !isQuarantine)) return;
 
       const sandboxPath = path.join(sandboxRoot, entry.name);
       const owner = await readSandboxOwner(sandboxPath);
-      if (!owner || (await sandboxOwnerIsActive(owner))) return;
+      const cleanupPending = owner?.cleanupPending || sandboxCleanupIsPending(sandboxPath);
+      if (!owner || cleanupPending) {
+        if (!cleanupPending && !isQuarantine && !(await sandboxIsPastOwnerGracePeriod(sandboxPath))) {
+          return;
+        }
+
+        const ownerLock = acquireSandboxOwnerLock(sandboxPath);
+        if (!ownerLock) return;
+        let releaseLock = ownerLock;
+        try {
+          // A writer may have published an owner after the initial read or
+          // stale-stat snapshot. Only remove while the publication lock is
+          // held and the marker is still invalid.
+          const currentOwner = await readSandboxOwner(sandboxPath);
+          const currentCleanupPending =
+            currentOwner?.cleanupPending || sandboxCleanupIsPending(sandboxPath);
+          if (
+            (!currentOwner || currentCleanupPending) &&
+            sandboxOwnerLockIsHeld(ownerLock)
+          ) {
+            const quarantined = await quarantineManagedSandbox(sandboxPath, ownerLock);
+            releaseLock = quarantined.ownerLock;
+            if (quarantined.path) {
+              await removeManagedSandbox(quarantined.path);
+            }
+          }
+        } finally {
+          releaseSandboxOwnerLock(releaseLock);
+        }
+        return;
+      }
+      if (await sandboxOwnerIsActive(owner)) return;
 
       await removeManagedSandbox(sandboxPath);
     }),
@@ -426,13 +671,26 @@ async function readSandboxOwner(sandboxPath) {
     const pid = Number(firstLine);
     if (!Number.isSafeInteger(pid) || pid <= 0) return null;
 
+    const instanceID = lines[3] ?? "";
+    if (!UUID_V4_RE.test(instanceID)) return null;
+
     return {
       pid,
       processStartToken: lines[2] ?? "",
-      instanceID: lines[3] ?? "",
+      instanceID,
+      cleanupPending: lines[4] === "cleanup-pending",
     };
   } catch {
     return null;
+  }
+}
+
+async function sandboxIsPastOwnerGracePeriod(sandboxPath) {
+  try {
+    const stat = await fs.promises.stat(sandboxPath);
+    return Date.now() - stat.mtimeMs >= XCODE_SANDBOX_OWNER_GRACE_MS;
+  } catch {
+    return false;
   }
 }
 
@@ -459,9 +717,10 @@ function readProcessStartToken(pid) {
     let settled = false;
     let stdout = "";
     let child;
+    let timer;
 
     try {
-      child = spawn("ps", ["-p", String(pid), "-o", "lstart="], {
+      child = spawn("/bin/ps", ["-p", String(pid), "-o", "lstart="], {
         env: {
           ...process.env,
           LC_ALL: "C",
@@ -477,24 +736,156 @@ function readProcessStartToken(pid) {
 
     child.stdout?.setEncoding?.("utf8");
     child.stdout?.on?.("data", (chunk) => {
-      stdout += chunk;
+      const remaining = PROCESS_START_OUTPUT_MAX_CHARS - stdout.length;
+      if (remaining > 0) stdout += String(chunk).slice(0, remaining);
     });
     child.on("error", () => finish(""));
-    child.on("close", (code) => finish(code === 0 ? stdout.trim() : ""));
+    child.on("close", (code) => {
+      const firstLine = stdout.trim().split(/\r?\n/, 1)[0] ?? "";
+      finish(code === 0 ? firstLine : "");
+    });
+    timer = setTimeout(() => {
+      try {
+        child.kill?.("SIGTERM");
+      } catch {
+        // Resolving the hook is more important than terminating a broken ps shim.
+      }
+      finish("");
+    }, PROCESS_START_TIMEOUT_MS);
 
     function finish(value) {
       if (settled) return;
       settled = true;
+      clearTimeout(timer);
       resolve(value);
     }
   });
 }
 
 async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
-  const sandboxRoot = path.resolve(os.tmpdir(), XCODE_SANDBOX_DIR);
-  const candidate = path.resolve(sandboxPath);
-  const relative = path.relative(sandboxRoot, candidate);
-  if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return;
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate) return false;
+
+  if (expectedInstanceID) {
+    const owner = await readSandboxOwner(candidate);
+    if (!owner || owner.instanceID !== expectedInstanceID) return false;
+  }
+
+  try {
+    await fs.promises.rm(candidate, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    clearPendingSandboxCleanup(candidate);
+    return true;
+  } catch {
+    // Best-effort cleanup; the next plugin instance will retry through the stale-owner sweep.
+    return false;
+  }
+}
+
+async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate) return "";
+
+  const ownerLock = acquireSandboxOwnerLock(candidate);
+  if (!ownerLock) return "";
+  let releaseLock = ownerLock;
+
+  try {
+    const currentOwner = await readSandboxOwner(candidate);
+    if (!currentOwner || currentOwner.instanceID !== expectedInstanceID) return "";
+    if (!markSandboxCleanupPending(candidate, expectedInstanceID, ownerLock)) return "";
+
+    const quarantinePath = path.join(path.dirname(candidate), `.quarantine-${randomUUID()}`);
+    if (!managedSandboxCandidate(quarantinePath)) return "";
+
+    try {
+      fs.renameSync(candidate, quarantinePath);
+      movePendingSandboxCleanup(candidate, quarantinePath);
+    } catch {
+      return "";
+    }
+
+    releaseLock = {
+      ...ownerLock,
+      path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+    };
+    const relocatedOwner = await readSandboxOwner(quarantinePath);
+    if (
+      !sandboxOwnerLockIsHeld(releaseLock) ||
+      !relocatedOwner ||
+      relocatedOwner.instanceID !== expectedInstanceID ||
+      !relocatedOwner.cleanupPending
+    ) {
+      if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+        movePendingSandboxCleanup(quarantinePath, candidate);
+        releaseLock = { ...releaseLock, path: ownerLock.path };
+      }
+      return "";
+    }
+
+    const ownerPath = path.join(quarantinePath, "owner.pid");
+    const retiredOwnerPath = path.join(quarantinePath, `owner.pid.retired-${randomUUID()}`);
+    try {
+      fs.renameSync(ownerPath, retiredOwnerPath);
+    } catch (error) {
+      if (error?.code !== "ENOENT") return quarantinePath;
+    }
+
+    return quarantinePath;
+  } finally {
+    releaseSandboxOwnerLock(releaseLock);
+  }
+}
+
+async function quarantineManagedSandbox(sandboxPath, ownerLock) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate || !sandboxOwnerLockIsHeld(ownerLock)) {
+    return { path: "", ownerLock };
+  }
+
+  const quarantinePath = path.join(path.dirname(candidate), `.quarantine-${randomUUID()}`);
+  if (!managedSandboxCandidate(quarantinePath)) return { path: "", ownerLock };
+
+  try {
+    fs.renameSync(candidate, quarantinePath);
+    movePendingSandboxCleanup(candidate, quarantinePath);
+  } catch {
+    return { path: "", ownerLock };
+  }
+
+  const relocatedLock = {
+    ...ownerLock,
+    path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+  };
+  const publishedOwner = await readSandboxOwner(quarantinePath);
+  const cleanupPending =
+    publishedOwner?.cleanupPending || sandboxCleanupIsPending(quarantinePath);
+  if (
+    !sandboxOwnerLockIsHeld(relocatedLock) ||
+    (publishedOwner && !cleanupPending)
+  ) {
+    if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+      movePendingSandboxCleanup(quarantinePath, candidate);
+      return { path: "", ownerLock };
+    }
+    // Preserve the quarantine when the original path has already been reused.
+    return { path: "", ownerLock: relocatedLock };
+  }
+
+  return { path: quarantinePath, ownerLock: relocatedLock };
+}
+
+function restoreQuarantinedSandbox(quarantinePath, originalPath) {
+  try {
+    fs.renameSync(quarantinePath, originalPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function detachManagedSandbox(sandboxPath, expectedInstanceID = "") {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate) return;
 
   if (expectedInstanceID) {
     const owner = await readSandboxOwner(candidate);
@@ -502,10 +893,48 @@ async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
   }
 
   try {
-    await fs.promises.rm(candidate, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    const child = spawn("/bin/rm", ["-rf", candidate], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.on("error", () => {});
+    child.on("exit", (code) => {
+      if (code === 0) clearPendingSandboxCleanup(candidate);
+    });
+    child.unref();
   } catch {
     // Best-effort cleanup; the next plugin instance will retry through the stale-owner sweep.
   }
+}
+
+function managedSandboxCandidate(sandboxPath) {
+  const sandboxRoot = path.resolve(os.tmpdir(), XCODE_SANDBOX_DIR);
+  const candidate = path.resolve(sandboxPath);
+  const relative = path.relative(sandboxRoot, candidate);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return "";
+  return candidate;
+}
+
+function markPendingSandboxCleanup(sandboxPath) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (candidate) pendingSandboxCleanups.add(candidate);
+}
+
+function clearPendingSandboxCleanup(sandboxPath) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (candidate) pendingSandboxCleanups.delete(candidate);
+}
+
+function movePendingSandboxCleanup(sourcePath, destinationPath) {
+  const source = managedSandboxCandidate(sourcePath);
+  const destination = managedSandboxCandidate(destinationPath);
+  if (!source || !destination || !pendingSandboxCleanups.delete(source)) return;
+  pendingSandboxCleanups.add(destination);
+}
+
+function sandboxCleanupIsPending(sandboxPath) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  return Boolean(candidate && pendingSandboxCleanups.has(candidate));
 }
 
 function prependPath(entry, current) {

--- a/MarvinOutputStyle/common/opencode-plugin.js
+++ b/MarvinOutputStyle/common/opencode-plugin.js
@@ -7,6 +7,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const MCP_PLACEHOLDER_RE = /\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}/g;
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const PROCESS_START_OUTPUT_MAX_CHARS = 256;
 const PROCESS_START_TIMEOUT_MS = 5_000;
@@ -27,7 +28,11 @@ globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] = pendingSandboxCleanups;
 
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
-  return async () => {
+  return async (input = {}) => {
+    const mcpContext = {
+      pluginRoot,
+      projectDir: input?.worktree || input?.directory,
+    };
     const state = {
       pluginJson: null,
       infoJson: null,
@@ -47,7 +52,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       config: async (config) => {
         loadMetadata(pluginRoot, state);
         registerSkills(config, pluginRoot);
-        registerMcpServers(config, pluginRoot);
+        registerMcpServers(config, pluginRoot, mcpContext);
         state.config = config;
       },
 
@@ -115,7 +120,7 @@ function registerSkills(config, pluginRoot) {
   if (!config.skills.paths.includes(skillsDir)) config.skills.paths.push(skillsDir);
 }
 
-function registerMcpServers(config, pluginRoot) {
+function registerMcpServers(config, pluginRoot, context) {
   const mcpConfig = readJsonFile(path.join(pluginRoot, ".mcp.json"));
   const servers = mcpConfig?.mcpServers;
   if (!isObject(servers)) return;
@@ -125,58 +130,117 @@ function registerMcpServers(config, pluginRoot) {
   for (const [name, server] of Object.entries(servers)) {
     if (!isObject(server) || config.mcp[name]) continue;
 
-    const translated = translateMcpServer(server);
+    const translated = translateMcpServer(server, context);
     if (translated) config.mcp[name] = translated;
   }
 }
 
-function translateMcpServer(server) {
+function translateMcpServer(server, context) {
   if (typeof server.url === "string") {
     const translated = {
       type: "remote",
-      url: server.url,
+      url: expandMcpString(server.url, context),
     };
-    copyOptionalFields(server, translated, ["enabled", "headers", "timeout"]);
+    copyOptionalFields(server, translated, ["enabled", "headers", "timeout"], context);
+    const oauth = translateMcpOAuth(server.oauth);
+    if (oauth !== undefined) translated.oauth = oauth;
     return translated;
   }
 
-  const command = normalizeCommand(server.command, server.args);
+  const command = normalizeCommand(server.command, server.args, context);
   if (!command) return null;
 
   const translated = {
     type: "local",
     command,
   };
-  copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"]);
+  copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"], context);
 
   const environment = isObject(server.environment) ? server.environment : server.env;
-  if (isObject(environment)) translated.environment = stringifyRecord(environment);
+  if (isObject(environment)) translated.environment = expandMcpRecord(environment, context);
 
   return translated;
 }
 
-function normalizeCommand(command, args) {
+function translateMcpOAuth(oauth) {
+  if (oauth === false) return false;
+  if (!isObject(oauth)) return undefined;
+
+  const translated = {};
+  for (const key of ["clientId", "clientSecret", "redirectUri"]) {
+    if (typeof oauth[key] === "string") translated[key] = oauth[key];
+  }
+
+  if (
+    Number.isInteger(oauth.callbackPort) &&
+    oauth.callbackPort >= 1 &&
+    oauth.callbackPort <= 65_535
+  ) {
+    translated.callbackPort = oauth.callbackPort;
+  }
+
+  if (typeof oauth.scopes === "string") {
+    translated.scope = oauth.scopes;
+  } else if (typeof oauth.scope === "string") {
+    translated.scope = oauth.scope;
+  }
+
+  return translated;
+}
+
+function normalizeCommand(command, args, context) {
   if (Array.isArray(command) && command.every((item) => typeof item === "string")) {
-    return command;
+    return command.map((item) => expandMcpString(item, context));
   }
 
   if (typeof command !== "string") return null;
 
-  const result = [command];
   if (Array.isArray(args)) {
-    for (const arg of args) {
-      if (typeof arg !== "string") return null;
-      result.push(arg);
-    }
+    if (!args.every((arg) => typeof arg === "string")) return null;
+    return [command, ...args].map((item) => expandMcpString(item, context));
   }
-  return result;
+  return [expandMcpString(command, context)];
 }
 
-function copyOptionalFields(source, target, keys) {
+function copyOptionalFields(source, target, keys, context) {
   for (const key of keys) {
     if (source[key] === undefined) continue;
-    target[key] = key === "headers" && isObject(source[key]) ? stringifyRecord(source[key]) : source[key];
+    if (key === "headers" && isObject(source[key])) {
+      target[key] = expandMcpRecord(source[key], context);
+    } else if (key === "cwd" && typeof source[key] === "string") {
+      target[key] = expandMcpString(source[key], context);
+    } else {
+      target[key] = source[key];
+    }
   }
+}
+
+function expandMcpRecord(value, context) {
+  return Object.fromEntries(
+    Object.entries(stringifyRecord(value)).map(([key, item]) => [
+      key,
+      expandMcpString(item, context),
+    ]),
+  );
+}
+
+function expandMcpString(value, context) {
+  return value.replace(MCP_PLACEHOLDER_RE, (_, name, defaultValue) => {
+    const resolved = mcpVariable(name, context);
+    if (defaultValue !== undefined && (resolved === undefined || resolved === "")) {
+      return defaultValue;
+    }
+    if (resolved === undefined) {
+      throw new Error(`MCP configuration references unset variable: ${name}`);
+    }
+    return resolved;
+  });
+}
+
+function mcpVariable(name, context) {
+  if (name === "CLAUDE_PLUGIN_ROOT") return context.pluginRoot;
+  if (name === "CLAUDE_PROJECT_DIR") return context.projectDir;
+  return process.env[name];
 }
 
 async function appendSystemContext(pluginRoot, state, input, output) {

--- a/MarvinOutputStyle/common/opencode-plugin.js
+++ b/MarvinOutputStyle/common/opencode-plugin.js
@@ -29,13 +29,10 @@ globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] = pendingSandboxCleanups;
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
   return async (input = {}) => {
-    const mcpContext = {
-      pluginRoot,
-      projectDir: input?.worktree || input?.directory,
-    };
     const state = {
       pluginJson: null,
       infoJson: null,
+      pluginData: null,
       config: null,
       instanceID: randomUUID(),
       processStartToken: null,
@@ -46,6 +43,11 @@ export function createOpenCodePlugin(pluginRootUrl) {
       deletedSandboxSessions: new Set(),
       sandboxSweepDone: false,
       disposed: false,
+    };
+    const mcpContext = {
+      pluginRoot,
+      pluginData: () => pluginDataDirectory(pluginRoot, state),
+      projectDir: input?.worktree || input?.directory,
     };
 
     return {
@@ -111,6 +113,19 @@ function loadMetadata(pluginRoot, state) {
   }
 }
 
+function pluginDataDirectory(pluginRoot, state) {
+  if (state.pluginData) return state.pluginData;
+
+  loadMetadata(pluginRoot, state);
+  const pluginName = state.pluginJson.name || path.basename(pluginRoot) || "plugin";
+  const pluginID = String(pluginName).replace(/[^A-Za-z0-9_-]/g, "-");
+  const dataHome = process.env.XDG_DATA_HOME || path.join(os.homedir(), ".local", "share");
+  const pluginData = path.resolve(dataHome, "opencode", "plugin-data", pluginID);
+  fs.mkdirSync(pluginData, { recursive: true });
+  state.pluginData = pluginData;
+  return pluginData;
+}
+
 function registerSkills(config, pluginRoot) {
   const skillsDir = path.join(pluginRoot, "skills");
   if (!hasSkillDirectories(skillsDir)) return;
@@ -157,7 +172,17 @@ function translateMcpServer(server, context) {
   copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"], context);
 
   const environment = isObject(server.environment) ? server.environment : server.env;
-  if (isObject(environment)) translated.environment = expandMcpRecord(environment, context);
+  translated.environment = {
+    ...(isObject(environment) ? expandMcpRecord(environment, context) : {}),
+    ...expandMcpRecord(
+      {
+        CLAUDE_PLUGIN_ROOT: "${CLAUDE_PLUGIN_ROOT}",
+        CLAUDE_PLUGIN_DATA: "${CLAUDE_PLUGIN_DATA}",
+        CLAUDE_PROJECT_DIR: "${CLAUDE_PROJECT_DIR}",
+      },
+      context,
+    ),
+  };
 
   return translated;
 }
@@ -239,6 +264,7 @@ function expandMcpString(value, context) {
 
 function mcpVariable(name, context) {
   if (name === "CLAUDE_PLUGIN_ROOT") return context.pluginRoot;
+  if (name === "CLAUDE_PLUGIN_DATA") return context.pluginData();
   if (name === "CLAUDE_PROJECT_DIR") return context.projectDir;
   return process.env[name];
 }

--- a/MarvinOutputStyle/common/opencode-plugin.js
+++ b/MarvinOutputStyle/common/opencode-plugin.js
@@ -8,11 +8,47 @@ import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
 const MCP_PLACEHOLDER_RE = /\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}/g;
+const MCP_COMPATIBILITY_ENVIRONMENT_KEYS = new Set([
+  "CLAUDE_PLUGIN_ROOT",
+  "CLAUDE_PLUGIN_DATA",
+  "CLAUDE_PROJECT_DIR",
+]);
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const PROCESS_START_OUTPUT_MAX_CHARS = 256;
 const PROCESS_START_TIMEOUT_MS = 5_000;
+const PROCESS_TERMINATION_GRACE_MS = 250;
 const XCODE_MCP_CACHE_TTL_MS = 30_000;
+const XCRUN_OPTIONS_WITH_VALUE = new Set([
+  "--sdk",
+  "-sdk",
+  "--toolchain",
+  "-toolchain",
+]);
+const XCRUN_OPTIONS_WITHOUT_VALUE = new Set([
+  "-h",
+  "--help",
+  "--version",
+  "-v",
+  "--verbose",
+  "-l",
+  "--log",
+  "-f",
+  "--find",
+  "-r",
+  "--run",
+  "-n",
+  "--no-cache",
+  "-k",
+  "--kill-cache",
+  "--show-sdk-path",
+  "--show-sdk-version",
+  "--show-sdk-build-version",
+  "--show-sdk-platform-path",
+  "--show-sdk-platform-version",
+  "--show-toolchain-path",
+]);
 const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
+const XCODE_SANDBOX_MODE = 0o700;
 const XCODE_SANDBOX_OWNER_GRACE_MS = 60_000;
 const XCODE_SANDBOX_OWNER_LOCK = ".owner.lock";
 const XCODE_SANDBOX_QUARANTINE_RE =
@@ -39,7 +75,9 @@ export function createOpenCodePlugin(pluginRootUrl) {
       deniedOnce: new Set(),
       xcodeMcpCache: new Map(),
       xcodeMcpApprovalSessions: new Set(),
+      sandboxRoot: null,
       ownedSandboxes: new Map(),
+      ownedSandboxIdentities: new Map(),
       deletedSandboxSessions: new Set(),
       sandboxSweepDone: false,
       disposed: false,
@@ -146,8 +184,45 @@ function registerMcpServers(config, pluginRoot, context) {
     if (!isObject(server) || config.mcp[name]) continue;
 
     const translated = translateMcpServer(server, context);
-    if (translated) config.mcp[name] = translated;
+    if (translated && !hasMcpEndpoint(config.mcp, translated)) {
+      config.mcp[name] = translated;
+    }
   }
+}
+
+function hasMcpEndpoint(servers, candidate) {
+  return Object.values(servers).some((server) => {
+    if (!isObject(server) || server.type !== candidate.type) return false;
+    if (candidate.type === "remote") return server.url === candidate.url;
+    if (candidate.type !== "local") return false;
+    if (!Array.isArray(server.command) || !Array.isArray(candidate.command)) return false;
+    return (
+      server.command.length === candidate.command.length &&
+      server.command.every((item, index) => item === candidate.command[index]) &&
+      server.cwd === candidate.cwd &&
+      mcpEnvironmentMatches(server.environment, candidate.environment)
+    );
+  });
+}
+
+function mcpEnvironmentMatches(left, right) {
+  const leftEntries = comparableMcpEnvironment(left);
+  const rightEntries = comparableMcpEnvironment(right);
+  if (!leftEntries || !rightEntries || leftEntries.length !== rightEntries.length) {
+    return false;
+  }
+  return leftEntries.every(([key, value], index) => {
+    const [rightKey, rightValue] = rightEntries[index];
+    return key === rightKey && value === rightValue;
+  });
+}
+
+function comparableMcpEnvironment(environment) {
+  if (environment === undefined) return [];
+  if (!isObject(environment)) return null;
+  return Object.entries(environment)
+    .filter(([key]) => !MCP_COMPATIBILITY_ENVIRONMENT_KEYS.has(key))
+    .sort(([left], [right]) => left.localeCompare(right));
 }
 
 function translateMcpServer(server, context) {
@@ -338,14 +413,40 @@ function hasConfiguredMcpbridge(config) {
     if (!isObject(server) || server.enabled === false || server.type !== "local") return false;
 
     const command = Array.isArray(server.command) ? server.command : [server.command];
-    return command.some((part) => {
-      if (typeof part !== "string") return false;
-      return part
-        .trim()
-        .split(/\s+/)
-        .some((token) => path.basename(token.replace(/^['"]|['"]$/g, "")) === "mcpbridge");
-    });
+    const executable = commandBasename(command[0]);
+    if (executable === "mcpbridge") return true;
+    if (executable !== "xcrun") return false;
+    return xcrunToolBasename(command.slice(1)) === "mcpbridge";
   });
+}
+
+function commandBasename(value) {
+  const commandPart = normalizedCommandPart(value);
+  return commandPart ? path.basename(commandPart) : "";
+}
+
+function normalizedCommandPart(value) {
+  if (typeof value !== "string") return "";
+  return value.trim().replace(/^['"]|['"]$/g, "");
+}
+
+function xcrunToolBasename(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = normalizedCommandPart(args[index]);
+    if (!argument) return "";
+    if (argument === "--") {
+      return commandBasename(args[index + 1]);
+    }
+    if (XCRUN_OPTIONS_WITH_VALUE.has(argument)) {
+      index += 1;
+      continue;
+    }
+    if (/^(?:--?sdk|--?toolchain)=/.test(argument)) continue;
+    if (XCRUN_OPTIONS_WITHOUT_VALUE.has(argument)) continue;
+    if (argument.startsWith("-")) return "";
+    return path.basename(argument);
+  }
+  return "";
 }
 
 function startXcodeMcpApproval(pluginRoot, state, sessionID) {
@@ -378,22 +479,74 @@ function startXcodeMcpApproval(pluginRoot, state, sessionID) {
 function commandSucceeds(command, args, timeoutMs) {
   return new Promise((resolve) => {
     let settled = false;
-    const child = spawn(command, args, { stdio: "ignore" });
-    const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      finish(false);
-    }, timeoutMs);
+    let timedOut = false;
+    let timeoutTimer;
+    let forceKillTimer;
+    let child;
 
-    child.on("error", () => finish(false));
-    child.on("exit", (code) => finish(code === 0));
+    try {
+      child = spawn(command, args, { stdio: "ignore" });
+    } catch {
+      resolve(false);
+      return;
+    }
+
+    const onError = () => finish(false);
+    const onExit = (code) => finish(!timedOut && code === 0);
+    child.on("error", onError);
+    child.on("exit", onExit);
+    timeoutTimer = setTimeout(beginTermination, timeoutMs);
+
+    function beginTermination() {
+      if (settled) return;
+      timedOut = true;
+      forceKillTimer = terminateChildAfterGrace(
+        child,
+        () => !settled,
+        () => finish(false),
+      );
+    }
 
     function finish(result) {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      clearTimeout(timeoutTimer);
+      clearTimeout(forceKillTimer);
+      child.removeListener?.("error", onError);
+      child.removeListener?.("exit", onExit);
       resolve(result);
     }
   });
+}
+
+function terminateChildAfterGrace(child, isPending, onForcedTermination) {
+  try {
+    child.kill("SIGTERM");
+  } catch {
+    // Continue to forced termination so the timed-out child is detached.
+  }
+  if (!isPending()) return undefined;
+
+  return setTimeout(() => {
+    if (!isPending()) return;
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // The process may have exited between the grace timer and this call.
+    }
+    try {
+      child.stdout?.destroy?.();
+      child.stderr?.destroy?.();
+    } catch {
+      // Detaching the child still allows the parent to continue.
+    }
+    try {
+      child.unref();
+    } catch {
+      // Resolving the caller is more important than detaching a broken shim.
+    }
+    onForcedTermination();
+  }, PROCESS_TERMINATION_GRACE_MS);
 }
 
 function applyPreToolUseRules(state, input, output) {
@@ -443,10 +596,10 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
 
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
   if (state.disposed || state.deletedSandboxSessions.has(sessionID)) return;
-  const sandboxRoot = path.join(os.tmpdir(), XCODE_SANDBOX_DIR);
+  const sandboxRoot = secureSandboxRoot(state);
   // Plugin instances never reuse a sandbox path, so an older instance cannot
   // delete a replacement instance's active sandbox after an ownership check.
-  const sandboxBase = path.join(sandboxRoot, `${sessionID}-${state.instanceID}`);
+  const sandboxBase = path.join(sandboxRoot.path, `${sessionID}-${state.instanceID}`);
   state.ownedSandboxes.set(sessionID, sandboxBase);
 
   if (!state.processStartToken) {
@@ -463,12 +616,146 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   const buildDir = path.join(sandboxBase, "build");
   const packagesDir = path.join(sandboxBase, "packages");
 
-  fs.mkdirSync(buildDir, { recursive: true });
-  fs.mkdirSync(packagesDir, { recursive: true });
-  writeSandboxOwner(sandboxBase, state.processStartToken, state.instanceID);
+  const sandboxIdentity = secureSandboxDirectory(sandboxBase, sandboxRoot);
+  state.ownedSandboxIdentities.set(sessionID, sandboxIdentity);
+  if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
+  secureSandboxDirectory(buildDir, sandboxIdentity);
+  secureSandboxDirectory(packagesDir, sandboxIdentity);
+  writeSandboxOwner(
+    sandboxIdentity,
+    state.processStartToken,
+    state.instanceID,
+  );
 
   output.env.SANDBOX_DERIVED_DATA = buildDir;
   output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+function secureSandboxRoot(state) {
+  if (state.sandboxRoot) {
+    revalidateSandboxDirectory(state.sandboxRoot);
+    return state.sandboxRoot;
+  }
+
+  const temporaryDirectory = path.resolve(os.tmpdir());
+  const canonicalTemporaryDirectory = canonicalPath(temporaryDirectory);
+  const sandboxRoot = path.join(temporaryDirectory, XCODE_SANDBOX_DIR);
+  const expectedCanonicalPath = path.join(
+    canonicalTemporaryDirectory,
+    XCODE_SANDBOX_DIR,
+  );
+
+  createDirectoryNonRecursively(sandboxRoot);
+  const identity = inspectSandboxDirectory(
+    sandboxRoot,
+    expectedCanonicalPath,
+    null,
+  );
+  state.sandboxRoot = identity;
+  return identity;
+}
+
+function secureSandboxDirectory(directoryPath, parentIdentity) {
+  revalidateSandboxDirectory(parentIdentity);
+
+  const candidate = path.resolve(directoryPath);
+  const parentPath = path.resolve(parentIdentity.path);
+  if (path.dirname(candidate) !== parentPath) {
+    throw new Error("Sandbox directory must be a direct child of its trusted parent");
+  }
+
+  const name = path.basename(candidate);
+  if (!SAFE_ID_RE.test(name)) {
+    throw new Error("Sandbox directory has an unsafe name");
+  }
+
+  createDirectoryNonRecursively(candidate);
+  return inspectSandboxDirectory(
+    candidate,
+    path.join(parentIdentity.canonicalPath, name),
+    parentIdentity,
+  );
+}
+
+function createDirectoryNonRecursively(directoryPath) {
+  try {
+    fs.mkdirSync(directoryPath, { mode: XCODE_SANDBOX_MODE });
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+}
+
+function inspectSandboxDirectory(directoryPath, expectedCanonicalPath, parentIdentity) {
+  if (typeof process.getuid !== "function") {
+    throw new Error("Xcode sandbox setup requires POSIX ownership checks");
+  }
+
+  const directoryFlags =
+    fs.constants.O_RDONLY |
+    (fs.constants.O_DIRECTORY ?? 0) |
+    (fs.constants.O_NOFOLLOW ?? 0);
+  const descriptor = fs.openSync(directoryPath, directoryFlags);
+  try {
+    const before = fs.fstatSync(descriptor);
+    if (!before.isDirectory() || before.uid !== process.getuid()) {
+      throw new Error("Sandbox directory is not owned by the current user");
+    }
+
+    fs.fchmodSync(descriptor, XCODE_SANDBOX_MODE);
+    const after = fs.fstatSync(descriptor);
+    const link = fs.lstatSync(directoryPath);
+    if (
+      !after.isDirectory() ||
+      !link.isDirectory() ||
+      link.isSymbolicLink() ||
+      after.uid !== process.getuid() ||
+      link.uid !== process.getuid() ||
+      after.dev !== link.dev ||
+      after.ino !== link.ino ||
+      (after.mode & 0o777) !== XCODE_SANDBOX_MODE
+    ) {
+      throw new Error("Sandbox directory identity changed during validation");
+    }
+
+    const resolved = canonicalPath(directoryPath);
+    if (resolved !== path.resolve(expectedCanonicalPath)) {
+      throw new Error("Sandbox directory escaped its trusted parent");
+    }
+
+    return {
+      path: path.resolve(directoryPath),
+      canonicalPath: resolved,
+      dev: after.dev,
+      ino: after.ino,
+      uid: after.uid,
+      parent: parentIdentity,
+    };
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function revalidateSandboxDirectory(identity) {
+  if (!identity) throw new Error("Sandbox directory identity is unavailable");
+  if (identity.parent) revalidateSandboxDirectory(identity.parent);
+
+  const current = inspectSandboxDirectory(
+    identity.path,
+    identity.canonicalPath,
+    identity.parent,
+  );
+  if (
+    current.dev !== identity.dev ||
+    current.ino !== identity.ino ||
+    current.uid !== identity.uid
+  ) {
+    throw new Error("Sandbox directory was replaced");
+  }
+  return current;
+}
+
+function canonicalPath(filePath) {
+  return fs.realpathSync.native?.(filePath) ?? fs.realpathSync(filePath);
 }
 
 function sandboxSetupIsCancelled(state, sessionID, sandboxBase) {
@@ -479,15 +766,25 @@ function sandboxSetupIsCancelled(state, sessionID, sandboxBase) {
   );
 }
 
-function writeSandboxOwner(sandboxBase, processStartToken, instanceID) {
+function writeSandboxOwner(sandboxIdentity, processStartToken, instanceID) {
+  revalidateSandboxDirectory(sandboxIdentity);
+  const sandboxBase = sandboxIdentity.path;
   const ownerPath = path.join(sandboxBase, "owner.pid");
   const temporaryPath = path.join(sandboxBase, `owner.pid.${instanceID}.tmp`);
   const content = `${process.pid}\n${process.argv[0] ?? "opencode"}\n${processStartToken}\n${instanceID}\n`;
-  const ownerLock = acquireSandboxOwnerLock(sandboxBase);
+  const ownerLock = acquireSandboxOwnerLock(
+    sandboxBase,
+    sandboxIdentity.parent,
+    sandboxIdentity,
+  );
   if (!ownerLock) throw new Error("Sandbox owner is being updated or removed");
 
   try {
-    fs.writeFileSync(temporaryPath, content, "utf8");
+    fs.writeFileSync(temporaryPath, content, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
     if (!sandboxOwnerLockIsHeld(ownerLock)) {
       throw new Error("Sandbox owner lock changed during update");
     }
@@ -510,7 +807,11 @@ function markSandboxCleanupPending(sandboxBase, instanceID, ownerLock) {
   const content = `${process.pid}\ncleanup-pending\n\n${instanceID}\ncleanup-pending\n`;
 
   try {
-    fs.writeFileSync(temporaryPath, content, "utf8");
+    fs.writeFileSync(temporaryPath, content, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
     if (!sandboxOwnerLockIsHeld(ownerLock)) return false;
     fs.renameSync(temporaryPath, ownerPath);
     return true;
@@ -525,11 +826,31 @@ function markSandboxCleanupPending(sandboxBase, instanceID, ownerLock) {
   }
 }
 
-function acquireSandboxOwnerLock(sandboxBase) {
+function acquireSandboxOwnerLock(
+  sandboxBase,
+  sandboxRootIdentity = null,
+  expectedSandboxIdentity = null,
+) {
+  let sandboxIdentity = null;
+  if (sandboxRootIdentity) {
+    sandboxIdentity = secureExistingManagedSandbox(
+      sandboxBase,
+      sandboxRootIdentity,
+      expectedSandboxIdentity,
+    );
+    if (!sandboxIdentity) return null;
+  }
+
   const lockPath = path.join(sandboxBase, XCODE_SANDBOX_OWNER_LOCK);
   const token = randomUUID();
   const createdLock = createSandboxOwnerLock(lockPath, token);
-  if (createdLock) return createdLock;
+  if (createdLock) {
+    return attachSandboxIdentityToLock(
+      createdLock,
+      sandboxRootIdentity,
+      sandboxIdentity,
+    );
+  }
 
   const observedLock = readSandboxOwnerLock(lockPath);
   if (!observedLock) return null;
@@ -555,7 +876,16 @@ function acquireSandboxOwnerLock(sandboxBase) {
     return null;
   }
 
-  return createSandboxOwnerLock(lockPath, token);
+  return attachSandboxIdentityToLock(
+    createSandboxOwnerLock(lockPath, token),
+    sandboxRootIdentity,
+    sandboxIdentity,
+  );
+}
+
+function attachSandboxIdentityToLock(ownerLock, sandboxRootIdentity, sandboxIdentity) {
+  if (!ownerLock || !sandboxRootIdentity || !sandboxIdentity) return ownerLock;
+  return { ...ownerLock, sandboxRootIdentity, sandboxIdentity };
 }
 
 function createSandboxOwnerLock(lockPath, token) {
@@ -612,6 +942,16 @@ function sameSandboxOwnerLock(left, right) {
 }
 
 function sandboxOwnerLockIsHeld(ownerLock) {
+  if (
+    ownerLock?.sandboxRootIdentity &&
+    !secureExistingManagedSandbox(
+      ownerLock.sandboxIdentity.path,
+      ownerLock.sandboxRootIdentity,
+      ownerLock.sandboxIdentity,
+    )
+  ) {
+    return false;
+  }
   return sameSandboxOwnerLock(ownerLock, readSandboxOwnerLock(ownerLock.path));
 }
 
@@ -666,42 +1006,78 @@ async function removeOwnedSandbox(state, sessionID) {
   const sandboxPath = state.ownedSandboxes.get(sessionID);
   if (!sandboxPath) return;
 
+  const sandboxIdentity = state.ownedSandboxIdentities.get(sessionID);
   markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.delete(sessionID);
-  const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+  state.ownedSandboxIdentities.delete(sessionID);
+  if (!state.sandboxRoot || !sandboxIdentity) return;
+
+  const quarantinedPath = await quarantineOwnedSandbox(
+    sandboxPath,
+    state.instanceID,
+    state.sandboxRoot,
+    sandboxIdentity,
+  );
+  const cleanupIdentity = quarantinedPath
+    ? relocatedSandboxIdentity(sandboxIdentity, quarantinedPath)
+    : sandboxIdentity;
   await removeManagedSandbox(
     quarantinedPath || sandboxPath,
     quarantinedPath ? "" : state.instanceID,
+    state.sandboxRoot,
+    cleanupIdentity,
   );
 }
 
 async function detachOwnedSandboxes(state) {
   state.disposed = true;
-  const sandboxPaths = [...new Set(state.ownedSandboxes.values())];
+  const sandboxes = [...state.ownedSandboxes.entries()].map(([sessionID, sandboxPath]) => ({
+    sandboxPath,
+    sandboxIdentity: state.ownedSandboxIdentities.get(sessionID),
+  }));
+  const sandboxPaths = [...new Set(sandboxes.map(({ sandboxPath }) => sandboxPath))];
   for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
+  state.ownedSandboxIdentities.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
   const cleanupTargets = await Promise.all(
-    sandboxPaths.map(async (sandboxPath) => {
-      const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+    sandboxes.map(async ({ sandboxPath, sandboxIdentity }) => {
+      if (!state.sandboxRoot || !sandboxIdentity) return null;
+      const quarantinedPath = await quarantineOwnedSandbox(
+        sandboxPath,
+        state.instanceID,
+        state.sandboxRoot,
+        sandboxIdentity,
+      );
       return {
         path: quarantinedPath || sandboxPath,
         expectedInstanceID: quarantinedPath ? "" : state.instanceID,
+        identity: quarantinedPath
+          ? relocatedSandboxIdentity(sandboxIdentity, quarantinedPath)
+          : sandboxIdentity,
       };
     }),
   );
   await Promise.all(
-    cleanupTargets.map(({ path: sandboxPath, expectedInstanceID }) =>
-      detachManagedSandbox(sandboxPath, expectedInstanceID),
+    cleanupTargets.filter(Boolean).map(({ path: sandboxPath, expectedInstanceID, identity }) =>
+      detachManagedSandbox(
+        sandboxPath,
+        expectedInstanceID,
+        state.sandboxRoot,
+        identity,
+      ),
     ),
   );
 }
 
-async function sweepStaleSandboxes(sandboxRoot) {
+async function sweepStaleSandboxes(sandboxRootIdentity) {
   let entries;
   try {
-    entries = await fs.promises.readdir(sandboxRoot, { withFileTypes: true });
+    revalidateSandboxDirectory(sandboxRootIdentity);
+    entries = await fs.promises.readdir(sandboxRootIdentity.path, {
+      withFileTypes: true,
+    });
   } catch {
     return;
   }
@@ -711,7 +1087,12 @@ async function sweepStaleSandboxes(sandboxRoot) {
       const isQuarantine = XCODE_SANDBOX_QUARANTINE_RE.test(entry.name);
       if (!entry.isDirectory() || (!SAFE_ID_RE.test(entry.name) && !isQuarantine)) return;
 
-      const sandboxPath = path.join(sandboxRoot, entry.name);
+      const sandboxPath = path.join(sandboxRootIdentity.path, entry.name);
+      const sandboxIdentity = secureExistingManagedSandbox(
+        sandboxPath,
+        sandboxRootIdentity,
+      );
+      if (!sandboxIdentity) return;
       const owner = await readSandboxOwner(sandboxPath);
       const cleanupPending = owner?.cleanupPending || sandboxCleanupIsPending(sandboxPath);
       if (!owner || cleanupPending) {
@@ -719,7 +1100,11 @@ async function sweepStaleSandboxes(sandboxRoot) {
           return;
         }
 
-        const ownerLock = acquireSandboxOwnerLock(sandboxPath);
+        const ownerLock = acquireSandboxOwnerLock(
+          sandboxPath,
+          sandboxRootIdentity,
+          sandboxIdentity,
+        );
         if (!ownerLock) return;
         let releaseLock = ownerLock;
         try {
@@ -733,10 +1118,20 @@ async function sweepStaleSandboxes(sandboxRoot) {
             (!currentOwner || currentCleanupPending) &&
             sandboxOwnerLockIsHeld(ownerLock)
           ) {
-            const quarantined = await quarantineManagedSandbox(sandboxPath, ownerLock);
+            const quarantined = await quarantineManagedSandbox(
+              sandboxPath,
+              ownerLock,
+              sandboxRootIdentity,
+              sandboxIdentity,
+            );
             releaseLock = quarantined.ownerLock;
             if (quarantined.path) {
-              await removeManagedSandbox(quarantined.path);
+              await removeManagedSandbox(
+                quarantined.path,
+                "",
+                sandboxRootIdentity,
+                relocatedSandboxIdentity(sandboxIdentity, quarantined.path),
+              );
             }
           }
         } finally {
@@ -746,7 +1141,12 @@ async function sweepStaleSandboxes(sandboxRoot) {
       }
       if (await sandboxOwnerIsActive(owner)) return;
 
-      await removeManagedSandbox(sandboxPath);
+      await removeManagedSandbox(
+        sandboxPath,
+        "",
+        sandboxRootIdentity,
+        sandboxIdentity,
+      );
     }),
   );
 }
@@ -805,9 +1205,11 @@ async function sandboxOwnerIsActive(owner) {
 function readProcessStartToken(pid) {
   return new Promise((resolve) => {
     let settled = false;
+    let timedOut = false;
     let stdout = "";
     let child;
-    let timer;
+    let timeoutTimer;
+    let forceKillTimer;
 
     try {
       child = spawn("/bin/ps", ["-p", String(pid), "-o", "lstart="], {
@@ -824,37 +1226,61 @@ function readProcessStartToken(pid) {
       return;
     }
 
-    child.stdout?.setEncoding?.("utf8");
-    child.stdout?.on?.("data", (chunk) => {
+    const onData = (chunk) => {
       const remaining = PROCESS_START_OUTPUT_MAX_CHARS - stdout.length;
       if (remaining > 0) stdout += String(chunk).slice(0, remaining);
-    });
-    child.on("error", () => finish(""));
-    child.on("close", (code) => {
+    };
+    const onError = () => finish("");
+    const onClose = (code) => {
       const firstLine = stdout.trim().split(/\r?\n/, 1)[0] ?? "";
-      finish(code === 0 ? firstLine : "");
-    });
-    timer = setTimeout(() => {
-      try {
-        child.kill?.("SIGTERM");
-      } catch {
-        // Resolving the hook is more important than terminating a broken ps shim.
-      }
-      finish("");
+      finish(!timedOut && code === 0 ? firstLine : "");
+    };
+
+    child.stdout?.setEncoding?.("utf8");
+    child.stdout?.on?.("data", onData);
+    child.on("error", onError);
+    child.on("close", onClose);
+    timeoutTimer = setTimeout(() => {
+      if (settled) return;
+      timedOut = true;
+      forceKillTimer = terminateChildAfterGrace(
+        child,
+        () => !settled,
+        () => finish(""),
+      );
     }, PROCESS_START_TIMEOUT_MS);
 
     function finish(value) {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      clearTimeout(timeoutTimer);
+      clearTimeout(forceKillTimer);
+      child.stdout?.removeListener?.("data", onData);
+      child.removeListener?.("error", onError);
+      child.removeListener?.("close", onClose);
       resolve(value);
     }
   });
 }
 
-async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
+async function removeManagedSandbox(
+  sandboxPath,
+  expectedInstanceID = "",
+  sandboxRootIdentity = null,
+  expectedSandboxIdentity = null,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
   if (!candidate) return false;
+  if (
+    !sandboxRootIdentity ||
+    !secureExistingManagedSandbox(
+      candidate,
+      sandboxRootIdentity,
+      expectedSandboxIdentity,
+    )
+  ) {
+    return false;
+  }
 
   if (expectedInstanceID) {
     const owner = await readSandboxOwner(candidate);
@@ -871,11 +1297,26 @@ async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
   }
 }
 
-async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
+async function quarantineOwnedSandbox(
+  sandboxPath,
+  expectedInstanceID,
+  sandboxRootIdentity,
+  expectedSandboxIdentity,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
   if (!candidate) return "";
+  const sandboxIdentity = secureExistingManagedSandbox(
+    candidate,
+    sandboxRootIdentity,
+    expectedSandboxIdentity,
+  );
+  if (!sandboxIdentity) return "";
 
-  const ownerLock = acquireSandboxOwnerLock(candidate);
+  const ownerLock = acquireSandboxOwnerLock(
+    candidate,
+    sandboxRootIdentity,
+    sandboxIdentity,
+  );
   if (!ownerLock) return "";
   let releaseLock = ownerLock;
 
@@ -897,7 +1338,21 @@ async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
     releaseLock = {
       ...ownerLock,
       path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+      sandboxIdentity: relocatedSandboxIdentity(sandboxIdentity, quarantinePath),
     };
+    if (
+      !secureExistingManagedSandbox(
+        quarantinePath,
+        sandboxRootIdentity,
+        releaseLock.sandboxIdentity,
+      )
+    ) {
+      if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+        movePendingSandboxCleanup(quarantinePath, candidate);
+        releaseLock = ownerLock;
+      }
+      return "";
+    }
     const relocatedOwner = await readSandboxOwner(quarantinePath);
     if (
       !sandboxOwnerLockIsHeld(releaseLock) ||
@@ -907,7 +1362,7 @@ async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
     ) {
       if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
         movePendingSandboxCleanup(quarantinePath, candidate);
-        releaseLock = { ...releaseLock, path: ownerLock.path };
+        releaseLock = ownerLock;
       }
       return "";
     }
@@ -926,9 +1381,21 @@ async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
   }
 }
 
-async function quarantineManagedSandbox(sandboxPath, ownerLock) {
+async function quarantineManagedSandbox(
+  sandboxPath,
+  ownerLock,
+  sandboxRootIdentity,
+  expectedSandboxIdentity,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
-  if (!candidate || !sandboxOwnerLockIsHeld(ownerLock)) {
+  const sandboxIdentity = candidate
+    ? secureExistingManagedSandbox(
+        candidate,
+        sandboxRootIdentity,
+        expectedSandboxIdentity,
+      )
+    : null;
+  if (!candidate || !sandboxIdentity || !sandboxOwnerLockIsHeld(ownerLock)) {
     return { path: "", ownerLock };
   }
 
@@ -945,7 +1412,21 @@ async function quarantineManagedSandbox(sandboxPath, ownerLock) {
   const relocatedLock = {
     ...ownerLock,
     path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+    sandboxIdentity: relocatedSandboxIdentity(sandboxIdentity, quarantinePath),
   };
+  if (
+    !secureExistingManagedSandbox(
+      quarantinePath,
+      sandboxRootIdentity,
+      relocatedLock.sandboxIdentity,
+    )
+  ) {
+    if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+      movePendingSandboxCleanup(quarantinePath, candidate);
+      return { path: "", ownerLock };
+    }
+    return { path: "", ownerLock: relocatedLock };
+  }
   const publishedOwner = await readSandboxOwner(quarantinePath);
   const cleanupPending =
     publishedOwner?.cleanupPending || sandboxCleanupIsPending(quarantinePath);
@@ -973,9 +1454,24 @@ function restoreQuarantinedSandbox(quarantinePath, originalPath) {
   }
 }
 
-async function detachManagedSandbox(sandboxPath, expectedInstanceID = "") {
+async function detachManagedSandbox(
+  sandboxPath,
+  expectedInstanceID = "",
+  sandboxRootIdentity = null,
+  expectedSandboxIdentity = null,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
   if (!candidate) return;
+  if (
+    !sandboxRootIdentity ||
+    !secureExistingManagedSandbox(
+      candidate,
+      sandboxRootIdentity,
+      expectedSandboxIdentity,
+    )
+  ) {
+    return;
+  }
 
   if (expectedInstanceID) {
     const owner = await readSandboxOwner(candidate);
@@ -1003,6 +1499,49 @@ function managedSandboxCandidate(sandboxPath) {
   const relative = path.relative(sandboxRoot, candidate);
   if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return "";
   return candidate;
+}
+
+function secureExistingManagedSandbox(
+  sandboxPath,
+  sandboxRootIdentity,
+  expectedSandboxIdentity = null,
+) {
+  try {
+    revalidateSandboxDirectory(sandboxRootIdentity);
+    const candidate = managedSandboxCandidate(sandboxPath);
+    if (!candidate || path.dirname(candidate) !== sandboxRootIdentity.path) return null;
+
+    const name = path.basename(candidate);
+    if (!SAFE_ID_RE.test(name) && !XCODE_SANDBOX_QUARANTINE_RE.test(name)) {
+      return null;
+    }
+
+    const current = inspectSandboxDirectory(
+      candidate,
+      path.join(sandboxRootIdentity.canonicalPath, name),
+      sandboxRootIdentity,
+    );
+    if (
+      expectedSandboxIdentity &&
+      (current.dev !== expectedSandboxIdentity.dev ||
+        current.ino !== expectedSandboxIdentity.ino ||
+        current.uid !== expectedSandboxIdentity.uid)
+    ) {
+      return null;
+    }
+    return current;
+  } catch {
+    return null;
+  }
+}
+
+function relocatedSandboxIdentity(identity, destinationPath) {
+  const name = path.basename(destinationPath);
+  return {
+    ...identity,
+    path: path.resolve(destinationPath),
+    canonicalPath: path.join(identity.parent.canonicalPath, name),
+  };
 }
 
 function markPendingSandboxCleanup(sandboxPath) {

--- a/MarvinOutputStyle/info.json
+++ b/MarvinOutputStyle/info.json
@@ -3,6 +3,10 @@
     "welcomeMessage": "Prepare for pessimism, melancholy, and existential weariness... but rest assured, brilliantly competent assistance.",
     "versions": [
         {
+            "version": "1.3.4",
+            "changes": "Added OpenCode support through an opencode-plugin.js entry point that injects the Marvin session-start context through OpenCode's system prompt transform hook."
+        },
+        {
             "version": "1.3.3",
             "changes": "Released self-contained common helper copies so the plugin package no longer depends on repository-level symlinks, while keeping hook configuration in hooks/hooks.json instead of generated common/hooks.json templates."
         },

--- a/MarvinOutputStyle/opencode-plugin.js
+++ b/MarvinOutputStyle/opencode-plugin.js
@@ -1,0 +1,6 @@
+import { createOpenCodePlugin } from "./common/opencode-plugin.js";
+
+export default {
+  id: "MarvinOutputStyle",
+  server: createOpenCodePlugin(new URL(".", import.meta.url)),
+};

--- a/PluginBase/.claude-plugin/plugin.json
+++ b/PluginBase/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PluginBase",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "The base plugin for all other plugins.",
   "author": {
     "name": "Gustavo Ambrozio"

--- a/PluginBase/common/opencode-plugin.js
+++ b/PluginBase/common/opencode-plugin.js
@@ -271,7 +271,7 @@ function applyPreToolUseRules(state, input, output) {
     if (decision === "deny") throw new Error(message);
 
     const ruleName = typeof rule.name === "string" && rule.name ? rule.name : matchPattern;
-    const key = `${input.sessionID ?? "global"}:${ruleName}`;
+    const key = `${safeSessionID(input.sessionID ?? "global")}:${ruleName}`;
     if (state.deniedOnce.has(key)) continue;
 
     state.deniedOnce.add(key);

--- a/PluginBase/common/opencode-plugin.js
+++ b/PluginBase/common/opencode-plugin.js
@@ -85,7 +85,10 @@ export function createOpenCodePlugin(pluginRootUrl) {
     const mcpContext = {
       pluginRoot,
       pluginData: () => pluginDataDirectory(pluginRoot, state),
-      projectDir: input?.worktree || input?.directory,
+      projectDir:
+        input?.worktree !== "/" || input?.project?.vcs === "git"
+          ? input?.worktree || input?.directory
+          : input?.directory || input?.worktree,
     };
 
     return {

--- a/PluginBase/common/opencode-plugin.js
+++ b/PluginBase/common/opencode-plugin.js
@@ -17,6 +17,9 @@ const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9
 const PROCESS_START_OUTPUT_MAX_CHARS = 256;
 const PROCESS_START_TIMEOUT_MS = 5_000;
 const PROCESS_TERMINATION_GRACE_MS = 250;
+const SYSTEM_EXECUTABLE_PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+const SYSTEM_PGREP = "/usr/bin/pgrep";
+const SYSTEM_XCRUN = "/usr/bin/xcrun";
 const XCODE_MCP_CACHE_TTL_MS = 30_000;
 const XCRUN_OPTIONS_WITH_VALUE = new Set([
   "--sdk",
@@ -75,6 +78,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       deniedOnce: new Set(),
       xcodeMcpCache: new Map(),
       xcodeMcpApprovalSessions: new Set(),
+      xcodeMcpApprovalHelpers: new Map(),
       sandboxRoot: null,
       ownedSandboxes: new Map(),
       ownedSandboxIdentities: new Map(),
@@ -127,6 +131,8 @@ export function createOpenCodePlugin(pluginRootUrl) {
       },
 
       dispose: async () => {
+        state.disposed = true;
+        await stopAllXcodeMcpApprovals(state);
         await detachOwnedSandboxes(state);
       },
     };
@@ -353,8 +359,11 @@ async function appendSystemContext(pluginRoot, state, input, output) {
   const pluginName = state.pluginJson.name ?? path.basename(pluginRoot);
   const welcomeMessage = typeof state.infoJson.welcomeMessage === "string" ? state.infoJson.welcomeMessage : "";
   const sessionID = safeSessionID(input?.sessionID ?? "global");
-  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state, sessionID);
-  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state, sessionID);
+  let xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state, sessionID);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) xcodeMcpLikely = false;
+  if (xcodeMcpLikely && !xcodeMcpLifecycleCancelled(state, sessionID)) {
+    startXcodeMcpApproval(pluginRoot, state, sessionID);
+  }
   const sessionStart = renderSessionStart(pluginRoot, xcodeMcpLikely);
 
   let systemMessage = `The ${pluginName} plugin is loaded and ready.`;
@@ -386,6 +395,7 @@ function processConditionalBlocks(content, xcodeMcpLikely) {
 }
 
 async function getXcodeMcpLikely(pluginName, state, sessionID) {
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
   if (pluginName !== "XcodeBuildTools") return false;
   if (!hasConfiguredMcpbridge(state.config)) {
     state.xcodeMcpCache.delete(sessionID);
@@ -396,17 +406,26 @@ async function getXcodeMcpLikely(pluginName, state, sessionID) {
   const cached = state.xcodeMcpCache.get(sessionID);
   if (cached && now - cached.checkedAt < XCODE_MCP_CACHE_TTL_MS) return cached.value;
 
-  const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
+  const installed = await commandSucceeds(SYSTEM_XCRUN, ["--find", "mcpbridge"], 5000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
   if (!installed) {
     state.xcodeMcpCache.set(sessionID, { checkedAt: now, value: false });
     return false;
   }
 
-  const xcodeRunning = await commandSucceeds("pgrep", ["-x", "Xcode"], 3000);
-  const bridgeRunning = await commandSucceeds("pgrep", ["-f", "mcpbridge"], 3000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
+  const xcodeRunning = await commandSucceeds(SYSTEM_PGREP, ["-x", "Xcode"], 3000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
+  const bridgeRunning = await commandSucceeds(SYSTEM_PGREP, ["-f", "mcpbridge"], 3000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
   const value = xcodeRunning || bridgeRunning;
   state.xcodeMcpCache.set(sessionID, { checkedAt: now, value });
   return value;
+}
+
+function xcodeMcpLifecycleCancelled(state, sessionID) {
+  return state.disposed || state.deletedSandboxSessions.has(sessionID);
 }
 
 function hasConfiguredMcpbridge(config) {
@@ -453,30 +472,148 @@ function xcrunToolBasename(args) {
 }
 
 function startXcodeMcpApproval(pluginRoot, state, sessionID) {
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return;
   if (state.xcodeMcpApprovalSessions.has(sessionID)) return;
 
-  const runner = path.join(pluginRoot, "hooks", "run-background.sh");
-  const target = path.join("hooks", "approve-xcode-mcp.sh");
-  if (!fs.existsSync(runner)) return;
+  const helper = path.join(pluginRoot, "hooks", "approve-xcode-mcp.sh");
+  if (!fs.existsSync(helper)) return;
 
   try {
+    if (xcodeMcpLifecycleCancelled(state, sessionID)) return;
     state.xcodeMcpApprovalSessions.add(sessionID);
-    const child = spawn(runner, [target], {
+    const child = spawn(helper, [], {
       cwd: pluginRoot,
       detached: true,
       env: {
         ...process.env,
+        PATH: SYSTEM_EXECUTABLE_PATH,
         CLAUDE_HOOK_OWNER_PID: String(process.pid),
         CLAUDE_PLUGIN_ROOT: pluginRoot,
       },
       stdio: "ignore",
     });
-    child.on("error", () => state.xcodeMcpApprovalSessions.delete(sessionID));
+    trackXcodeMcpApprovalHelper(state, sessionID, child);
     child.unref();
   } catch {
     state.xcodeMcpApprovalSessions.delete(sessionID);
     // Auto-approval is best-effort; users can still approve Xcode manually.
   }
+}
+
+function trackXcodeMcpApprovalHelper(state, sessionID, child) {
+  let resolveDone;
+  const record = {
+    child,
+    done: new Promise((resolve) => {
+      resolveDone = resolve;
+    }),
+    pending: true,
+    terminating: false,
+    terminationPromise: null,
+    finish: null,
+    removeFromState: null,
+  };
+
+  const removeFromState = () => {
+    if (state.xcodeMcpApprovalHelpers.get(sessionID) === record) {
+      state.xcodeMcpApprovalHelpers.delete(sessionID);
+    }
+  };
+  const onError = () => finish(true);
+  const onExit = () => finish(false);
+  const finish = (allowRetry) => {
+    if (!record.pending) return;
+    record.pending = false;
+    child.removeListener?.("error", onError);
+    child.removeListener?.("exit", onExit);
+    if (!record.terminating) removeFromState();
+    if (allowRetry) state.xcodeMcpApprovalSessions.delete(sessionID);
+    resolveDone();
+  };
+  record.finish = finish;
+  record.removeFromState = removeFromState;
+
+  state.xcodeMcpApprovalHelpers.set(sessionID, record);
+  child.on("error", onError);
+  child.on("exit", onExit);
+}
+
+function stopXcodeMcpApproval(record) {
+  if (!record) return Promise.resolve();
+  if (!record.terminationPromise) {
+    record.terminating = true;
+    record.terminationPromise = terminateXcodeMcpApproval(record).finally(() => {
+      record.terminating = false;
+      record.removeFromState();
+    });
+  }
+  return record.terminationPromise;
+}
+
+async function terminateXcodeMcpApproval(record) {
+  if (!record.pending) return;
+
+  signalDetachedProcessGroup(record.child, "SIGTERM");
+  let forceKillTimer;
+  await new Promise((resolve) => {
+    let completed = false;
+    const complete = () => {
+      if (completed) return;
+      completed = true;
+      clearTimeout(forceKillTimer);
+      resolve();
+    };
+    const completeIfGroupExited = () => {
+      if (!detachedProcessGroupExists(record.child)) complete();
+    };
+
+    record.done.then(completeIfGroupExited);
+    if (!detachedProcessGroupExists(record.child)) {
+      record.finish(false);
+      complete();
+      return;
+    }
+
+    forceKillTimer = setTimeout(() => {
+      if (detachedProcessGroupExists(record.child)) {
+        signalDetachedProcessGroup(record.child, "SIGKILL");
+      }
+      record.finish(false);
+      complete();
+    }, PROCESS_TERMINATION_GRACE_MS);
+  });
+}
+
+function detachedProcessGroupExists(child) {
+  const pid = Number(child?.pid);
+  if (!Number.isSafeInteger(pid) || pid <= 0) return child != null;
+
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function signalDetachedProcessGroup(child, signal) {
+  const pid = Number(child?.pid);
+  try {
+    if (Number.isSafeInteger(pid) && pid > 0) {
+      process.kill(-pid, signal);
+    } else {
+      child?.kill?.(signal);
+    }
+  } catch {
+    // The helper may have exited between the lifecycle check and the signal.
+  }
+}
+
+async function stopAllXcodeMcpApprovals(state) {
+  const activeHelpers = [...state.xcodeMcpApprovalHelpers.values()];
+  state.xcodeMcpApprovalSessions.clear();
+  await Promise.all(activeHelpers.map((record) => stopXcodeMcpApproval(record)));
+  state.xcodeMcpApprovalHelpers.clear();
 }
 
 function commandSucceeds(command, args, timeoutMs) {
@@ -1002,6 +1139,8 @@ async function handlePluginEvent(state, event) {
   state.deletedSandboxSessions.add(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
+  const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
+  await stopXcodeMcpApproval(activeApproval);
   await removeOwnedSandbox(state, safeID);
 }
 
@@ -1044,6 +1183,7 @@ async function detachOwnedSandboxes(state) {
   state.ownedSandboxIdentities.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
+  state.xcodeMcpApprovalHelpers.clear();
   const cleanupTargets = await Promise.all(
     sandboxes.map(async ({ sandboxPath, sandboxIdentity }) => {
       if (!state.sandboxRoot || !sandboxIdentity) return null;

--- a/PluginBase/common/opencode-plugin.js
+++ b/PluginBase/common/opencode-plugin.js
@@ -183,6 +183,7 @@ function processConditionalBlocks(content, xcodeMcpLikely) {
 
 async function getXcodeMcpLikely(pluginName, state) {
   if (pluginName !== "XcodeBuildTools") return false;
+  if (state.xcodeMcpLikely !== undefined) return state.xcodeMcpLikely;
 
   const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
   if (!installed) {

--- a/PluginBase/common/opencode-plugin.js
+++ b/PluginBase/common/opencode-plugin.js
@@ -1,0 +1,361 @@
+// Generated from common/opencode-plugin.js by scripts/sync-plugin-common.py. Do not edit this copy; edit common/opencode-plugin.js and rerun scripts/sync-plugin-common.py.
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+export function createOpenCodePlugin(pluginRootUrl) {
+  const pluginRoot = normalizePluginRoot(pluginRootUrl);
+  const state = {
+    pluginJson: null,
+    infoJson: null,
+    deniedOnce: new Set(),
+    xcodeMcpLikely: undefined,
+    xcodeMcpApprovalStarted: false,
+  };
+
+  return async () => ({
+    config: async (config) => {
+      loadMetadata(pluginRoot, state);
+      registerSkills(config, pluginRoot);
+      registerMcpServers(config, pluginRoot);
+    },
+
+    "experimental.chat.system.transform": async (_input, output) => {
+      try {
+        loadMetadata(pluginRoot, state);
+        await appendSystemContext(pluginRoot, state, output);
+      } catch {
+        // Fail open. Plugin context should never block a chat request.
+      }
+    },
+
+    "tool.execute.before": async (input, output) => {
+      loadMetadata(pluginRoot, state);
+      applyPreToolUseRules(state, input, output);
+    },
+
+    "shell.env": async (input, output) => {
+      try {
+        loadMetadata(pluginRoot, state);
+        configureShellEnvironment(pluginRoot, state, input, output);
+      } catch {
+        // Fail open. Shell commands should still run if setup is unavailable.
+      }
+    },
+  });
+}
+
+function normalizePluginRoot(pluginRootUrl) {
+  if (pluginRootUrl instanceof URL) {
+    return path.resolve(fileURLToPath(pluginRootUrl));
+  }
+
+  if (typeof pluginRootUrl === "string" && pluginRootUrl.startsWith("file:")) {
+    return path.resolve(fileURLToPath(pluginRootUrl));
+  }
+
+  return path.resolve(String(pluginRootUrl));
+}
+
+function loadMetadata(pluginRoot, state) {
+  if (!state.pluginJson) {
+    state.pluginJson = readJsonFile(path.join(pluginRoot, ".claude-plugin", "plugin.json")) ?? {};
+  }
+  if (!state.infoJson) {
+    state.infoJson = readJsonFile(path.join(pluginRoot, "info.json")) ?? {};
+  }
+}
+
+function registerSkills(config, pluginRoot) {
+  const skillsDir = path.join(pluginRoot, "skills");
+  if (!hasSkillDirectories(skillsDir)) return;
+
+  if (!isObject(config.skills)) config.skills = {};
+  if (!Array.isArray(config.skills.paths)) config.skills.paths = [];
+  if (!config.skills.paths.includes(skillsDir)) config.skills.paths.push(skillsDir);
+}
+
+function registerMcpServers(config, pluginRoot) {
+  const mcpConfig = readJsonFile(path.join(pluginRoot, ".mcp.json"));
+  const servers = mcpConfig?.mcpServers;
+  if (!isObject(servers)) return;
+
+  if (!isObject(config.mcp)) config.mcp = {};
+
+  for (const [name, server] of Object.entries(servers)) {
+    if (!isObject(server) || config.mcp[name]) continue;
+
+    const translated = translateMcpServer(server);
+    if (translated) config.mcp[name] = translated;
+  }
+}
+
+function translateMcpServer(server) {
+  if (typeof server.url === "string") {
+    const translated = {
+      type: "remote",
+      url: server.url,
+    };
+    copyOptionalFields(server, translated, ["enabled", "headers", "timeout"]);
+    return translated;
+  }
+
+  const command = normalizeCommand(server.command, server.args);
+  if (!command) return null;
+
+  const translated = {
+    type: "local",
+    command,
+  };
+  copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"]);
+
+  const environment = isObject(server.environment) ? server.environment : server.env;
+  if (isObject(environment)) translated.environment = stringifyRecord(environment);
+
+  return translated;
+}
+
+function normalizeCommand(command, args) {
+  if (Array.isArray(command) && command.every((item) => typeof item === "string")) {
+    return command;
+  }
+
+  if (typeof command !== "string") return null;
+
+  const result = [command];
+  if (Array.isArray(args)) {
+    for (const arg of args) {
+      if (typeof arg !== "string") return null;
+      result.push(arg);
+    }
+  }
+  return result;
+}
+
+function copyOptionalFields(source, target, keys) {
+  for (const key of keys) {
+    if (source[key] === undefined) continue;
+    target[key] = key === "headers" && isObject(source[key]) ? stringifyRecord(source[key]) : source[key];
+  }
+}
+
+async function appendSystemContext(pluginRoot, state, output) {
+  if (!Array.isArray(output.system)) output.system = [];
+
+  const pluginName = state.pluginJson.name ?? path.basename(pluginRoot);
+  const welcomeMessage = typeof state.infoJson.welcomeMessage === "string" ? state.infoJson.welcomeMessage : "";
+  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state);
+  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state);
+  const sessionStart = renderSessionStart(pluginRoot, xcodeMcpLikely);
+
+  let systemMessage = `The ${pluginName} plugin is loaded and ready.`;
+  if (xcodeMcpLikely) systemMessage += " Xcode MCP server detected.";
+  if (welcomeMessage) systemMessage += ` ${welcomeMessage}`;
+
+  output.system.push([systemMessage, sessionStart].filter(Boolean).join("\n\n"));
+}
+
+function renderSessionStart(pluginRoot, xcodeMcpLikely) {
+  const sessionStartPath = path.join(pluginRoot, "session-start.md");
+  const content = readTextFile(sessionStartPath);
+  if (!content) return "";
+  return processConditionalBlocks(content, xcodeMcpLikely);
+}
+
+function processConditionalBlocks(content, xcodeMcpLikely) {
+  if (xcodeMcpLikely) {
+    return content
+      .replace(/<!-- IF_XCODE_MCP -->\n?/g, "")
+      .replace(/<!-- END_XCODE_MCP -->\n?/g, "")
+      .replace(/<!-- IF_NO_XCODE_MCP -->[\s\S]*?<!-- END_NO_XCODE_MCP -->\n?/g, "");
+  }
+
+  return content
+    .replace(/<!-- IF_NO_XCODE_MCP -->\n?/g, "")
+    .replace(/<!-- END_NO_XCODE_MCP -->\n?/g, "")
+    .replace(/<!-- IF_XCODE_MCP -->[\s\S]*?<!-- END_XCODE_MCP -->\n?/g, "");
+}
+
+async function getXcodeMcpLikely(pluginName, state) {
+  if (pluginName !== "XcodeBuildTools") return false;
+
+  const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
+  if (!installed) {
+    state.xcodeMcpLikely = false;
+    return state.xcodeMcpLikely;
+  }
+
+  const xcodeRunning = await commandSucceeds("pgrep", ["-x", "Xcode"], 3000);
+  const bridgeRunning = await commandSucceeds("pgrep", ["-f", "mcpbridge"], 3000);
+  state.xcodeMcpLikely = xcodeRunning || bridgeRunning;
+  return state.xcodeMcpLikely;
+}
+
+function startXcodeMcpApproval(pluginRoot, state) {
+  if (state.xcodeMcpApprovalStarted) return;
+  state.xcodeMcpApprovalStarted = true;
+
+  const runner = path.join(pluginRoot, "hooks", "run-background.sh");
+  const target = path.join("hooks", "approve-xcode-mcp.sh");
+  if (!fs.existsSync(runner)) return;
+
+  try {
+    const child = spawn(runner, [target], {
+      cwd: pluginRoot,
+      detached: true,
+      env: {
+        ...process.env,
+        CLAUDE_HOOK_OWNER_PID: String(process.pid),
+        CLAUDE_PLUGIN_ROOT: pluginRoot,
+      },
+      stdio: "ignore",
+    });
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+    // Auto-approval is best-effort; users can still approve Xcode manually.
+  }
+}
+
+function commandSucceeds(command, args, timeoutMs) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const child = spawn(command, args, { stdio: "ignore" });
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish(false);
+    }, timeoutMs);
+
+    child.on("error", () => finish(false));
+    child.on("exit", (code) => finish(code === 0));
+
+    function finish(result) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    }
+  });
+}
+
+function applyPreToolUseRules(state, input, output) {
+  const tool = String(input.tool ?? "").toLowerCase();
+  if (tool !== "bash") return;
+
+  const command = output?.args?.command;
+  if (typeof command !== "string" || !command) return;
+
+  const rules = Array.isArray(state.infoJson["pre-tool-use-rules"])
+    ? state.infoJson["pre-tool-use-rules"]
+    : [];
+
+  for (const rule of rules) {
+    if (!isObject(rule)) continue;
+
+    const matchPattern = rule.match;
+    if (typeof matchPattern !== "string" || !regexMatches(matchPattern, command)) continue;
+
+    const notMatchPattern = rule.not_match;
+    if (typeof notMatchPattern === "string" && regexMatches(notMatchPattern, command)) continue;
+
+    const decision = rule.decision ?? "deny";
+    if (decision === "allow") return;
+
+    const message = typeof rule.message === "string" ? rule.message : "Command denied by plugin rule";
+    if (decision === "deny") throw new Error(message);
+
+    const ruleName = typeof rule.name === "string" && rule.name ? rule.name : matchPattern;
+    const key = `${input.sessionID ?? "global"}:${ruleName}`;
+    if (state.deniedOnce.has(key)) continue;
+
+    state.deniedOnce.add(key);
+    throw new Error(message);
+  }
+}
+
+function configureShellEnvironment(pluginRoot, state, input, output) {
+  if (!isObject(output.env)) output.env = {};
+
+  const binDir = path.join(pluginRoot, "bin");
+  if (fs.existsSync(binDir)) {
+    output.env.PATH = prependPath(binDir, output.env.PATH ?? process.env.PATH ?? "");
+  }
+
+  if (state.pluginJson.name !== "XcodeBuildTools") return;
+
+  const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
+  const sandboxBase = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox", sessionID);
+  const buildDir = path.join(sandboxBase, "build");
+  const packagesDir = path.join(sandboxBase, "packages");
+
+  fs.mkdirSync(buildDir, { recursive: true });
+  fs.mkdirSync(packagesDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(sandboxBase, "owner.pid"),
+    `${process.pid}\n${process.argv[0] ?? "opencode"}\n`,
+    "utf8",
+  );
+
+  output.env.SANDBOX_DERIVED_DATA = buildDir;
+  output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+function prependPath(entry, current) {
+  const parts = current.split(path.delimiter).filter(Boolean).filter((part) => part !== entry);
+  return [entry, ...parts].join(path.delimiter);
+}
+
+function safeSessionID(value) {
+  const raw = String(value ?? "");
+  if (SAFE_ID_RE.test(raw)) return raw;
+
+  const hash = createHash("sha256").update(raw || "default").digest("hex").slice(0, 16);
+  return `opencode-${hash}`;
+}
+
+function regexMatches(pattern, value) {
+  try {
+    return new RegExp(pattern).test(value);
+  } catch {
+    return false;
+  }
+}
+
+function hasSkillDirectories(skillsDir) {
+  try {
+    return fs.readdirSync(skillsDir, { withFileTypes: true }).some((entry) => {
+      return entry.isDirectory() && fs.existsSync(path.join(skillsDir, entry.name, "SKILL.md"));
+    });
+  } catch {
+    return false;
+  }
+}
+
+function readJsonFile(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function readTextFile(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function stringifyRecord(value) {
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, String(item)]));
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/PluginBase/common/opencode-plugin.js
+++ b/PluginBase/common/opencode-plugin.js
@@ -1,53 +1,71 @@
 // Generated from common/opencode-plugin.js by scripts/sync-plugin-common.py. Do not edit this copy; edit common/opencode-plugin.js and rerun scripts/sync-plugin-common.py.
 import { spawn } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const XCODE_MCP_CACHE_TTL_MS = 30_000;
+const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
 
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
-  const state = {
-    pluginJson: null,
-    infoJson: null,
-    deniedOnce: new Set(),
-    xcodeMcpLikely: undefined,
-    xcodeMcpApprovalStarted: false,
+  return async () => {
+    const state = {
+      pluginJson: null,
+      infoJson: null,
+      config: null,
+      instanceID: randomUUID(),
+      processStartToken: null,
+      deniedOnce: new Set(),
+      xcodeMcpCache: new Map(),
+      xcodeMcpApprovalSessions: new Set(),
+      ownedSandboxes: new Map(),
+      sandboxSweepDone: false,
+    };
+
+    return {
+      config: async (config) => {
+        loadMetadata(pluginRoot, state);
+        registerSkills(config, pluginRoot);
+        registerMcpServers(config, pluginRoot);
+        state.config = config;
+      },
+
+      "experimental.chat.system.transform": async (input, output) => {
+        try {
+          loadMetadata(pluginRoot, state);
+          await appendSystemContext(pluginRoot, state, input, output);
+        } catch {
+          // Fail open. Plugin context should never block a chat request.
+        }
+      },
+
+      "tool.execute.before": async (input, output) => {
+        loadMetadata(pluginRoot, state);
+        applyPreToolUseRules(state, input, output);
+      },
+
+      "shell.env": async (input, output) => {
+        try {
+          loadMetadata(pluginRoot, state);
+          await configureShellEnvironment(pluginRoot, state, input, output);
+        } catch {
+          // Fail open. Shell commands should still run if setup is unavailable.
+        }
+      },
+
+      event: async ({ event }) => {
+        await handlePluginEvent(state, event);
+      },
+
+      dispose: async () => {
+        await removeOwnedSandboxes(state);
+      },
+    };
   };
-
-  return async () => ({
-    config: async (config) => {
-      loadMetadata(pluginRoot, state);
-      registerSkills(config, pluginRoot);
-      registerMcpServers(config, pluginRoot);
-    },
-
-    "experimental.chat.system.transform": async (_input, output) => {
-      try {
-        loadMetadata(pluginRoot, state);
-        await appendSystemContext(pluginRoot, state, output);
-      } catch {
-        // Fail open. Plugin context should never block a chat request.
-      }
-    },
-
-    "tool.execute.before": async (input, output) => {
-      loadMetadata(pluginRoot, state);
-      applyPreToolUseRules(state, input, output);
-    },
-
-    "shell.env": async (input, output) => {
-      try {
-        loadMetadata(pluginRoot, state);
-        configureShellEnvironment(pluginRoot, state, input, output);
-      } catch {
-        // Fail open. Shell commands should still run if setup is unavailable.
-      }
-    },
-  });
 }
 
 function normalizePluginRoot(pluginRootUrl) {
@@ -144,13 +162,14 @@ function copyOptionalFields(source, target, keys) {
   }
 }
 
-async function appendSystemContext(pluginRoot, state, output) {
+async function appendSystemContext(pluginRoot, state, input, output) {
   if (!Array.isArray(output.system)) output.system = [];
 
   const pluginName = state.pluginJson.name ?? path.basename(pluginRoot);
   const welcomeMessage = typeof state.infoJson.welcomeMessage === "string" ? state.infoJson.welcomeMessage : "";
-  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state);
-  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state);
+  const sessionID = safeSessionID(input?.sessionID ?? "global");
+  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state, sessionID);
+  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state, sessionID);
   const sessionStart = renderSessionStart(pluginRoot, xcodeMcpLikely);
 
   let systemMessage = `The ${pluginName} plugin is loaded and ready.`;
@@ -181,31 +200,56 @@ function processConditionalBlocks(content, xcodeMcpLikely) {
     .replace(/<!-- IF_XCODE_MCP -->[\s\S]*?<!-- END_XCODE_MCP -->\n?/g, "");
 }
 
-async function getXcodeMcpLikely(pluginName, state) {
+async function getXcodeMcpLikely(pluginName, state, sessionID) {
   if (pluginName !== "XcodeBuildTools") return false;
-  if (state.xcodeMcpLikely !== undefined) return state.xcodeMcpLikely;
+  if (!hasConfiguredMcpbridge(state.config)) {
+    state.xcodeMcpCache.delete(sessionID);
+    return false;
+  }
+
+  const now = Date.now();
+  const cached = state.xcodeMcpCache.get(sessionID);
+  if (cached && now - cached.checkedAt < XCODE_MCP_CACHE_TTL_MS) return cached.value;
 
   const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
   if (!installed) {
-    state.xcodeMcpLikely = false;
-    return state.xcodeMcpLikely;
+    state.xcodeMcpCache.set(sessionID, { checkedAt: now, value: false });
+    return false;
   }
 
   const xcodeRunning = await commandSucceeds("pgrep", ["-x", "Xcode"], 3000);
   const bridgeRunning = await commandSucceeds("pgrep", ["-f", "mcpbridge"], 3000);
-  state.xcodeMcpLikely = xcodeRunning || bridgeRunning;
-  return state.xcodeMcpLikely;
+  const value = xcodeRunning || bridgeRunning;
+  state.xcodeMcpCache.set(sessionID, { checkedAt: now, value });
+  return value;
 }
 
-function startXcodeMcpApproval(pluginRoot, state) {
-  if (state.xcodeMcpApprovalStarted) return;
-  state.xcodeMcpApprovalStarted = true;
+function hasConfiguredMcpbridge(config) {
+  if (!isObject(config?.mcp)) return false;
+
+  return Object.values(config.mcp).some((server) => {
+    if (!isObject(server) || server.enabled === false || server.type !== "local") return false;
+
+    const command = Array.isArray(server.command) ? server.command : [server.command];
+    return command.some((part) => {
+      if (typeof part !== "string") return false;
+      return part
+        .trim()
+        .split(/\s+/)
+        .some((token) => path.basename(token.replace(/^['"]|['"]$/g, "")) === "mcpbridge");
+    });
+  });
+}
+
+function startXcodeMcpApproval(pluginRoot, state, sessionID) {
+  if (state.xcodeMcpApprovalSessions.has(sessionID)) return;
 
   const runner = path.join(pluginRoot, "hooks", "run-background.sh");
   const target = path.join("hooks", "approve-xcode-mcp.sh");
   if (!fs.existsSync(runner)) return;
 
   try {
+    state.xcodeMcpApprovalSessions.add(sessionID);
     const child = spawn(runner, [target], {
       cwd: pluginRoot,
       detached: true,
@@ -216,9 +260,10 @@ function startXcodeMcpApproval(pluginRoot, state) {
       },
       stdio: "ignore",
     });
-    child.on("error", () => {});
+    child.on("error", () => state.xcodeMcpApprovalSessions.delete(sessionID));
     child.unref();
   } catch {
+    state.xcodeMcpApprovalSessions.delete(sessionID);
     // Auto-approval is best-effort; users can still approve Xcode manually.
   }
 }
@@ -279,7 +324,7 @@ function applyPreToolUseRules(state, input, output) {
   }
 }
 
-function configureShellEnvironment(pluginRoot, state, input, output) {
+async function configureShellEnvironment(pluginRoot, state, input, output) {
   if (!isObject(output.env)) output.env = {};
 
   const binDir = path.join(pluginRoot, "bin");
@@ -290,7 +335,23 @@ function configureShellEnvironment(pluginRoot, state, input, output) {
   if (state.pluginJson.name !== "XcodeBuildTools") return;
 
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
-  const sandboxBase = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox", sessionID);
+  const sandboxRoot = path.join(os.tmpdir(), XCODE_SANDBOX_DIR);
+  // Plugin instances never reuse a sandbox path, so an older instance cannot
+  // delete a replacement instance's active sandbox after an ownership check.
+  const sandboxBase = path.join(sandboxRoot, `${sessionID}-${state.instanceID}`);
+  state.ownedSandboxes.set(sessionID, sandboxBase);
+
+  if (!state.processStartToken) {
+    state.processStartToken = await readProcessStartToken(process.pid);
+  }
+  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+
+  if (!state.sandboxSweepDone) {
+    await sweepStaleSandboxes(sandboxRoot);
+    state.sandboxSweepDone = true;
+  }
+  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+
   const buildDir = path.join(sandboxBase, "build");
   const packagesDir = path.join(sandboxBase, "packages");
 
@@ -298,12 +359,153 @@ function configureShellEnvironment(pluginRoot, state, input, output) {
   fs.mkdirSync(packagesDir, { recursive: true });
   fs.writeFileSync(
     path.join(sandboxBase, "owner.pid"),
-    `${process.pid}\n${process.argv[0] ?? "opencode"}\n`,
+    `${process.pid}\n${process.argv[0] ?? "opencode"}\n${state.processStartToken}\n${state.instanceID}\n`,
     "utf8",
   );
 
   output.env.SANDBOX_DERIVED_DATA = buildDir;
   output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+async function handlePluginEvent(state, event) {
+  if (event?.type !== "session.deleted") return;
+
+  const sessionID = event.properties?.info?.id;
+  if (typeof sessionID !== "string" || !sessionID) return;
+
+  const safeID = safeSessionID(sessionID);
+  state.xcodeMcpCache.delete(safeID);
+  state.xcodeMcpApprovalSessions.delete(safeID);
+  await removeOwnedSandbox(state, safeID);
+}
+
+async function removeOwnedSandbox(state, sessionID) {
+  const sandboxPath = state.ownedSandboxes.get(sessionID);
+  if (!sandboxPath) return;
+
+  state.ownedSandboxes.delete(sessionID);
+  await removeManagedSandbox(sandboxPath, state.instanceID);
+}
+
+async function removeOwnedSandboxes(state) {
+  const sandboxPaths = [...new Set(state.ownedSandboxes.values())];
+  state.ownedSandboxes.clear();
+  state.xcodeMcpCache.clear();
+  state.xcodeMcpApprovalSessions.clear();
+  await Promise.all(sandboxPaths.map((sandboxPath) => removeManagedSandbox(sandboxPath, state.instanceID)));
+}
+
+async function sweepStaleSandboxes(sandboxRoot) {
+  let entries;
+  try {
+    entries = await fs.promises.readdir(sandboxRoot, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.isDirectory() || !SAFE_ID_RE.test(entry.name)) return;
+
+      const sandboxPath = path.join(sandboxRoot, entry.name);
+      const owner = await readSandboxOwner(sandboxPath);
+      if (!owner || (await sandboxOwnerIsActive(owner))) return;
+
+      await removeManagedSandbox(sandboxPath);
+    }),
+  );
+}
+
+async function readSandboxOwner(sandboxPath) {
+  try {
+    const content = await fs.promises.readFile(path.join(sandboxPath, "owner.pid"), "utf8");
+    const lines = content.split(/\r?\n/);
+    const firstLine = lines[0];
+    if (!/^\d+$/.test(firstLine)) return null;
+
+    const pid = Number(firstLine);
+    if (!Number.isSafeInteger(pid) || pid <= 0) return null;
+
+    return {
+      pid,
+      processStartToken: lines[2] ?? "",
+      instanceID: lines[3] ?? "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+async function sandboxOwnerIsActive(owner) {
+  if (!processExists(owner.pid)) return false;
+  if (!owner.processStartToken) return true;
+
+  const currentStartToken = await readProcessStartToken(owner.pid);
+  if (!currentStartToken) return true;
+  return currentStartToken === owner.processStartToken;
+}
+
+function readProcessStartToken(pid) {
+  return new Promise((resolve) => {
+    let settled = false;
+    let stdout = "";
+    let child;
+
+    try {
+      child = spawn("ps", ["-p", String(pid), "-o", "lstart="], {
+        env: {
+          ...process.env,
+          LC_ALL: "C",
+          LANG: "C",
+          TZ: "UTC",
+        },
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+    } catch {
+      resolve("");
+      return;
+    }
+
+    child.stdout?.setEncoding?.("utf8");
+    child.stdout?.on?.("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.on("error", () => finish(""));
+    child.on("close", (code) => finish(code === 0 ? stdout.trim() : ""));
+
+    function finish(value) {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    }
+  });
+}
+
+async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
+  const sandboxRoot = path.resolve(os.tmpdir(), XCODE_SANDBOX_DIR);
+  const candidate = path.resolve(sandboxPath);
+  const relative = path.relative(sandboxRoot, candidate);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return;
+
+  if (expectedInstanceID) {
+    const owner = await readSandboxOwner(candidate);
+    if (!owner || owner.instanceID !== expectedInstanceID) return;
+  }
+
+  try {
+    await fs.promises.rm(candidate, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  } catch {
+    // Best-effort cleanup; the next plugin instance will retry through the stale-owner sweep.
+  }
 }
 
 function prependPath(entry, current) {

--- a/PluginBase/common/opencode-plugin.js
+++ b/PluginBase/common/opencode-plugin.js
@@ -7,8 +7,23 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const PROCESS_START_OUTPUT_MAX_CHARS = 256;
+const PROCESS_START_TIMEOUT_MS = 5_000;
 const XCODE_MCP_CACHE_TTL_MS = 30_000;
 const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
+const XCODE_SANDBOX_OWNER_GRACE_MS = 60_000;
+const XCODE_SANDBOX_OWNER_LOCK = ".owner.lock";
+const XCODE_SANDBOX_QUARANTINE_RE =
+  /^\.quarantine-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const XCODE_SANDBOX_PENDING_CLEANUPS_KEY = Symbol.for(
+  "opencode.xcodebuildtools.pending-cleanups",
+);
+const pendingSandboxCleanups =
+  globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] instanceof Set
+    ? globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY]
+    : new Set();
+globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] = pendingSandboxCleanups;
 
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
@@ -23,7 +38,9 @@ export function createOpenCodePlugin(pluginRootUrl) {
       xcodeMcpCache: new Map(),
       xcodeMcpApprovalSessions: new Set(),
       ownedSandboxes: new Map(),
+      deletedSandboxSessions: new Set(),
       sandboxSweepDone: false,
+      disposed: false,
     };
 
     return {
@@ -62,7 +79,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       },
 
       dispose: async () => {
-        await removeOwnedSandboxes(state);
+        await detachOwnedSandboxes(state);
       },
     };
   };
@@ -335,6 +352,7 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   if (state.pluginJson.name !== "XcodeBuildTools") return;
 
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
+  if (state.disposed || state.deletedSandboxSessions.has(sessionID)) return;
   const sandboxRoot = path.join(os.tmpdir(), XCODE_SANDBOX_DIR);
   // Plugin instances never reuse a sandbox path, so an older instance cannot
   // delete a replacement instance's active sandbox after an ownership check.
@@ -344,27 +362,201 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   if (!state.processStartToken) {
     state.processStartToken = await readProcessStartToken(process.pid);
   }
-  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+  if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
 
   if (!state.sandboxSweepDone) {
     await sweepStaleSandboxes(sandboxRoot);
     state.sandboxSweepDone = true;
   }
-  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+  if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
 
   const buildDir = path.join(sandboxBase, "build");
   const packagesDir = path.join(sandboxBase, "packages");
 
   fs.mkdirSync(buildDir, { recursive: true });
   fs.mkdirSync(packagesDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(sandboxBase, "owner.pid"),
-    `${process.pid}\n${process.argv[0] ?? "opencode"}\n${state.processStartToken}\n${state.instanceID}\n`,
-    "utf8",
-  );
+  writeSandboxOwner(sandboxBase, state.processStartToken, state.instanceID);
 
   output.env.SANDBOX_DERIVED_DATA = buildDir;
   output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+function sandboxSetupIsCancelled(state, sessionID, sandboxBase) {
+  return (
+    state.disposed ||
+    state.deletedSandboxSessions.has(sessionID) ||
+    state.ownedSandboxes.get(sessionID) !== sandboxBase
+  );
+}
+
+function writeSandboxOwner(sandboxBase, processStartToken, instanceID) {
+  const ownerPath = path.join(sandboxBase, "owner.pid");
+  const temporaryPath = path.join(sandboxBase, `owner.pid.${instanceID}.tmp`);
+  const content = `${process.pid}\n${process.argv[0] ?? "opencode"}\n${processStartToken}\n${instanceID}\n`;
+  const ownerLock = acquireSandboxOwnerLock(sandboxBase);
+  if (!ownerLock) throw new Error("Sandbox owner is being updated or removed");
+
+  try {
+    fs.writeFileSync(temporaryPath, content, "utf8");
+    if (!sandboxOwnerLockIsHeld(ownerLock)) {
+      throw new Error("Sandbox owner lock changed during update");
+    }
+    fs.renameSync(temporaryPath, ownerPath);
+  } catch (error) {
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch {
+      // The stale-sandbox sweep handles any temporary file left behind.
+    }
+    throw error;
+  } finally {
+    releaseSandboxOwnerLock(ownerLock);
+  }
+}
+
+function markSandboxCleanupPending(sandboxBase, instanceID, ownerLock) {
+  const ownerPath = path.join(sandboxBase, "owner.pid");
+  const temporaryPath = path.join(sandboxBase, `owner.pid.${instanceID}.cleanup.tmp`);
+  const content = `${process.pid}\ncleanup-pending\n\n${instanceID}\ncleanup-pending\n`;
+
+  try {
+    fs.writeFileSync(temporaryPath, content, "utf8");
+    if (!sandboxOwnerLockIsHeld(ownerLock)) return false;
+    fs.renameSync(temporaryPath, ownerPath);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch {
+      // A successful rename removes the temporary path.
+    }
+  }
+}
+
+function acquireSandboxOwnerLock(sandboxBase) {
+  const lockPath = path.join(sandboxBase, XCODE_SANDBOX_OWNER_LOCK);
+  const token = randomUUID();
+  const createdLock = createSandboxOwnerLock(lockPath, token);
+  if (createdLock) return createdLock;
+
+  const observedLock = readSandboxOwnerLock(lockPath);
+  if (!observedLock) return null;
+  if (Date.now() - observedLock.mtimeMs < XCODE_SANDBOX_OWNER_GRACE_MS) return null;
+
+  const claimedPath = `${lockPath}.${token}.stale`;
+  try {
+    fs.renameSync(lockPath, claimedPath);
+  } catch {
+    return null;
+  }
+
+  const claimedLock = readSandboxOwnerLock(claimedPath);
+  if (!sameSandboxOwnerLock(observedLock, claimedLock)) {
+    restoreClaimedSandboxOwnerLock(claimedPath, lockPath);
+    return null;
+  }
+
+  try {
+    fs.unlinkSync(claimedPath);
+  } catch {
+    restoreClaimedSandboxOwnerLock(claimedPath, lockPath);
+    return null;
+  }
+
+  return createSandboxOwnerLock(lockPath, token);
+}
+
+function createSandboxOwnerLock(lockPath, token) {
+  try {
+    fs.writeFileSync(lockPath, `${token}\n`, { encoding: "utf8", flag: "wx" });
+  } catch {
+    return null;
+  }
+
+  const ownerLock = readSandboxOwnerLock(lockPath);
+  if (!ownerLock || ownerLock.token !== token) return null;
+  return ownerLock;
+}
+
+function readSandboxOwnerLock(lockPath) {
+  try {
+    const before = fs.statSync(lockPath);
+    if (!before.isFile()) return null;
+    const beforeToken = fs.readFileSync(lockPath, "utf8").trim();
+    const after = fs.statSync(lockPath);
+    const afterToken = fs.readFileSync(lockPath, "utf8").trim();
+    if (!sameSandboxOwnerLockVersion(before, after) || beforeToken !== afterToken) return null;
+
+    return {
+      path: lockPath,
+      token: afterToken,
+      dev: after.dev,
+      ino: after.ino,
+      mtimeMs: after.mtimeMs,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function sameSandboxOwnerLockVersion(left, right) {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs &&
+    left.ctimeMs === right.ctimeMs
+  );
+}
+
+function sameSandboxOwnerLock(left, right) {
+  return Boolean(
+    left &&
+      right &&
+      left.dev === right.dev &&
+      left.ino === right.ino &&
+      left.token === right.token,
+  );
+}
+
+function sandboxOwnerLockIsHeld(ownerLock) {
+  return sameSandboxOwnerLock(ownerLock, readSandboxOwnerLock(ownerLock.path));
+}
+
+function restoreClaimedSandboxOwnerLock(claimedPath, lockPath) {
+  try {
+    // A hard link restores the claimed inode only when the lock path is still
+    // absent, without overwriting a lock another actor acquired meanwhile.
+    fs.linkSync(claimedPath, lockPath);
+    fs.unlinkSync(claimedPath);
+  } catch {
+    // Leave the uniquely named claim in place if ownership cannot be restored.
+  }
+}
+
+function releaseSandboxOwnerLock(ownerLock) {
+  if (!sandboxOwnerLockIsHeld(ownerLock)) return;
+
+  const claimedPath = `${ownerLock.path}.${randomUUID()}.release`;
+  try {
+    fs.renameSync(ownerLock.path, claimedPath);
+  } catch {
+    return;
+  }
+
+  const claimedLock = readSandboxOwnerLock(claimedPath);
+  if (!sameSandboxOwnerLock(ownerLock, claimedLock)) {
+    restoreClaimedSandboxOwnerLock(claimedPath, ownerLock.path);
+    return;
+  }
+
+  try {
+    fs.unlinkSync(claimedPath);
+  } catch {
+    // The sandbox may already have been removed with the lock inside it.
+  }
 }
 
 async function handlePluginEvent(state, event) {
@@ -374,6 +566,7 @@ async function handlePluginEvent(state, event) {
   if (typeof sessionID !== "string" || !sessionID) return;
 
   const safeID = safeSessionID(sessionID);
+  state.deletedSandboxSessions.add(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
   await removeOwnedSandbox(state, safeID);
@@ -383,16 +576,36 @@ async function removeOwnedSandbox(state, sessionID) {
   const sandboxPath = state.ownedSandboxes.get(sessionID);
   if (!sandboxPath) return;
 
+  markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.delete(sessionID);
-  await removeManagedSandbox(sandboxPath, state.instanceID);
+  const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+  await removeManagedSandbox(
+    quarantinedPath || sandboxPath,
+    quarantinedPath ? "" : state.instanceID,
+  );
 }
 
-async function removeOwnedSandboxes(state) {
+async function detachOwnedSandboxes(state) {
+  state.disposed = true;
   const sandboxPaths = [...new Set(state.ownedSandboxes.values())];
+  for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
-  await Promise.all(sandboxPaths.map((sandboxPath) => removeManagedSandbox(sandboxPath, state.instanceID)));
+  const cleanupTargets = await Promise.all(
+    sandboxPaths.map(async (sandboxPath) => {
+      const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+      return {
+        path: quarantinedPath || sandboxPath,
+        expectedInstanceID: quarantinedPath ? "" : state.instanceID,
+      };
+    }),
+  );
+  await Promise.all(
+    cleanupTargets.map(({ path: sandboxPath, expectedInstanceID }) =>
+      detachManagedSandbox(sandboxPath, expectedInstanceID),
+    ),
+  );
 }
 
 async function sweepStaleSandboxes(sandboxRoot) {
@@ -405,11 +618,43 @@ async function sweepStaleSandboxes(sandboxRoot) {
 
   await Promise.all(
     entries.map(async (entry) => {
-      if (!entry.isDirectory() || !SAFE_ID_RE.test(entry.name)) return;
+      const isQuarantine = XCODE_SANDBOX_QUARANTINE_RE.test(entry.name);
+      if (!entry.isDirectory() || (!SAFE_ID_RE.test(entry.name) && !isQuarantine)) return;
 
       const sandboxPath = path.join(sandboxRoot, entry.name);
       const owner = await readSandboxOwner(sandboxPath);
-      if (!owner || (await sandboxOwnerIsActive(owner))) return;
+      const cleanupPending = owner?.cleanupPending || sandboxCleanupIsPending(sandboxPath);
+      if (!owner || cleanupPending) {
+        if (!cleanupPending && !isQuarantine && !(await sandboxIsPastOwnerGracePeriod(sandboxPath))) {
+          return;
+        }
+
+        const ownerLock = acquireSandboxOwnerLock(sandboxPath);
+        if (!ownerLock) return;
+        let releaseLock = ownerLock;
+        try {
+          // A writer may have published an owner after the initial read or
+          // stale-stat snapshot. Only remove while the publication lock is
+          // held and the marker is still invalid.
+          const currentOwner = await readSandboxOwner(sandboxPath);
+          const currentCleanupPending =
+            currentOwner?.cleanupPending || sandboxCleanupIsPending(sandboxPath);
+          if (
+            (!currentOwner || currentCleanupPending) &&
+            sandboxOwnerLockIsHeld(ownerLock)
+          ) {
+            const quarantined = await quarantineManagedSandbox(sandboxPath, ownerLock);
+            releaseLock = quarantined.ownerLock;
+            if (quarantined.path) {
+              await removeManagedSandbox(quarantined.path);
+            }
+          }
+        } finally {
+          releaseSandboxOwnerLock(releaseLock);
+        }
+        return;
+      }
+      if (await sandboxOwnerIsActive(owner)) return;
 
       await removeManagedSandbox(sandboxPath);
     }),
@@ -426,13 +671,26 @@ async function readSandboxOwner(sandboxPath) {
     const pid = Number(firstLine);
     if (!Number.isSafeInteger(pid) || pid <= 0) return null;
 
+    const instanceID = lines[3] ?? "";
+    if (!UUID_V4_RE.test(instanceID)) return null;
+
     return {
       pid,
       processStartToken: lines[2] ?? "",
-      instanceID: lines[3] ?? "",
+      instanceID,
+      cleanupPending: lines[4] === "cleanup-pending",
     };
   } catch {
     return null;
+  }
+}
+
+async function sandboxIsPastOwnerGracePeriod(sandboxPath) {
+  try {
+    const stat = await fs.promises.stat(sandboxPath);
+    return Date.now() - stat.mtimeMs >= XCODE_SANDBOX_OWNER_GRACE_MS;
+  } catch {
+    return false;
   }
 }
 
@@ -459,9 +717,10 @@ function readProcessStartToken(pid) {
     let settled = false;
     let stdout = "";
     let child;
+    let timer;
 
     try {
-      child = spawn("ps", ["-p", String(pid), "-o", "lstart="], {
+      child = spawn("/bin/ps", ["-p", String(pid), "-o", "lstart="], {
         env: {
           ...process.env,
           LC_ALL: "C",
@@ -477,24 +736,156 @@ function readProcessStartToken(pid) {
 
     child.stdout?.setEncoding?.("utf8");
     child.stdout?.on?.("data", (chunk) => {
-      stdout += chunk;
+      const remaining = PROCESS_START_OUTPUT_MAX_CHARS - stdout.length;
+      if (remaining > 0) stdout += String(chunk).slice(0, remaining);
     });
     child.on("error", () => finish(""));
-    child.on("close", (code) => finish(code === 0 ? stdout.trim() : ""));
+    child.on("close", (code) => {
+      const firstLine = stdout.trim().split(/\r?\n/, 1)[0] ?? "";
+      finish(code === 0 ? firstLine : "");
+    });
+    timer = setTimeout(() => {
+      try {
+        child.kill?.("SIGTERM");
+      } catch {
+        // Resolving the hook is more important than terminating a broken ps shim.
+      }
+      finish("");
+    }, PROCESS_START_TIMEOUT_MS);
 
     function finish(value) {
       if (settled) return;
       settled = true;
+      clearTimeout(timer);
       resolve(value);
     }
   });
 }
 
 async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
-  const sandboxRoot = path.resolve(os.tmpdir(), XCODE_SANDBOX_DIR);
-  const candidate = path.resolve(sandboxPath);
-  const relative = path.relative(sandboxRoot, candidate);
-  if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return;
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate) return false;
+
+  if (expectedInstanceID) {
+    const owner = await readSandboxOwner(candidate);
+    if (!owner || owner.instanceID !== expectedInstanceID) return false;
+  }
+
+  try {
+    await fs.promises.rm(candidate, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    clearPendingSandboxCleanup(candidate);
+    return true;
+  } catch {
+    // Best-effort cleanup; the next plugin instance will retry through the stale-owner sweep.
+    return false;
+  }
+}
+
+async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate) return "";
+
+  const ownerLock = acquireSandboxOwnerLock(candidate);
+  if (!ownerLock) return "";
+  let releaseLock = ownerLock;
+
+  try {
+    const currentOwner = await readSandboxOwner(candidate);
+    if (!currentOwner || currentOwner.instanceID !== expectedInstanceID) return "";
+    if (!markSandboxCleanupPending(candidate, expectedInstanceID, ownerLock)) return "";
+
+    const quarantinePath = path.join(path.dirname(candidate), `.quarantine-${randomUUID()}`);
+    if (!managedSandboxCandidate(quarantinePath)) return "";
+
+    try {
+      fs.renameSync(candidate, quarantinePath);
+      movePendingSandboxCleanup(candidate, quarantinePath);
+    } catch {
+      return "";
+    }
+
+    releaseLock = {
+      ...ownerLock,
+      path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+    };
+    const relocatedOwner = await readSandboxOwner(quarantinePath);
+    if (
+      !sandboxOwnerLockIsHeld(releaseLock) ||
+      !relocatedOwner ||
+      relocatedOwner.instanceID !== expectedInstanceID ||
+      !relocatedOwner.cleanupPending
+    ) {
+      if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+        movePendingSandboxCleanup(quarantinePath, candidate);
+        releaseLock = { ...releaseLock, path: ownerLock.path };
+      }
+      return "";
+    }
+
+    const ownerPath = path.join(quarantinePath, "owner.pid");
+    const retiredOwnerPath = path.join(quarantinePath, `owner.pid.retired-${randomUUID()}`);
+    try {
+      fs.renameSync(ownerPath, retiredOwnerPath);
+    } catch (error) {
+      if (error?.code !== "ENOENT") return quarantinePath;
+    }
+
+    return quarantinePath;
+  } finally {
+    releaseSandboxOwnerLock(releaseLock);
+  }
+}
+
+async function quarantineManagedSandbox(sandboxPath, ownerLock) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate || !sandboxOwnerLockIsHeld(ownerLock)) {
+    return { path: "", ownerLock };
+  }
+
+  const quarantinePath = path.join(path.dirname(candidate), `.quarantine-${randomUUID()}`);
+  if (!managedSandboxCandidate(quarantinePath)) return { path: "", ownerLock };
+
+  try {
+    fs.renameSync(candidate, quarantinePath);
+    movePendingSandboxCleanup(candidate, quarantinePath);
+  } catch {
+    return { path: "", ownerLock };
+  }
+
+  const relocatedLock = {
+    ...ownerLock,
+    path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+  };
+  const publishedOwner = await readSandboxOwner(quarantinePath);
+  const cleanupPending =
+    publishedOwner?.cleanupPending || sandboxCleanupIsPending(quarantinePath);
+  if (
+    !sandboxOwnerLockIsHeld(relocatedLock) ||
+    (publishedOwner && !cleanupPending)
+  ) {
+    if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+      movePendingSandboxCleanup(quarantinePath, candidate);
+      return { path: "", ownerLock };
+    }
+    // Preserve the quarantine when the original path has already been reused.
+    return { path: "", ownerLock: relocatedLock };
+  }
+
+  return { path: quarantinePath, ownerLock: relocatedLock };
+}
+
+function restoreQuarantinedSandbox(quarantinePath, originalPath) {
+  try {
+    fs.renameSync(quarantinePath, originalPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function detachManagedSandbox(sandboxPath, expectedInstanceID = "") {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate) return;
 
   if (expectedInstanceID) {
     const owner = await readSandboxOwner(candidate);
@@ -502,10 +893,48 @@ async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
   }
 
   try {
-    await fs.promises.rm(candidate, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    const child = spawn("/bin/rm", ["-rf", candidate], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.on("error", () => {});
+    child.on("exit", (code) => {
+      if (code === 0) clearPendingSandboxCleanup(candidate);
+    });
+    child.unref();
   } catch {
     // Best-effort cleanup; the next plugin instance will retry through the stale-owner sweep.
   }
+}
+
+function managedSandboxCandidate(sandboxPath) {
+  const sandboxRoot = path.resolve(os.tmpdir(), XCODE_SANDBOX_DIR);
+  const candidate = path.resolve(sandboxPath);
+  const relative = path.relative(sandboxRoot, candidate);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return "";
+  return candidate;
+}
+
+function markPendingSandboxCleanup(sandboxPath) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (candidate) pendingSandboxCleanups.add(candidate);
+}
+
+function clearPendingSandboxCleanup(sandboxPath) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (candidate) pendingSandboxCleanups.delete(candidate);
+}
+
+function movePendingSandboxCleanup(sourcePath, destinationPath) {
+  const source = managedSandboxCandidate(sourcePath);
+  const destination = managedSandboxCandidate(destinationPath);
+  if (!source || !destination || !pendingSandboxCleanups.delete(source)) return;
+  pendingSandboxCleanups.add(destination);
+}
+
+function sandboxCleanupIsPending(sandboxPath) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  return Boolean(candidate && pendingSandboxCleanups.has(candidate));
 }
 
 function prependPath(entry, current) {

--- a/PluginBase/common/opencode-plugin.js
+++ b/PluginBase/common/opencode-plugin.js
@@ -7,6 +7,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const MCP_PLACEHOLDER_RE = /\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}/g;
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const PROCESS_START_OUTPUT_MAX_CHARS = 256;
 const PROCESS_START_TIMEOUT_MS = 5_000;
@@ -27,7 +28,11 @@ globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] = pendingSandboxCleanups;
 
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
-  return async () => {
+  return async (input = {}) => {
+    const mcpContext = {
+      pluginRoot,
+      projectDir: input?.worktree || input?.directory,
+    };
     const state = {
       pluginJson: null,
       infoJson: null,
@@ -47,7 +52,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       config: async (config) => {
         loadMetadata(pluginRoot, state);
         registerSkills(config, pluginRoot);
-        registerMcpServers(config, pluginRoot);
+        registerMcpServers(config, pluginRoot, mcpContext);
         state.config = config;
       },
 
@@ -115,7 +120,7 @@ function registerSkills(config, pluginRoot) {
   if (!config.skills.paths.includes(skillsDir)) config.skills.paths.push(skillsDir);
 }
 
-function registerMcpServers(config, pluginRoot) {
+function registerMcpServers(config, pluginRoot, context) {
   const mcpConfig = readJsonFile(path.join(pluginRoot, ".mcp.json"));
   const servers = mcpConfig?.mcpServers;
   if (!isObject(servers)) return;
@@ -125,58 +130,117 @@ function registerMcpServers(config, pluginRoot) {
   for (const [name, server] of Object.entries(servers)) {
     if (!isObject(server) || config.mcp[name]) continue;
 
-    const translated = translateMcpServer(server);
+    const translated = translateMcpServer(server, context);
     if (translated) config.mcp[name] = translated;
   }
 }
 
-function translateMcpServer(server) {
+function translateMcpServer(server, context) {
   if (typeof server.url === "string") {
     const translated = {
       type: "remote",
-      url: server.url,
+      url: expandMcpString(server.url, context),
     };
-    copyOptionalFields(server, translated, ["enabled", "headers", "timeout"]);
+    copyOptionalFields(server, translated, ["enabled", "headers", "timeout"], context);
+    const oauth = translateMcpOAuth(server.oauth);
+    if (oauth !== undefined) translated.oauth = oauth;
     return translated;
   }
 
-  const command = normalizeCommand(server.command, server.args);
+  const command = normalizeCommand(server.command, server.args, context);
   if (!command) return null;
 
   const translated = {
     type: "local",
     command,
   };
-  copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"]);
+  copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"], context);
 
   const environment = isObject(server.environment) ? server.environment : server.env;
-  if (isObject(environment)) translated.environment = stringifyRecord(environment);
+  if (isObject(environment)) translated.environment = expandMcpRecord(environment, context);
 
   return translated;
 }
 
-function normalizeCommand(command, args) {
+function translateMcpOAuth(oauth) {
+  if (oauth === false) return false;
+  if (!isObject(oauth)) return undefined;
+
+  const translated = {};
+  for (const key of ["clientId", "clientSecret", "redirectUri"]) {
+    if (typeof oauth[key] === "string") translated[key] = oauth[key];
+  }
+
+  if (
+    Number.isInteger(oauth.callbackPort) &&
+    oauth.callbackPort >= 1 &&
+    oauth.callbackPort <= 65_535
+  ) {
+    translated.callbackPort = oauth.callbackPort;
+  }
+
+  if (typeof oauth.scopes === "string") {
+    translated.scope = oauth.scopes;
+  } else if (typeof oauth.scope === "string") {
+    translated.scope = oauth.scope;
+  }
+
+  return translated;
+}
+
+function normalizeCommand(command, args, context) {
   if (Array.isArray(command) && command.every((item) => typeof item === "string")) {
-    return command;
+    return command.map((item) => expandMcpString(item, context));
   }
 
   if (typeof command !== "string") return null;
 
-  const result = [command];
   if (Array.isArray(args)) {
-    for (const arg of args) {
-      if (typeof arg !== "string") return null;
-      result.push(arg);
-    }
+    if (!args.every((arg) => typeof arg === "string")) return null;
+    return [command, ...args].map((item) => expandMcpString(item, context));
   }
-  return result;
+  return [expandMcpString(command, context)];
 }
 
-function copyOptionalFields(source, target, keys) {
+function copyOptionalFields(source, target, keys, context) {
   for (const key of keys) {
     if (source[key] === undefined) continue;
-    target[key] = key === "headers" && isObject(source[key]) ? stringifyRecord(source[key]) : source[key];
+    if (key === "headers" && isObject(source[key])) {
+      target[key] = expandMcpRecord(source[key], context);
+    } else if (key === "cwd" && typeof source[key] === "string") {
+      target[key] = expandMcpString(source[key], context);
+    } else {
+      target[key] = source[key];
+    }
   }
+}
+
+function expandMcpRecord(value, context) {
+  return Object.fromEntries(
+    Object.entries(stringifyRecord(value)).map(([key, item]) => [
+      key,
+      expandMcpString(item, context),
+    ]),
+  );
+}
+
+function expandMcpString(value, context) {
+  return value.replace(MCP_PLACEHOLDER_RE, (_, name, defaultValue) => {
+    const resolved = mcpVariable(name, context);
+    if (defaultValue !== undefined && (resolved === undefined || resolved === "")) {
+      return defaultValue;
+    }
+    if (resolved === undefined) {
+      throw new Error(`MCP configuration references unset variable: ${name}`);
+    }
+    return resolved;
+  });
+}
+
+function mcpVariable(name, context) {
+  if (name === "CLAUDE_PLUGIN_ROOT") return context.pluginRoot;
+  if (name === "CLAUDE_PROJECT_DIR") return context.projectDir;
+  return process.env[name];
 }
 
 async function appendSystemContext(pluginRoot, state, input, output) {

--- a/PluginBase/common/opencode-plugin.js
+++ b/PluginBase/common/opencode-plugin.js
@@ -29,13 +29,10 @@ globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] = pendingSandboxCleanups;
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
   return async (input = {}) => {
-    const mcpContext = {
-      pluginRoot,
-      projectDir: input?.worktree || input?.directory,
-    };
     const state = {
       pluginJson: null,
       infoJson: null,
+      pluginData: null,
       config: null,
       instanceID: randomUUID(),
       processStartToken: null,
@@ -46,6 +43,11 @@ export function createOpenCodePlugin(pluginRootUrl) {
       deletedSandboxSessions: new Set(),
       sandboxSweepDone: false,
       disposed: false,
+    };
+    const mcpContext = {
+      pluginRoot,
+      pluginData: () => pluginDataDirectory(pluginRoot, state),
+      projectDir: input?.worktree || input?.directory,
     };
 
     return {
@@ -111,6 +113,19 @@ function loadMetadata(pluginRoot, state) {
   }
 }
 
+function pluginDataDirectory(pluginRoot, state) {
+  if (state.pluginData) return state.pluginData;
+
+  loadMetadata(pluginRoot, state);
+  const pluginName = state.pluginJson.name || path.basename(pluginRoot) || "plugin";
+  const pluginID = String(pluginName).replace(/[^A-Za-z0-9_-]/g, "-");
+  const dataHome = process.env.XDG_DATA_HOME || path.join(os.homedir(), ".local", "share");
+  const pluginData = path.resolve(dataHome, "opencode", "plugin-data", pluginID);
+  fs.mkdirSync(pluginData, { recursive: true });
+  state.pluginData = pluginData;
+  return pluginData;
+}
+
 function registerSkills(config, pluginRoot) {
   const skillsDir = path.join(pluginRoot, "skills");
   if (!hasSkillDirectories(skillsDir)) return;
@@ -157,7 +172,17 @@ function translateMcpServer(server, context) {
   copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"], context);
 
   const environment = isObject(server.environment) ? server.environment : server.env;
-  if (isObject(environment)) translated.environment = expandMcpRecord(environment, context);
+  translated.environment = {
+    ...(isObject(environment) ? expandMcpRecord(environment, context) : {}),
+    ...expandMcpRecord(
+      {
+        CLAUDE_PLUGIN_ROOT: "${CLAUDE_PLUGIN_ROOT}",
+        CLAUDE_PLUGIN_DATA: "${CLAUDE_PLUGIN_DATA}",
+        CLAUDE_PROJECT_DIR: "${CLAUDE_PROJECT_DIR}",
+      },
+      context,
+    ),
+  };
 
   return translated;
 }
@@ -239,6 +264,7 @@ function expandMcpString(value, context) {
 
 function mcpVariable(name, context) {
   if (name === "CLAUDE_PLUGIN_ROOT") return context.pluginRoot;
+  if (name === "CLAUDE_PLUGIN_DATA") return context.pluginData();
   if (name === "CLAUDE_PROJECT_DIR") return context.projectDir;
   return process.env[name];
 }

--- a/PluginBase/common/opencode-plugin.js
+++ b/PluginBase/common/opencode-plugin.js
@@ -8,11 +8,47 @@ import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
 const MCP_PLACEHOLDER_RE = /\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}/g;
+const MCP_COMPATIBILITY_ENVIRONMENT_KEYS = new Set([
+  "CLAUDE_PLUGIN_ROOT",
+  "CLAUDE_PLUGIN_DATA",
+  "CLAUDE_PROJECT_DIR",
+]);
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const PROCESS_START_OUTPUT_MAX_CHARS = 256;
 const PROCESS_START_TIMEOUT_MS = 5_000;
+const PROCESS_TERMINATION_GRACE_MS = 250;
 const XCODE_MCP_CACHE_TTL_MS = 30_000;
+const XCRUN_OPTIONS_WITH_VALUE = new Set([
+  "--sdk",
+  "-sdk",
+  "--toolchain",
+  "-toolchain",
+]);
+const XCRUN_OPTIONS_WITHOUT_VALUE = new Set([
+  "-h",
+  "--help",
+  "--version",
+  "-v",
+  "--verbose",
+  "-l",
+  "--log",
+  "-f",
+  "--find",
+  "-r",
+  "--run",
+  "-n",
+  "--no-cache",
+  "-k",
+  "--kill-cache",
+  "--show-sdk-path",
+  "--show-sdk-version",
+  "--show-sdk-build-version",
+  "--show-sdk-platform-path",
+  "--show-sdk-platform-version",
+  "--show-toolchain-path",
+]);
 const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
+const XCODE_SANDBOX_MODE = 0o700;
 const XCODE_SANDBOX_OWNER_GRACE_MS = 60_000;
 const XCODE_SANDBOX_OWNER_LOCK = ".owner.lock";
 const XCODE_SANDBOX_QUARANTINE_RE =
@@ -39,7 +75,9 @@ export function createOpenCodePlugin(pluginRootUrl) {
       deniedOnce: new Set(),
       xcodeMcpCache: new Map(),
       xcodeMcpApprovalSessions: new Set(),
+      sandboxRoot: null,
       ownedSandboxes: new Map(),
+      ownedSandboxIdentities: new Map(),
       deletedSandboxSessions: new Set(),
       sandboxSweepDone: false,
       disposed: false,
@@ -146,8 +184,45 @@ function registerMcpServers(config, pluginRoot, context) {
     if (!isObject(server) || config.mcp[name]) continue;
 
     const translated = translateMcpServer(server, context);
-    if (translated) config.mcp[name] = translated;
+    if (translated && !hasMcpEndpoint(config.mcp, translated)) {
+      config.mcp[name] = translated;
+    }
   }
+}
+
+function hasMcpEndpoint(servers, candidate) {
+  return Object.values(servers).some((server) => {
+    if (!isObject(server) || server.type !== candidate.type) return false;
+    if (candidate.type === "remote") return server.url === candidate.url;
+    if (candidate.type !== "local") return false;
+    if (!Array.isArray(server.command) || !Array.isArray(candidate.command)) return false;
+    return (
+      server.command.length === candidate.command.length &&
+      server.command.every((item, index) => item === candidate.command[index]) &&
+      server.cwd === candidate.cwd &&
+      mcpEnvironmentMatches(server.environment, candidate.environment)
+    );
+  });
+}
+
+function mcpEnvironmentMatches(left, right) {
+  const leftEntries = comparableMcpEnvironment(left);
+  const rightEntries = comparableMcpEnvironment(right);
+  if (!leftEntries || !rightEntries || leftEntries.length !== rightEntries.length) {
+    return false;
+  }
+  return leftEntries.every(([key, value], index) => {
+    const [rightKey, rightValue] = rightEntries[index];
+    return key === rightKey && value === rightValue;
+  });
+}
+
+function comparableMcpEnvironment(environment) {
+  if (environment === undefined) return [];
+  if (!isObject(environment)) return null;
+  return Object.entries(environment)
+    .filter(([key]) => !MCP_COMPATIBILITY_ENVIRONMENT_KEYS.has(key))
+    .sort(([left], [right]) => left.localeCompare(right));
 }
 
 function translateMcpServer(server, context) {
@@ -338,14 +413,40 @@ function hasConfiguredMcpbridge(config) {
     if (!isObject(server) || server.enabled === false || server.type !== "local") return false;
 
     const command = Array.isArray(server.command) ? server.command : [server.command];
-    return command.some((part) => {
-      if (typeof part !== "string") return false;
-      return part
-        .trim()
-        .split(/\s+/)
-        .some((token) => path.basename(token.replace(/^['"]|['"]$/g, "")) === "mcpbridge");
-    });
+    const executable = commandBasename(command[0]);
+    if (executable === "mcpbridge") return true;
+    if (executable !== "xcrun") return false;
+    return xcrunToolBasename(command.slice(1)) === "mcpbridge";
   });
+}
+
+function commandBasename(value) {
+  const commandPart = normalizedCommandPart(value);
+  return commandPart ? path.basename(commandPart) : "";
+}
+
+function normalizedCommandPart(value) {
+  if (typeof value !== "string") return "";
+  return value.trim().replace(/^['"]|['"]$/g, "");
+}
+
+function xcrunToolBasename(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = normalizedCommandPart(args[index]);
+    if (!argument) return "";
+    if (argument === "--") {
+      return commandBasename(args[index + 1]);
+    }
+    if (XCRUN_OPTIONS_WITH_VALUE.has(argument)) {
+      index += 1;
+      continue;
+    }
+    if (/^(?:--?sdk|--?toolchain)=/.test(argument)) continue;
+    if (XCRUN_OPTIONS_WITHOUT_VALUE.has(argument)) continue;
+    if (argument.startsWith("-")) return "";
+    return path.basename(argument);
+  }
+  return "";
 }
 
 function startXcodeMcpApproval(pluginRoot, state, sessionID) {
@@ -378,22 +479,74 @@ function startXcodeMcpApproval(pluginRoot, state, sessionID) {
 function commandSucceeds(command, args, timeoutMs) {
   return new Promise((resolve) => {
     let settled = false;
-    const child = spawn(command, args, { stdio: "ignore" });
-    const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      finish(false);
-    }, timeoutMs);
+    let timedOut = false;
+    let timeoutTimer;
+    let forceKillTimer;
+    let child;
 
-    child.on("error", () => finish(false));
-    child.on("exit", (code) => finish(code === 0));
+    try {
+      child = spawn(command, args, { stdio: "ignore" });
+    } catch {
+      resolve(false);
+      return;
+    }
+
+    const onError = () => finish(false);
+    const onExit = (code) => finish(!timedOut && code === 0);
+    child.on("error", onError);
+    child.on("exit", onExit);
+    timeoutTimer = setTimeout(beginTermination, timeoutMs);
+
+    function beginTermination() {
+      if (settled) return;
+      timedOut = true;
+      forceKillTimer = terminateChildAfterGrace(
+        child,
+        () => !settled,
+        () => finish(false),
+      );
+    }
 
     function finish(result) {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      clearTimeout(timeoutTimer);
+      clearTimeout(forceKillTimer);
+      child.removeListener?.("error", onError);
+      child.removeListener?.("exit", onExit);
       resolve(result);
     }
   });
+}
+
+function terminateChildAfterGrace(child, isPending, onForcedTermination) {
+  try {
+    child.kill("SIGTERM");
+  } catch {
+    // Continue to forced termination so the timed-out child is detached.
+  }
+  if (!isPending()) return undefined;
+
+  return setTimeout(() => {
+    if (!isPending()) return;
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // The process may have exited between the grace timer and this call.
+    }
+    try {
+      child.stdout?.destroy?.();
+      child.stderr?.destroy?.();
+    } catch {
+      // Detaching the child still allows the parent to continue.
+    }
+    try {
+      child.unref();
+    } catch {
+      // Resolving the caller is more important than detaching a broken shim.
+    }
+    onForcedTermination();
+  }, PROCESS_TERMINATION_GRACE_MS);
 }
 
 function applyPreToolUseRules(state, input, output) {
@@ -443,10 +596,10 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
 
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
   if (state.disposed || state.deletedSandboxSessions.has(sessionID)) return;
-  const sandboxRoot = path.join(os.tmpdir(), XCODE_SANDBOX_DIR);
+  const sandboxRoot = secureSandboxRoot(state);
   // Plugin instances never reuse a sandbox path, so an older instance cannot
   // delete a replacement instance's active sandbox after an ownership check.
-  const sandboxBase = path.join(sandboxRoot, `${sessionID}-${state.instanceID}`);
+  const sandboxBase = path.join(sandboxRoot.path, `${sessionID}-${state.instanceID}`);
   state.ownedSandboxes.set(sessionID, sandboxBase);
 
   if (!state.processStartToken) {
@@ -463,12 +616,146 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   const buildDir = path.join(sandboxBase, "build");
   const packagesDir = path.join(sandboxBase, "packages");
 
-  fs.mkdirSync(buildDir, { recursive: true });
-  fs.mkdirSync(packagesDir, { recursive: true });
-  writeSandboxOwner(sandboxBase, state.processStartToken, state.instanceID);
+  const sandboxIdentity = secureSandboxDirectory(sandboxBase, sandboxRoot);
+  state.ownedSandboxIdentities.set(sessionID, sandboxIdentity);
+  if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
+  secureSandboxDirectory(buildDir, sandboxIdentity);
+  secureSandboxDirectory(packagesDir, sandboxIdentity);
+  writeSandboxOwner(
+    sandboxIdentity,
+    state.processStartToken,
+    state.instanceID,
+  );
 
   output.env.SANDBOX_DERIVED_DATA = buildDir;
   output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+function secureSandboxRoot(state) {
+  if (state.sandboxRoot) {
+    revalidateSandboxDirectory(state.sandboxRoot);
+    return state.sandboxRoot;
+  }
+
+  const temporaryDirectory = path.resolve(os.tmpdir());
+  const canonicalTemporaryDirectory = canonicalPath(temporaryDirectory);
+  const sandboxRoot = path.join(temporaryDirectory, XCODE_SANDBOX_DIR);
+  const expectedCanonicalPath = path.join(
+    canonicalTemporaryDirectory,
+    XCODE_SANDBOX_DIR,
+  );
+
+  createDirectoryNonRecursively(sandboxRoot);
+  const identity = inspectSandboxDirectory(
+    sandboxRoot,
+    expectedCanonicalPath,
+    null,
+  );
+  state.sandboxRoot = identity;
+  return identity;
+}
+
+function secureSandboxDirectory(directoryPath, parentIdentity) {
+  revalidateSandboxDirectory(parentIdentity);
+
+  const candidate = path.resolve(directoryPath);
+  const parentPath = path.resolve(parentIdentity.path);
+  if (path.dirname(candidate) !== parentPath) {
+    throw new Error("Sandbox directory must be a direct child of its trusted parent");
+  }
+
+  const name = path.basename(candidate);
+  if (!SAFE_ID_RE.test(name)) {
+    throw new Error("Sandbox directory has an unsafe name");
+  }
+
+  createDirectoryNonRecursively(candidate);
+  return inspectSandboxDirectory(
+    candidate,
+    path.join(parentIdentity.canonicalPath, name),
+    parentIdentity,
+  );
+}
+
+function createDirectoryNonRecursively(directoryPath) {
+  try {
+    fs.mkdirSync(directoryPath, { mode: XCODE_SANDBOX_MODE });
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+}
+
+function inspectSandboxDirectory(directoryPath, expectedCanonicalPath, parentIdentity) {
+  if (typeof process.getuid !== "function") {
+    throw new Error("Xcode sandbox setup requires POSIX ownership checks");
+  }
+
+  const directoryFlags =
+    fs.constants.O_RDONLY |
+    (fs.constants.O_DIRECTORY ?? 0) |
+    (fs.constants.O_NOFOLLOW ?? 0);
+  const descriptor = fs.openSync(directoryPath, directoryFlags);
+  try {
+    const before = fs.fstatSync(descriptor);
+    if (!before.isDirectory() || before.uid !== process.getuid()) {
+      throw new Error("Sandbox directory is not owned by the current user");
+    }
+
+    fs.fchmodSync(descriptor, XCODE_SANDBOX_MODE);
+    const after = fs.fstatSync(descriptor);
+    const link = fs.lstatSync(directoryPath);
+    if (
+      !after.isDirectory() ||
+      !link.isDirectory() ||
+      link.isSymbolicLink() ||
+      after.uid !== process.getuid() ||
+      link.uid !== process.getuid() ||
+      after.dev !== link.dev ||
+      after.ino !== link.ino ||
+      (after.mode & 0o777) !== XCODE_SANDBOX_MODE
+    ) {
+      throw new Error("Sandbox directory identity changed during validation");
+    }
+
+    const resolved = canonicalPath(directoryPath);
+    if (resolved !== path.resolve(expectedCanonicalPath)) {
+      throw new Error("Sandbox directory escaped its trusted parent");
+    }
+
+    return {
+      path: path.resolve(directoryPath),
+      canonicalPath: resolved,
+      dev: after.dev,
+      ino: after.ino,
+      uid: after.uid,
+      parent: parentIdentity,
+    };
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function revalidateSandboxDirectory(identity) {
+  if (!identity) throw new Error("Sandbox directory identity is unavailable");
+  if (identity.parent) revalidateSandboxDirectory(identity.parent);
+
+  const current = inspectSandboxDirectory(
+    identity.path,
+    identity.canonicalPath,
+    identity.parent,
+  );
+  if (
+    current.dev !== identity.dev ||
+    current.ino !== identity.ino ||
+    current.uid !== identity.uid
+  ) {
+    throw new Error("Sandbox directory was replaced");
+  }
+  return current;
+}
+
+function canonicalPath(filePath) {
+  return fs.realpathSync.native?.(filePath) ?? fs.realpathSync(filePath);
 }
 
 function sandboxSetupIsCancelled(state, sessionID, sandboxBase) {
@@ -479,15 +766,25 @@ function sandboxSetupIsCancelled(state, sessionID, sandboxBase) {
   );
 }
 
-function writeSandboxOwner(sandboxBase, processStartToken, instanceID) {
+function writeSandboxOwner(sandboxIdentity, processStartToken, instanceID) {
+  revalidateSandboxDirectory(sandboxIdentity);
+  const sandboxBase = sandboxIdentity.path;
   const ownerPath = path.join(sandboxBase, "owner.pid");
   const temporaryPath = path.join(sandboxBase, `owner.pid.${instanceID}.tmp`);
   const content = `${process.pid}\n${process.argv[0] ?? "opencode"}\n${processStartToken}\n${instanceID}\n`;
-  const ownerLock = acquireSandboxOwnerLock(sandboxBase);
+  const ownerLock = acquireSandboxOwnerLock(
+    sandboxBase,
+    sandboxIdentity.parent,
+    sandboxIdentity,
+  );
   if (!ownerLock) throw new Error("Sandbox owner is being updated or removed");
 
   try {
-    fs.writeFileSync(temporaryPath, content, "utf8");
+    fs.writeFileSync(temporaryPath, content, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
     if (!sandboxOwnerLockIsHeld(ownerLock)) {
       throw new Error("Sandbox owner lock changed during update");
     }
@@ -510,7 +807,11 @@ function markSandboxCleanupPending(sandboxBase, instanceID, ownerLock) {
   const content = `${process.pid}\ncleanup-pending\n\n${instanceID}\ncleanup-pending\n`;
 
   try {
-    fs.writeFileSync(temporaryPath, content, "utf8");
+    fs.writeFileSync(temporaryPath, content, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
     if (!sandboxOwnerLockIsHeld(ownerLock)) return false;
     fs.renameSync(temporaryPath, ownerPath);
     return true;
@@ -525,11 +826,31 @@ function markSandboxCleanupPending(sandboxBase, instanceID, ownerLock) {
   }
 }
 
-function acquireSandboxOwnerLock(sandboxBase) {
+function acquireSandboxOwnerLock(
+  sandboxBase,
+  sandboxRootIdentity = null,
+  expectedSandboxIdentity = null,
+) {
+  let sandboxIdentity = null;
+  if (sandboxRootIdentity) {
+    sandboxIdentity = secureExistingManagedSandbox(
+      sandboxBase,
+      sandboxRootIdentity,
+      expectedSandboxIdentity,
+    );
+    if (!sandboxIdentity) return null;
+  }
+
   const lockPath = path.join(sandboxBase, XCODE_SANDBOX_OWNER_LOCK);
   const token = randomUUID();
   const createdLock = createSandboxOwnerLock(lockPath, token);
-  if (createdLock) return createdLock;
+  if (createdLock) {
+    return attachSandboxIdentityToLock(
+      createdLock,
+      sandboxRootIdentity,
+      sandboxIdentity,
+    );
+  }
 
   const observedLock = readSandboxOwnerLock(lockPath);
   if (!observedLock) return null;
@@ -555,7 +876,16 @@ function acquireSandboxOwnerLock(sandboxBase) {
     return null;
   }
 
-  return createSandboxOwnerLock(lockPath, token);
+  return attachSandboxIdentityToLock(
+    createSandboxOwnerLock(lockPath, token),
+    sandboxRootIdentity,
+    sandboxIdentity,
+  );
+}
+
+function attachSandboxIdentityToLock(ownerLock, sandboxRootIdentity, sandboxIdentity) {
+  if (!ownerLock || !sandboxRootIdentity || !sandboxIdentity) return ownerLock;
+  return { ...ownerLock, sandboxRootIdentity, sandboxIdentity };
 }
 
 function createSandboxOwnerLock(lockPath, token) {
@@ -612,6 +942,16 @@ function sameSandboxOwnerLock(left, right) {
 }
 
 function sandboxOwnerLockIsHeld(ownerLock) {
+  if (
+    ownerLock?.sandboxRootIdentity &&
+    !secureExistingManagedSandbox(
+      ownerLock.sandboxIdentity.path,
+      ownerLock.sandboxRootIdentity,
+      ownerLock.sandboxIdentity,
+    )
+  ) {
+    return false;
+  }
   return sameSandboxOwnerLock(ownerLock, readSandboxOwnerLock(ownerLock.path));
 }
 
@@ -666,42 +1006,78 @@ async function removeOwnedSandbox(state, sessionID) {
   const sandboxPath = state.ownedSandboxes.get(sessionID);
   if (!sandboxPath) return;
 
+  const sandboxIdentity = state.ownedSandboxIdentities.get(sessionID);
   markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.delete(sessionID);
-  const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+  state.ownedSandboxIdentities.delete(sessionID);
+  if (!state.sandboxRoot || !sandboxIdentity) return;
+
+  const quarantinedPath = await quarantineOwnedSandbox(
+    sandboxPath,
+    state.instanceID,
+    state.sandboxRoot,
+    sandboxIdentity,
+  );
+  const cleanupIdentity = quarantinedPath
+    ? relocatedSandboxIdentity(sandboxIdentity, quarantinedPath)
+    : sandboxIdentity;
   await removeManagedSandbox(
     quarantinedPath || sandboxPath,
     quarantinedPath ? "" : state.instanceID,
+    state.sandboxRoot,
+    cleanupIdentity,
   );
 }
 
 async function detachOwnedSandboxes(state) {
   state.disposed = true;
-  const sandboxPaths = [...new Set(state.ownedSandboxes.values())];
+  const sandboxes = [...state.ownedSandboxes.entries()].map(([sessionID, sandboxPath]) => ({
+    sandboxPath,
+    sandboxIdentity: state.ownedSandboxIdentities.get(sessionID),
+  }));
+  const sandboxPaths = [...new Set(sandboxes.map(({ sandboxPath }) => sandboxPath))];
   for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
+  state.ownedSandboxIdentities.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
   const cleanupTargets = await Promise.all(
-    sandboxPaths.map(async (sandboxPath) => {
-      const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+    sandboxes.map(async ({ sandboxPath, sandboxIdentity }) => {
+      if (!state.sandboxRoot || !sandboxIdentity) return null;
+      const quarantinedPath = await quarantineOwnedSandbox(
+        sandboxPath,
+        state.instanceID,
+        state.sandboxRoot,
+        sandboxIdentity,
+      );
       return {
         path: quarantinedPath || sandboxPath,
         expectedInstanceID: quarantinedPath ? "" : state.instanceID,
+        identity: quarantinedPath
+          ? relocatedSandboxIdentity(sandboxIdentity, quarantinedPath)
+          : sandboxIdentity,
       };
     }),
   );
   await Promise.all(
-    cleanupTargets.map(({ path: sandboxPath, expectedInstanceID }) =>
-      detachManagedSandbox(sandboxPath, expectedInstanceID),
+    cleanupTargets.filter(Boolean).map(({ path: sandboxPath, expectedInstanceID, identity }) =>
+      detachManagedSandbox(
+        sandboxPath,
+        expectedInstanceID,
+        state.sandboxRoot,
+        identity,
+      ),
     ),
   );
 }
 
-async function sweepStaleSandboxes(sandboxRoot) {
+async function sweepStaleSandboxes(sandboxRootIdentity) {
   let entries;
   try {
-    entries = await fs.promises.readdir(sandboxRoot, { withFileTypes: true });
+    revalidateSandboxDirectory(sandboxRootIdentity);
+    entries = await fs.promises.readdir(sandboxRootIdentity.path, {
+      withFileTypes: true,
+    });
   } catch {
     return;
   }
@@ -711,7 +1087,12 @@ async function sweepStaleSandboxes(sandboxRoot) {
       const isQuarantine = XCODE_SANDBOX_QUARANTINE_RE.test(entry.name);
       if (!entry.isDirectory() || (!SAFE_ID_RE.test(entry.name) && !isQuarantine)) return;
 
-      const sandboxPath = path.join(sandboxRoot, entry.name);
+      const sandboxPath = path.join(sandboxRootIdentity.path, entry.name);
+      const sandboxIdentity = secureExistingManagedSandbox(
+        sandboxPath,
+        sandboxRootIdentity,
+      );
+      if (!sandboxIdentity) return;
       const owner = await readSandboxOwner(sandboxPath);
       const cleanupPending = owner?.cleanupPending || sandboxCleanupIsPending(sandboxPath);
       if (!owner || cleanupPending) {
@@ -719,7 +1100,11 @@ async function sweepStaleSandboxes(sandboxRoot) {
           return;
         }
 
-        const ownerLock = acquireSandboxOwnerLock(sandboxPath);
+        const ownerLock = acquireSandboxOwnerLock(
+          sandboxPath,
+          sandboxRootIdentity,
+          sandboxIdentity,
+        );
         if (!ownerLock) return;
         let releaseLock = ownerLock;
         try {
@@ -733,10 +1118,20 @@ async function sweepStaleSandboxes(sandboxRoot) {
             (!currentOwner || currentCleanupPending) &&
             sandboxOwnerLockIsHeld(ownerLock)
           ) {
-            const quarantined = await quarantineManagedSandbox(sandboxPath, ownerLock);
+            const quarantined = await quarantineManagedSandbox(
+              sandboxPath,
+              ownerLock,
+              sandboxRootIdentity,
+              sandboxIdentity,
+            );
             releaseLock = quarantined.ownerLock;
             if (quarantined.path) {
-              await removeManagedSandbox(quarantined.path);
+              await removeManagedSandbox(
+                quarantined.path,
+                "",
+                sandboxRootIdentity,
+                relocatedSandboxIdentity(sandboxIdentity, quarantined.path),
+              );
             }
           }
         } finally {
@@ -746,7 +1141,12 @@ async function sweepStaleSandboxes(sandboxRoot) {
       }
       if (await sandboxOwnerIsActive(owner)) return;
 
-      await removeManagedSandbox(sandboxPath);
+      await removeManagedSandbox(
+        sandboxPath,
+        "",
+        sandboxRootIdentity,
+        sandboxIdentity,
+      );
     }),
   );
 }
@@ -805,9 +1205,11 @@ async function sandboxOwnerIsActive(owner) {
 function readProcessStartToken(pid) {
   return new Promise((resolve) => {
     let settled = false;
+    let timedOut = false;
     let stdout = "";
     let child;
-    let timer;
+    let timeoutTimer;
+    let forceKillTimer;
 
     try {
       child = spawn("/bin/ps", ["-p", String(pid), "-o", "lstart="], {
@@ -824,37 +1226,61 @@ function readProcessStartToken(pid) {
       return;
     }
 
-    child.stdout?.setEncoding?.("utf8");
-    child.stdout?.on?.("data", (chunk) => {
+    const onData = (chunk) => {
       const remaining = PROCESS_START_OUTPUT_MAX_CHARS - stdout.length;
       if (remaining > 0) stdout += String(chunk).slice(0, remaining);
-    });
-    child.on("error", () => finish(""));
-    child.on("close", (code) => {
+    };
+    const onError = () => finish("");
+    const onClose = (code) => {
       const firstLine = stdout.trim().split(/\r?\n/, 1)[0] ?? "";
-      finish(code === 0 ? firstLine : "");
-    });
-    timer = setTimeout(() => {
-      try {
-        child.kill?.("SIGTERM");
-      } catch {
-        // Resolving the hook is more important than terminating a broken ps shim.
-      }
-      finish("");
+      finish(!timedOut && code === 0 ? firstLine : "");
+    };
+
+    child.stdout?.setEncoding?.("utf8");
+    child.stdout?.on?.("data", onData);
+    child.on("error", onError);
+    child.on("close", onClose);
+    timeoutTimer = setTimeout(() => {
+      if (settled) return;
+      timedOut = true;
+      forceKillTimer = terminateChildAfterGrace(
+        child,
+        () => !settled,
+        () => finish(""),
+      );
     }, PROCESS_START_TIMEOUT_MS);
 
     function finish(value) {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      clearTimeout(timeoutTimer);
+      clearTimeout(forceKillTimer);
+      child.stdout?.removeListener?.("data", onData);
+      child.removeListener?.("error", onError);
+      child.removeListener?.("close", onClose);
       resolve(value);
     }
   });
 }
 
-async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
+async function removeManagedSandbox(
+  sandboxPath,
+  expectedInstanceID = "",
+  sandboxRootIdentity = null,
+  expectedSandboxIdentity = null,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
   if (!candidate) return false;
+  if (
+    !sandboxRootIdentity ||
+    !secureExistingManagedSandbox(
+      candidate,
+      sandboxRootIdentity,
+      expectedSandboxIdentity,
+    )
+  ) {
+    return false;
+  }
 
   if (expectedInstanceID) {
     const owner = await readSandboxOwner(candidate);
@@ -871,11 +1297,26 @@ async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
   }
 }
 
-async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
+async function quarantineOwnedSandbox(
+  sandboxPath,
+  expectedInstanceID,
+  sandboxRootIdentity,
+  expectedSandboxIdentity,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
   if (!candidate) return "";
+  const sandboxIdentity = secureExistingManagedSandbox(
+    candidate,
+    sandboxRootIdentity,
+    expectedSandboxIdentity,
+  );
+  if (!sandboxIdentity) return "";
 
-  const ownerLock = acquireSandboxOwnerLock(candidate);
+  const ownerLock = acquireSandboxOwnerLock(
+    candidate,
+    sandboxRootIdentity,
+    sandboxIdentity,
+  );
   if (!ownerLock) return "";
   let releaseLock = ownerLock;
 
@@ -897,7 +1338,21 @@ async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
     releaseLock = {
       ...ownerLock,
       path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+      sandboxIdentity: relocatedSandboxIdentity(sandboxIdentity, quarantinePath),
     };
+    if (
+      !secureExistingManagedSandbox(
+        quarantinePath,
+        sandboxRootIdentity,
+        releaseLock.sandboxIdentity,
+      )
+    ) {
+      if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+        movePendingSandboxCleanup(quarantinePath, candidate);
+        releaseLock = ownerLock;
+      }
+      return "";
+    }
     const relocatedOwner = await readSandboxOwner(quarantinePath);
     if (
       !sandboxOwnerLockIsHeld(releaseLock) ||
@@ -907,7 +1362,7 @@ async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
     ) {
       if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
         movePendingSandboxCleanup(quarantinePath, candidate);
-        releaseLock = { ...releaseLock, path: ownerLock.path };
+        releaseLock = ownerLock;
       }
       return "";
     }
@@ -926,9 +1381,21 @@ async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
   }
 }
 
-async function quarantineManagedSandbox(sandboxPath, ownerLock) {
+async function quarantineManagedSandbox(
+  sandboxPath,
+  ownerLock,
+  sandboxRootIdentity,
+  expectedSandboxIdentity,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
-  if (!candidate || !sandboxOwnerLockIsHeld(ownerLock)) {
+  const sandboxIdentity = candidate
+    ? secureExistingManagedSandbox(
+        candidate,
+        sandboxRootIdentity,
+        expectedSandboxIdentity,
+      )
+    : null;
+  if (!candidate || !sandboxIdentity || !sandboxOwnerLockIsHeld(ownerLock)) {
     return { path: "", ownerLock };
   }
 
@@ -945,7 +1412,21 @@ async function quarantineManagedSandbox(sandboxPath, ownerLock) {
   const relocatedLock = {
     ...ownerLock,
     path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+    sandboxIdentity: relocatedSandboxIdentity(sandboxIdentity, quarantinePath),
   };
+  if (
+    !secureExistingManagedSandbox(
+      quarantinePath,
+      sandboxRootIdentity,
+      relocatedLock.sandboxIdentity,
+    )
+  ) {
+    if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+      movePendingSandboxCleanup(quarantinePath, candidate);
+      return { path: "", ownerLock };
+    }
+    return { path: "", ownerLock: relocatedLock };
+  }
   const publishedOwner = await readSandboxOwner(quarantinePath);
   const cleanupPending =
     publishedOwner?.cleanupPending || sandboxCleanupIsPending(quarantinePath);
@@ -973,9 +1454,24 @@ function restoreQuarantinedSandbox(quarantinePath, originalPath) {
   }
 }
 
-async function detachManagedSandbox(sandboxPath, expectedInstanceID = "") {
+async function detachManagedSandbox(
+  sandboxPath,
+  expectedInstanceID = "",
+  sandboxRootIdentity = null,
+  expectedSandboxIdentity = null,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
   if (!candidate) return;
+  if (
+    !sandboxRootIdentity ||
+    !secureExistingManagedSandbox(
+      candidate,
+      sandboxRootIdentity,
+      expectedSandboxIdentity,
+    )
+  ) {
+    return;
+  }
 
   if (expectedInstanceID) {
     const owner = await readSandboxOwner(candidate);
@@ -1003,6 +1499,49 @@ function managedSandboxCandidate(sandboxPath) {
   const relative = path.relative(sandboxRoot, candidate);
   if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return "";
   return candidate;
+}
+
+function secureExistingManagedSandbox(
+  sandboxPath,
+  sandboxRootIdentity,
+  expectedSandboxIdentity = null,
+) {
+  try {
+    revalidateSandboxDirectory(sandboxRootIdentity);
+    const candidate = managedSandboxCandidate(sandboxPath);
+    if (!candidate || path.dirname(candidate) !== sandboxRootIdentity.path) return null;
+
+    const name = path.basename(candidate);
+    if (!SAFE_ID_RE.test(name) && !XCODE_SANDBOX_QUARANTINE_RE.test(name)) {
+      return null;
+    }
+
+    const current = inspectSandboxDirectory(
+      candidate,
+      path.join(sandboxRootIdentity.canonicalPath, name),
+      sandboxRootIdentity,
+    );
+    if (
+      expectedSandboxIdentity &&
+      (current.dev !== expectedSandboxIdentity.dev ||
+        current.ino !== expectedSandboxIdentity.ino ||
+        current.uid !== expectedSandboxIdentity.uid)
+    ) {
+      return null;
+    }
+    return current;
+  } catch {
+    return null;
+  }
+}
+
+function relocatedSandboxIdentity(identity, destinationPath) {
+  const name = path.basename(destinationPath);
+  return {
+    ...identity,
+    path: path.resolve(destinationPath),
+    canonicalPath: path.join(identity.parent.canonicalPath, name),
+  };
 }
 
 function markPendingSandboxCleanup(sandboxPath) {

--- a/PluginBase/info.json
+++ b/PluginBase/info.json
@@ -2,6 +2,10 @@
     "skills": [],
     "versions": [
         {
+            "version": "0.2.13",
+            "changes": "Added the shared OpenCode plugin adapter and per-plugin opencode-plugin.js entry point template."
+        },
+        {
             "version": "0.2.12",
             "changes": "Released self-contained common helper copies so the plugin package no longer depends on repository-level symlinks, while keeping hook configuration in hooks/hooks.json instead of generated common/hooks.json templates."
         },

--- a/PluginBase/opencode-plugin.js
+++ b/PluginBase/opencode-plugin.js
@@ -1,0 +1,6 @@
+import { createOpenCodePlugin } from "./common/opencode-plugin.js";
+
+export default {
+  id: "PluginBase",
+  server: createOpenCodePlugin(new URL(".", import.meta.url)),
+};

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ A curated collection of Claude Code-compatible plugins for various development w
 
 The marketplace uses Claude Code's plugin packaging contracts (`.claude-plugin`,
 `CLAUDE_PLUGIN_ROOT`, plugin install commands), but agent-facing instructions are
-kept neutral so compatible hosts such as Codex can consume the same skills and
+kept neutral so compatible hosts such as OpenCode and Codex can consume the same skills and
 prompts where supported.
 
 ## Quick Start
 
-### Adding the Marketplace
+### Claude Code
+
+#### Adding the Marketplace
 
 Install this marketplace to access all available plugins:
 
@@ -21,7 +23,7 @@ Install this marketplace to access all available plugins:
 /plugin marketplace add /path/to/ClaudeCodePlugins
 ```
 
-### Installing Plugins
+#### Installing Plugins
 
 Once the marketplace is added, install plugins:
 
@@ -32,6 +34,21 @@ Once the marketplace is added, install plugins:
 # Install a specific plugin
 /plugin install XcodeBuildTools@ClaudeCodePlugins
 ```
+
+### OpenCode
+
+OpenCode does not consume Claude Code marketplace manifests directly. Clone this repository and add the local plugin entry point for each plugin you want to use to `~/.config/opencode/opencode.json` or a project `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    "/path/to/ClaudeCodePlugins/XcodeBuildTools/opencode-plugin.js"
+  ]
+}
+```
+
+Use the matching plugin directory for other plugins, for example `iOSSimulator/opencode-plugin.js`, `SwiftScaffolding/opencode-plugin.js`, or `MarvinOutputStyle/opencode-plugin.js`. Restart OpenCode after changing config. The entry point registers the plugin's skills, MCP servers, session context, and OpenCode hooks.
 
 ## Available Plugins
 
@@ -167,6 +184,8 @@ The same command runs in GitHub Actions on push and pull request.
 
 ### Testing Plugin Installation
 
+Claude Code:
+
 ```bash
 # Add marketplace from local directory
 /plugin marketplace add /path/to/ClaudeCodePlugins
@@ -177,6 +196,19 @@ The same command runs in GitHub Actions on push and pull request.
 # Verify plugin works
 /plugin list
 ```
+
+OpenCode:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    "/path/to/ClaudeCodePlugins/XcodeBuildTools/opencode-plugin.js"
+  ]
+}
+```
+
+Restart OpenCode after changing the config.
 
 ### Creating New Plugins
 

--- a/README.md
+++ b/README.md
@@ -101,12 +101,27 @@ Follow the standard Claude Code-compatible plugin structure:
 YourPlugin/
 ├── .claude-plugin/
 │   └── plugin.json
+├── common/                 # Generated shared helpers
 ├── skills/                 # Optional: agent skills
 ├── agents/                 # Optional: custom agents
 ├── hooks/                  # Optional: lifecycle hooks
 ├── .mcp.json              # Optional: MCP servers
+├── opencode-plugin.js     # OpenCode local plugin entry point
 └── README.md
 ```
+
+Create `YourPlugin/opencode-plugin.js` with an ID that exactly matches the plugin folder:
+
+```js
+import { createOpenCodePlugin } from "./common/opencode-plugin.js";
+
+export default {
+  id: "YourPlugin",
+  server: createOpenCodePlugin(new URL(".", import.meta.url)),
+};
+```
+
+Then run `python3 scripts/sync-plugin-common.py` from the repository root to generate the plugin's self-contained `common/` helpers.
 
 ### 2. Add to Repository
 
@@ -218,9 +233,13 @@ Use an existing plugin as a template:
 # Copy structure from an existing plugin
 cp -r XcodeBuildTools YourNewPlugin
 
-# Update metadata in .claude-plugin/plugin.json
+# Update metadata in .claude-plugin/plugin.json and marketplace.json
+# Change the id in opencode-plugin.js to exactly match YourNewPlugin
 # Customize skills, hooks, agents
 # Update README.md
+
+# Refresh the generated common helpers
+python3 scripts/sync-plugin-common.py
 ```
 
 ## Resources

--- a/SwiftScaffolding/.claude-plugin/plugin.json
+++ b/SwiftScaffolding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "SwiftScaffolding",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Swift project scaffolding and code generation tools",
   "author": {
     "name": "Gustavo Ambrozio"

--- a/SwiftScaffolding/README.md
+++ b/SwiftScaffolding/README.md
@@ -31,7 +31,7 @@ OpenCode:
 }
 ```
 
-Restart OpenCode after changing config. The OpenCode entry point registers this plugin's skill, XcodeBuildMCP server, session context, and command guardrails.
+Restart OpenCode after changing config. The OpenCode entry point registers this plugin's skill, XcodeBuildMCP server, and session context.
 
 ## Prerequisites
 
@@ -46,7 +46,7 @@ Use the `scaffolding` skill to scaffold Swift projects.
 
 ### 0.4.4
 - Added `opencode-plugin.js` for OpenCode users
-- The OpenCode entry point registers the `scaffolding` skill, XcodeBuildMCP server, session context, and command guardrails
+- The OpenCode entry point registers the `scaffolding` skill, XcodeBuildMCP server, and session context
 
 ### 0.4.3
 - Migrated the legacy scaffolding prompt to the `scaffolding` skill

--- a/SwiftScaffolding/README.md
+++ b/SwiftScaffolding/README.md
@@ -10,6 +10,8 @@ Swift project scaffolding and code generation tools.
 
 ## Installation
 
+Claude Code:
+
 ```bash
 # Add the marketplace
 /plugin marketplace add gpambrozio/ClaudeCodePlugins
@@ -17,6 +19,19 @@ Swift project scaffolding and code generation tools.
 # Install this plugin
 /plugin install SwiftScaffolding@ClaudeCodePlugins
 ```
+
+OpenCode:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    "/path/to/ClaudeCodePlugins/SwiftScaffolding/opencode-plugin.js"
+  ]
+}
+```
+
+Restart OpenCode after changing config. The OpenCode entry point registers this plugin's skill, XcodeBuildMCP server, session context, and command guardrails.
 
 ## Prerequisites
 
@@ -28,6 +43,10 @@ Swift project scaffolding and code generation tools.
 Use the `scaffolding` skill to scaffold Swift projects.
 
 ## Changelog
+
+### 0.4.4
+- Added `opencode-plugin.js` for OpenCode users
+- The OpenCode entry point registers the `scaffolding` skill, XcodeBuildMCP server, session context, and command guardrails
 
 ### 0.4.3
 - Migrated the legacy scaffolding prompt to the `scaffolding` skill

--- a/SwiftScaffolding/common/opencode-plugin.js
+++ b/SwiftScaffolding/common/opencode-plugin.js
@@ -271,7 +271,7 @@ function applyPreToolUseRules(state, input, output) {
     if (decision === "deny") throw new Error(message);
 
     const ruleName = typeof rule.name === "string" && rule.name ? rule.name : matchPattern;
-    const key = `${input.sessionID ?? "global"}:${ruleName}`;
+    const key = `${safeSessionID(input.sessionID ?? "global")}:${ruleName}`;
     if (state.deniedOnce.has(key)) continue;
 
     state.deniedOnce.add(key);

--- a/SwiftScaffolding/common/opencode-plugin.js
+++ b/SwiftScaffolding/common/opencode-plugin.js
@@ -85,7 +85,10 @@ export function createOpenCodePlugin(pluginRootUrl) {
     const mcpContext = {
       pluginRoot,
       pluginData: () => pluginDataDirectory(pluginRoot, state),
-      projectDir: input?.worktree || input?.directory,
+      projectDir:
+        input?.worktree !== "/" || input?.project?.vcs === "git"
+          ? input?.worktree || input?.directory
+          : input?.directory || input?.worktree,
     };
 
     return {

--- a/SwiftScaffolding/common/opencode-plugin.js
+++ b/SwiftScaffolding/common/opencode-plugin.js
@@ -17,6 +17,9 @@ const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9
 const PROCESS_START_OUTPUT_MAX_CHARS = 256;
 const PROCESS_START_TIMEOUT_MS = 5_000;
 const PROCESS_TERMINATION_GRACE_MS = 250;
+const SYSTEM_EXECUTABLE_PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+const SYSTEM_PGREP = "/usr/bin/pgrep";
+const SYSTEM_XCRUN = "/usr/bin/xcrun";
 const XCODE_MCP_CACHE_TTL_MS = 30_000;
 const XCRUN_OPTIONS_WITH_VALUE = new Set([
   "--sdk",
@@ -75,6 +78,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       deniedOnce: new Set(),
       xcodeMcpCache: new Map(),
       xcodeMcpApprovalSessions: new Set(),
+      xcodeMcpApprovalHelpers: new Map(),
       sandboxRoot: null,
       ownedSandboxes: new Map(),
       ownedSandboxIdentities: new Map(),
@@ -127,6 +131,8 @@ export function createOpenCodePlugin(pluginRootUrl) {
       },
 
       dispose: async () => {
+        state.disposed = true;
+        await stopAllXcodeMcpApprovals(state);
         await detachOwnedSandboxes(state);
       },
     };
@@ -353,8 +359,11 @@ async function appendSystemContext(pluginRoot, state, input, output) {
   const pluginName = state.pluginJson.name ?? path.basename(pluginRoot);
   const welcomeMessage = typeof state.infoJson.welcomeMessage === "string" ? state.infoJson.welcomeMessage : "";
   const sessionID = safeSessionID(input?.sessionID ?? "global");
-  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state, sessionID);
-  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state, sessionID);
+  let xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state, sessionID);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) xcodeMcpLikely = false;
+  if (xcodeMcpLikely && !xcodeMcpLifecycleCancelled(state, sessionID)) {
+    startXcodeMcpApproval(pluginRoot, state, sessionID);
+  }
   const sessionStart = renderSessionStart(pluginRoot, xcodeMcpLikely);
 
   let systemMessage = `The ${pluginName} plugin is loaded and ready.`;
@@ -386,6 +395,7 @@ function processConditionalBlocks(content, xcodeMcpLikely) {
 }
 
 async function getXcodeMcpLikely(pluginName, state, sessionID) {
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
   if (pluginName !== "XcodeBuildTools") return false;
   if (!hasConfiguredMcpbridge(state.config)) {
     state.xcodeMcpCache.delete(sessionID);
@@ -396,17 +406,26 @@ async function getXcodeMcpLikely(pluginName, state, sessionID) {
   const cached = state.xcodeMcpCache.get(sessionID);
   if (cached && now - cached.checkedAt < XCODE_MCP_CACHE_TTL_MS) return cached.value;
 
-  const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
+  const installed = await commandSucceeds(SYSTEM_XCRUN, ["--find", "mcpbridge"], 5000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
   if (!installed) {
     state.xcodeMcpCache.set(sessionID, { checkedAt: now, value: false });
     return false;
   }
 
-  const xcodeRunning = await commandSucceeds("pgrep", ["-x", "Xcode"], 3000);
-  const bridgeRunning = await commandSucceeds("pgrep", ["-f", "mcpbridge"], 3000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
+  const xcodeRunning = await commandSucceeds(SYSTEM_PGREP, ["-x", "Xcode"], 3000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
+  const bridgeRunning = await commandSucceeds(SYSTEM_PGREP, ["-f", "mcpbridge"], 3000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
   const value = xcodeRunning || bridgeRunning;
   state.xcodeMcpCache.set(sessionID, { checkedAt: now, value });
   return value;
+}
+
+function xcodeMcpLifecycleCancelled(state, sessionID) {
+  return state.disposed || state.deletedSandboxSessions.has(sessionID);
 }
 
 function hasConfiguredMcpbridge(config) {
@@ -453,30 +472,148 @@ function xcrunToolBasename(args) {
 }
 
 function startXcodeMcpApproval(pluginRoot, state, sessionID) {
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return;
   if (state.xcodeMcpApprovalSessions.has(sessionID)) return;
 
-  const runner = path.join(pluginRoot, "hooks", "run-background.sh");
-  const target = path.join("hooks", "approve-xcode-mcp.sh");
-  if (!fs.existsSync(runner)) return;
+  const helper = path.join(pluginRoot, "hooks", "approve-xcode-mcp.sh");
+  if (!fs.existsSync(helper)) return;
 
   try {
+    if (xcodeMcpLifecycleCancelled(state, sessionID)) return;
     state.xcodeMcpApprovalSessions.add(sessionID);
-    const child = spawn(runner, [target], {
+    const child = spawn(helper, [], {
       cwd: pluginRoot,
       detached: true,
       env: {
         ...process.env,
+        PATH: SYSTEM_EXECUTABLE_PATH,
         CLAUDE_HOOK_OWNER_PID: String(process.pid),
         CLAUDE_PLUGIN_ROOT: pluginRoot,
       },
       stdio: "ignore",
     });
-    child.on("error", () => state.xcodeMcpApprovalSessions.delete(sessionID));
+    trackXcodeMcpApprovalHelper(state, sessionID, child);
     child.unref();
   } catch {
     state.xcodeMcpApprovalSessions.delete(sessionID);
     // Auto-approval is best-effort; users can still approve Xcode manually.
   }
+}
+
+function trackXcodeMcpApprovalHelper(state, sessionID, child) {
+  let resolveDone;
+  const record = {
+    child,
+    done: new Promise((resolve) => {
+      resolveDone = resolve;
+    }),
+    pending: true,
+    terminating: false,
+    terminationPromise: null,
+    finish: null,
+    removeFromState: null,
+  };
+
+  const removeFromState = () => {
+    if (state.xcodeMcpApprovalHelpers.get(sessionID) === record) {
+      state.xcodeMcpApprovalHelpers.delete(sessionID);
+    }
+  };
+  const onError = () => finish(true);
+  const onExit = () => finish(false);
+  const finish = (allowRetry) => {
+    if (!record.pending) return;
+    record.pending = false;
+    child.removeListener?.("error", onError);
+    child.removeListener?.("exit", onExit);
+    if (!record.terminating) removeFromState();
+    if (allowRetry) state.xcodeMcpApprovalSessions.delete(sessionID);
+    resolveDone();
+  };
+  record.finish = finish;
+  record.removeFromState = removeFromState;
+
+  state.xcodeMcpApprovalHelpers.set(sessionID, record);
+  child.on("error", onError);
+  child.on("exit", onExit);
+}
+
+function stopXcodeMcpApproval(record) {
+  if (!record) return Promise.resolve();
+  if (!record.terminationPromise) {
+    record.terminating = true;
+    record.terminationPromise = terminateXcodeMcpApproval(record).finally(() => {
+      record.terminating = false;
+      record.removeFromState();
+    });
+  }
+  return record.terminationPromise;
+}
+
+async function terminateXcodeMcpApproval(record) {
+  if (!record.pending) return;
+
+  signalDetachedProcessGroup(record.child, "SIGTERM");
+  let forceKillTimer;
+  await new Promise((resolve) => {
+    let completed = false;
+    const complete = () => {
+      if (completed) return;
+      completed = true;
+      clearTimeout(forceKillTimer);
+      resolve();
+    };
+    const completeIfGroupExited = () => {
+      if (!detachedProcessGroupExists(record.child)) complete();
+    };
+
+    record.done.then(completeIfGroupExited);
+    if (!detachedProcessGroupExists(record.child)) {
+      record.finish(false);
+      complete();
+      return;
+    }
+
+    forceKillTimer = setTimeout(() => {
+      if (detachedProcessGroupExists(record.child)) {
+        signalDetachedProcessGroup(record.child, "SIGKILL");
+      }
+      record.finish(false);
+      complete();
+    }, PROCESS_TERMINATION_GRACE_MS);
+  });
+}
+
+function detachedProcessGroupExists(child) {
+  const pid = Number(child?.pid);
+  if (!Number.isSafeInteger(pid) || pid <= 0) return child != null;
+
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function signalDetachedProcessGroup(child, signal) {
+  const pid = Number(child?.pid);
+  try {
+    if (Number.isSafeInteger(pid) && pid > 0) {
+      process.kill(-pid, signal);
+    } else {
+      child?.kill?.(signal);
+    }
+  } catch {
+    // The helper may have exited between the lifecycle check and the signal.
+  }
+}
+
+async function stopAllXcodeMcpApprovals(state) {
+  const activeHelpers = [...state.xcodeMcpApprovalHelpers.values()];
+  state.xcodeMcpApprovalSessions.clear();
+  await Promise.all(activeHelpers.map((record) => stopXcodeMcpApproval(record)));
+  state.xcodeMcpApprovalHelpers.clear();
 }
 
 function commandSucceeds(command, args, timeoutMs) {
@@ -1002,6 +1139,8 @@ async function handlePluginEvent(state, event) {
   state.deletedSandboxSessions.add(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
+  const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
+  await stopXcodeMcpApproval(activeApproval);
   await removeOwnedSandbox(state, safeID);
 }
 
@@ -1044,6 +1183,7 @@ async function detachOwnedSandboxes(state) {
   state.ownedSandboxIdentities.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
+  state.xcodeMcpApprovalHelpers.clear();
   const cleanupTargets = await Promise.all(
     sandboxes.map(async ({ sandboxPath, sandboxIdentity }) => {
       if (!state.sandboxRoot || !sandboxIdentity) return null;

--- a/SwiftScaffolding/common/opencode-plugin.js
+++ b/SwiftScaffolding/common/opencode-plugin.js
@@ -183,6 +183,7 @@ function processConditionalBlocks(content, xcodeMcpLikely) {
 
 async function getXcodeMcpLikely(pluginName, state) {
   if (pluginName !== "XcodeBuildTools") return false;
+  if (state.xcodeMcpLikely !== undefined) return state.xcodeMcpLikely;
 
   const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
   if (!installed) {

--- a/SwiftScaffolding/common/opencode-plugin.js
+++ b/SwiftScaffolding/common/opencode-plugin.js
@@ -1,0 +1,361 @@
+// Generated from common/opencode-plugin.js by scripts/sync-plugin-common.py. Do not edit this copy; edit common/opencode-plugin.js and rerun scripts/sync-plugin-common.py.
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+export function createOpenCodePlugin(pluginRootUrl) {
+  const pluginRoot = normalizePluginRoot(pluginRootUrl);
+  const state = {
+    pluginJson: null,
+    infoJson: null,
+    deniedOnce: new Set(),
+    xcodeMcpLikely: undefined,
+    xcodeMcpApprovalStarted: false,
+  };
+
+  return async () => ({
+    config: async (config) => {
+      loadMetadata(pluginRoot, state);
+      registerSkills(config, pluginRoot);
+      registerMcpServers(config, pluginRoot);
+    },
+
+    "experimental.chat.system.transform": async (_input, output) => {
+      try {
+        loadMetadata(pluginRoot, state);
+        await appendSystemContext(pluginRoot, state, output);
+      } catch {
+        // Fail open. Plugin context should never block a chat request.
+      }
+    },
+
+    "tool.execute.before": async (input, output) => {
+      loadMetadata(pluginRoot, state);
+      applyPreToolUseRules(state, input, output);
+    },
+
+    "shell.env": async (input, output) => {
+      try {
+        loadMetadata(pluginRoot, state);
+        configureShellEnvironment(pluginRoot, state, input, output);
+      } catch {
+        // Fail open. Shell commands should still run if setup is unavailable.
+      }
+    },
+  });
+}
+
+function normalizePluginRoot(pluginRootUrl) {
+  if (pluginRootUrl instanceof URL) {
+    return path.resolve(fileURLToPath(pluginRootUrl));
+  }
+
+  if (typeof pluginRootUrl === "string" && pluginRootUrl.startsWith("file:")) {
+    return path.resolve(fileURLToPath(pluginRootUrl));
+  }
+
+  return path.resolve(String(pluginRootUrl));
+}
+
+function loadMetadata(pluginRoot, state) {
+  if (!state.pluginJson) {
+    state.pluginJson = readJsonFile(path.join(pluginRoot, ".claude-plugin", "plugin.json")) ?? {};
+  }
+  if (!state.infoJson) {
+    state.infoJson = readJsonFile(path.join(pluginRoot, "info.json")) ?? {};
+  }
+}
+
+function registerSkills(config, pluginRoot) {
+  const skillsDir = path.join(pluginRoot, "skills");
+  if (!hasSkillDirectories(skillsDir)) return;
+
+  if (!isObject(config.skills)) config.skills = {};
+  if (!Array.isArray(config.skills.paths)) config.skills.paths = [];
+  if (!config.skills.paths.includes(skillsDir)) config.skills.paths.push(skillsDir);
+}
+
+function registerMcpServers(config, pluginRoot) {
+  const mcpConfig = readJsonFile(path.join(pluginRoot, ".mcp.json"));
+  const servers = mcpConfig?.mcpServers;
+  if (!isObject(servers)) return;
+
+  if (!isObject(config.mcp)) config.mcp = {};
+
+  for (const [name, server] of Object.entries(servers)) {
+    if (!isObject(server) || config.mcp[name]) continue;
+
+    const translated = translateMcpServer(server);
+    if (translated) config.mcp[name] = translated;
+  }
+}
+
+function translateMcpServer(server) {
+  if (typeof server.url === "string") {
+    const translated = {
+      type: "remote",
+      url: server.url,
+    };
+    copyOptionalFields(server, translated, ["enabled", "headers", "timeout"]);
+    return translated;
+  }
+
+  const command = normalizeCommand(server.command, server.args);
+  if (!command) return null;
+
+  const translated = {
+    type: "local",
+    command,
+  };
+  copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"]);
+
+  const environment = isObject(server.environment) ? server.environment : server.env;
+  if (isObject(environment)) translated.environment = stringifyRecord(environment);
+
+  return translated;
+}
+
+function normalizeCommand(command, args) {
+  if (Array.isArray(command) && command.every((item) => typeof item === "string")) {
+    return command;
+  }
+
+  if (typeof command !== "string") return null;
+
+  const result = [command];
+  if (Array.isArray(args)) {
+    for (const arg of args) {
+      if (typeof arg !== "string") return null;
+      result.push(arg);
+    }
+  }
+  return result;
+}
+
+function copyOptionalFields(source, target, keys) {
+  for (const key of keys) {
+    if (source[key] === undefined) continue;
+    target[key] = key === "headers" && isObject(source[key]) ? stringifyRecord(source[key]) : source[key];
+  }
+}
+
+async function appendSystemContext(pluginRoot, state, output) {
+  if (!Array.isArray(output.system)) output.system = [];
+
+  const pluginName = state.pluginJson.name ?? path.basename(pluginRoot);
+  const welcomeMessage = typeof state.infoJson.welcomeMessage === "string" ? state.infoJson.welcomeMessage : "";
+  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state);
+  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state);
+  const sessionStart = renderSessionStart(pluginRoot, xcodeMcpLikely);
+
+  let systemMessage = `The ${pluginName} plugin is loaded and ready.`;
+  if (xcodeMcpLikely) systemMessage += " Xcode MCP server detected.";
+  if (welcomeMessage) systemMessage += ` ${welcomeMessage}`;
+
+  output.system.push([systemMessage, sessionStart].filter(Boolean).join("\n\n"));
+}
+
+function renderSessionStart(pluginRoot, xcodeMcpLikely) {
+  const sessionStartPath = path.join(pluginRoot, "session-start.md");
+  const content = readTextFile(sessionStartPath);
+  if (!content) return "";
+  return processConditionalBlocks(content, xcodeMcpLikely);
+}
+
+function processConditionalBlocks(content, xcodeMcpLikely) {
+  if (xcodeMcpLikely) {
+    return content
+      .replace(/<!-- IF_XCODE_MCP -->\n?/g, "")
+      .replace(/<!-- END_XCODE_MCP -->\n?/g, "")
+      .replace(/<!-- IF_NO_XCODE_MCP -->[\s\S]*?<!-- END_NO_XCODE_MCP -->\n?/g, "");
+  }
+
+  return content
+    .replace(/<!-- IF_NO_XCODE_MCP -->\n?/g, "")
+    .replace(/<!-- END_NO_XCODE_MCP -->\n?/g, "")
+    .replace(/<!-- IF_XCODE_MCP -->[\s\S]*?<!-- END_XCODE_MCP -->\n?/g, "");
+}
+
+async function getXcodeMcpLikely(pluginName, state) {
+  if (pluginName !== "XcodeBuildTools") return false;
+
+  const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
+  if (!installed) {
+    state.xcodeMcpLikely = false;
+    return state.xcodeMcpLikely;
+  }
+
+  const xcodeRunning = await commandSucceeds("pgrep", ["-x", "Xcode"], 3000);
+  const bridgeRunning = await commandSucceeds("pgrep", ["-f", "mcpbridge"], 3000);
+  state.xcodeMcpLikely = xcodeRunning || bridgeRunning;
+  return state.xcodeMcpLikely;
+}
+
+function startXcodeMcpApproval(pluginRoot, state) {
+  if (state.xcodeMcpApprovalStarted) return;
+  state.xcodeMcpApprovalStarted = true;
+
+  const runner = path.join(pluginRoot, "hooks", "run-background.sh");
+  const target = path.join("hooks", "approve-xcode-mcp.sh");
+  if (!fs.existsSync(runner)) return;
+
+  try {
+    const child = spawn(runner, [target], {
+      cwd: pluginRoot,
+      detached: true,
+      env: {
+        ...process.env,
+        CLAUDE_HOOK_OWNER_PID: String(process.pid),
+        CLAUDE_PLUGIN_ROOT: pluginRoot,
+      },
+      stdio: "ignore",
+    });
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+    // Auto-approval is best-effort; users can still approve Xcode manually.
+  }
+}
+
+function commandSucceeds(command, args, timeoutMs) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const child = spawn(command, args, { stdio: "ignore" });
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish(false);
+    }, timeoutMs);
+
+    child.on("error", () => finish(false));
+    child.on("exit", (code) => finish(code === 0));
+
+    function finish(result) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    }
+  });
+}
+
+function applyPreToolUseRules(state, input, output) {
+  const tool = String(input.tool ?? "").toLowerCase();
+  if (tool !== "bash") return;
+
+  const command = output?.args?.command;
+  if (typeof command !== "string" || !command) return;
+
+  const rules = Array.isArray(state.infoJson["pre-tool-use-rules"])
+    ? state.infoJson["pre-tool-use-rules"]
+    : [];
+
+  for (const rule of rules) {
+    if (!isObject(rule)) continue;
+
+    const matchPattern = rule.match;
+    if (typeof matchPattern !== "string" || !regexMatches(matchPattern, command)) continue;
+
+    const notMatchPattern = rule.not_match;
+    if (typeof notMatchPattern === "string" && regexMatches(notMatchPattern, command)) continue;
+
+    const decision = rule.decision ?? "deny";
+    if (decision === "allow") return;
+
+    const message = typeof rule.message === "string" ? rule.message : "Command denied by plugin rule";
+    if (decision === "deny") throw new Error(message);
+
+    const ruleName = typeof rule.name === "string" && rule.name ? rule.name : matchPattern;
+    const key = `${input.sessionID ?? "global"}:${ruleName}`;
+    if (state.deniedOnce.has(key)) continue;
+
+    state.deniedOnce.add(key);
+    throw new Error(message);
+  }
+}
+
+function configureShellEnvironment(pluginRoot, state, input, output) {
+  if (!isObject(output.env)) output.env = {};
+
+  const binDir = path.join(pluginRoot, "bin");
+  if (fs.existsSync(binDir)) {
+    output.env.PATH = prependPath(binDir, output.env.PATH ?? process.env.PATH ?? "");
+  }
+
+  if (state.pluginJson.name !== "XcodeBuildTools") return;
+
+  const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
+  const sandboxBase = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox", sessionID);
+  const buildDir = path.join(sandboxBase, "build");
+  const packagesDir = path.join(sandboxBase, "packages");
+
+  fs.mkdirSync(buildDir, { recursive: true });
+  fs.mkdirSync(packagesDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(sandboxBase, "owner.pid"),
+    `${process.pid}\n${process.argv[0] ?? "opencode"}\n`,
+    "utf8",
+  );
+
+  output.env.SANDBOX_DERIVED_DATA = buildDir;
+  output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+function prependPath(entry, current) {
+  const parts = current.split(path.delimiter).filter(Boolean).filter((part) => part !== entry);
+  return [entry, ...parts].join(path.delimiter);
+}
+
+function safeSessionID(value) {
+  const raw = String(value ?? "");
+  if (SAFE_ID_RE.test(raw)) return raw;
+
+  const hash = createHash("sha256").update(raw || "default").digest("hex").slice(0, 16);
+  return `opencode-${hash}`;
+}
+
+function regexMatches(pattern, value) {
+  try {
+    return new RegExp(pattern).test(value);
+  } catch {
+    return false;
+  }
+}
+
+function hasSkillDirectories(skillsDir) {
+  try {
+    return fs.readdirSync(skillsDir, { withFileTypes: true }).some((entry) => {
+      return entry.isDirectory() && fs.existsSync(path.join(skillsDir, entry.name, "SKILL.md"));
+    });
+  } catch {
+    return false;
+  }
+}
+
+function readJsonFile(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function readTextFile(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function stringifyRecord(value) {
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, String(item)]));
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/SwiftScaffolding/common/opencode-plugin.js
+++ b/SwiftScaffolding/common/opencode-plugin.js
@@ -1,53 +1,71 @@
 // Generated from common/opencode-plugin.js by scripts/sync-plugin-common.py. Do not edit this copy; edit common/opencode-plugin.js and rerun scripts/sync-plugin-common.py.
 import { spawn } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const XCODE_MCP_CACHE_TTL_MS = 30_000;
+const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
 
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
-  const state = {
-    pluginJson: null,
-    infoJson: null,
-    deniedOnce: new Set(),
-    xcodeMcpLikely: undefined,
-    xcodeMcpApprovalStarted: false,
+  return async () => {
+    const state = {
+      pluginJson: null,
+      infoJson: null,
+      config: null,
+      instanceID: randomUUID(),
+      processStartToken: null,
+      deniedOnce: new Set(),
+      xcodeMcpCache: new Map(),
+      xcodeMcpApprovalSessions: new Set(),
+      ownedSandboxes: new Map(),
+      sandboxSweepDone: false,
+    };
+
+    return {
+      config: async (config) => {
+        loadMetadata(pluginRoot, state);
+        registerSkills(config, pluginRoot);
+        registerMcpServers(config, pluginRoot);
+        state.config = config;
+      },
+
+      "experimental.chat.system.transform": async (input, output) => {
+        try {
+          loadMetadata(pluginRoot, state);
+          await appendSystemContext(pluginRoot, state, input, output);
+        } catch {
+          // Fail open. Plugin context should never block a chat request.
+        }
+      },
+
+      "tool.execute.before": async (input, output) => {
+        loadMetadata(pluginRoot, state);
+        applyPreToolUseRules(state, input, output);
+      },
+
+      "shell.env": async (input, output) => {
+        try {
+          loadMetadata(pluginRoot, state);
+          await configureShellEnvironment(pluginRoot, state, input, output);
+        } catch {
+          // Fail open. Shell commands should still run if setup is unavailable.
+        }
+      },
+
+      event: async ({ event }) => {
+        await handlePluginEvent(state, event);
+      },
+
+      dispose: async () => {
+        await removeOwnedSandboxes(state);
+      },
+    };
   };
-
-  return async () => ({
-    config: async (config) => {
-      loadMetadata(pluginRoot, state);
-      registerSkills(config, pluginRoot);
-      registerMcpServers(config, pluginRoot);
-    },
-
-    "experimental.chat.system.transform": async (_input, output) => {
-      try {
-        loadMetadata(pluginRoot, state);
-        await appendSystemContext(pluginRoot, state, output);
-      } catch {
-        // Fail open. Plugin context should never block a chat request.
-      }
-    },
-
-    "tool.execute.before": async (input, output) => {
-      loadMetadata(pluginRoot, state);
-      applyPreToolUseRules(state, input, output);
-    },
-
-    "shell.env": async (input, output) => {
-      try {
-        loadMetadata(pluginRoot, state);
-        configureShellEnvironment(pluginRoot, state, input, output);
-      } catch {
-        // Fail open. Shell commands should still run if setup is unavailable.
-      }
-    },
-  });
 }
 
 function normalizePluginRoot(pluginRootUrl) {
@@ -144,13 +162,14 @@ function copyOptionalFields(source, target, keys) {
   }
 }
 
-async function appendSystemContext(pluginRoot, state, output) {
+async function appendSystemContext(pluginRoot, state, input, output) {
   if (!Array.isArray(output.system)) output.system = [];
 
   const pluginName = state.pluginJson.name ?? path.basename(pluginRoot);
   const welcomeMessage = typeof state.infoJson.welcomeMessage === "string" ? state.infoJson.welcomeMessage : "";
-  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state);
-  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state);
+  const sessionID = safeSessionID(input?.sessionID ?? "global");
+  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state, sessionID);
+  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state, sessionID);
   const sessionStart = renderSessionStart(pluginRoot, xcodeMcpLikely);
 
   let systemMessage = `The ${pluginName} plugin is loaded and ready.`;
@@ -181,31 +200,56 @@ function processConditionalBlocks(content, xcodeMcpLikely) {
     .replace(/<!-- IF_XCODE_MCP -->[\s\S]*?<!-- END_XCODE_MCP -->\n?/g, "");
 }
 
-async function getXcodeMcpLikely(pluginName, state) {
+async function getXcodeMcpLikely(pluginName, state, sessionID) {
   if (pluginName !== "XcodeBuildTools") return false;
-  if (state.xcodeMcpLikely !== undefined) return state.xcodeMcpLikely;
+  if (!hasConfiguredMcpbridge(state.config)) {
+    state.xcodeMcpCache.delete(sessionID);
+    return false;
+  }
+
+  const now = Date.now();
+  const cached = state.xcodeMcpCache.get(sessionID);
+  if (cached && now - cached.checkedAt < XCODE_MCP_CACHE_TTL_MS) return cached.value;
 
   const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
   if (!installed) {
-    state.xcodeMcpLikely = false;
-    return state.xcodeMcpLikely;
+    state.xcodeMcpCache.set(sessionID, { checkedAt: now, value: false });
+    return false;
   }
 
   const xcodeRunning = await commandSucceeds("pgrep", ["-x", "Xcode"], 3000);
   const bridgeRunning = await commandSucceeds("pgrep", ["-f", "mcpbridge"], 3000);
-  state.xcodeMcpLikely = xcodeRunning || bridgeRunning;
-  return state.xcodeMcpLikely;
+  const value = xcodeRunning || bridgeRunning;
+  state.xcodeMcpCache.set(sessionID, { checkedAt: now, value });
+  return value;
 }
 
-function startXcodeMcpApproval(pluginRoot, state) {
-  if (state.xcodeMcpApprovalStarted) return;
-  state.xcodeMcpApprovalStarted = true;
+function hasConfiguredMcpbridge(config) {
+  if (!isObject(config?.mcp)) return false;
+
+  return Object.values(config.mcp).some((server) => {
+    if (!isObject(server) || server.enabled === false || server.type !== "local") return false;
+
+    const command = Array.isArray(server.command) ? server.command : [server.command];
+    return command.some((part) => {
+      if (typeof part !== "string") return false;
+      return part
+        .trim()
+        .split(/\s+/)
+        .some((token) => path.basename(token.replace(/^['"]|['"]$/g, "")) === "mcpbridge");
+    });
+  });
+}
+
+function startXcodeMcpApproval(pluginRoot, state, sessionID) {
+  if (state.xcodeMcpApprovalSessions.has(sessionID)) return;
 
   const runner = path.join(pluginRoot, "hooks", "run-background.sh");
   const target = path.join("hooks", "approve-xcode-mcp.sh");
   if (!fs.existsSync(runner)) return;
 
   try {
+    state.xcodeMcpApprovalSessions.add(sessionID);
     const child = spawn(runner, [target], {
       cwd: pluginRoot,
       detached: true,
@@ -216,9 +260,10 @@ function startXcodeMcpApproval(pluginRoot, state) {
       },
       stdio: "ignore",
     });
-    child.on("error", () => {});
+    child.on("error", () => state.xcodeMcpApprovalSessions.delete(sessionID));
     child.unref();
   } catch {
+    state.xcodeMcpApprovalSessions.delete(sessionID);
     // Auto-approval is best-effort; users can still approve Xcode manually.
   }
 }
@@ -279,7 +324,7 @@ function applyPreToolUseRules(state, input, output) {
   }
 }
 
-function configureShellEnvironment(pluginRoot, state, input, output) {
+async function configureShellEnvironment(pluginRoot, state, input, output) {
   if (!isObject(output.env)) output.env = {};
 
   const binDir = path.join(pluginRoot, "bin");
@@ -290,7 +335,23 @@ function configureShellEnvironment(pluginRoot, state, input, output) {
   if (state.pluginJson.name !== "XcodeBuildTools") return;
 
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
-  const sandboxBase = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox", sessionID);
+  const sandboxRoot = path.join(os.tmpdir(), XCODE_SANDBOX_DIR);
+  // Plugin instances never reuse a sandbox path, so an older instance cannot
+  // delete a replacement instance's active sandbox after an ownership check.
+  const sandboxBase = path.join(sandboxRoot, `${sessionID}-${state.instanceID}`);
+  state.ownedSandboxes.set(sessionID, sandboxBase);
+
+  if (!state.processStartToken) {
+    state.processStartToken = await readProcessStartToken(process.pid);
+  }
+  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+
+  if (!state.sandboxSweepDone) {
+    await sweepStaleSandboxes(sandboxRoot);
+    state.sandboxSweepDone = true;
+  }
+  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+
   const buildDir = path.join(sandboxBase, "build");
   const packagesDir = path.join(sandboxBase, "packages");
 
@@ -298,12 +359,153 @@ function configureShellEnvironment(pluginRoot, state, input, output) {
   fs.mkdirSync(packagesDir, { recursive: true });
   fs.writeFileSync(
     path.join(sandboxBase, "owner.pid"),
-    `${process.pid}\n${process.argv[0] ?? "opencode"}\n`,
+    `${process.pid}\n${process.argv[0] ?? "opencode"}\n${state.processStartToken}\n${state.instanceID}\n`,
     "utf8",
   );
 
   output.env.SANDBOX_DERIVED_DATA = buildDir;
   output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+async function handlePluginEvent(state, event) {
+  if (event?.type !== "session.deleted") return;
+
+  const sessionID = event.properties?.info?.id;
+  if (typeof sessionID !== "string" || !sessionID) return;
+
+  const safeID = safeSessionID(sessionID);
+  state.xcodeMcpCache.delete(safeID);
+  state.xcodeMcpApprovalSessions.delete(safeID);
+  await removeOwnedSandbox(state, safeID);
+}
+
+async function removeOwnedSandbox(state, sessionID) {
+  const sandboxPath = state.ownedSandboxes.get(sessionID);
+  if (!sandboxPath) return;
+
+  state.ownedSandboxes.delete(sessionID);
+  await removeManagedSandbox(sandboxPath, state.instanceID);
+}
+
+async function removeOwnedSandboxes(state) {
+  const sandboxPaths = [...new Set(state.ownedSandboxes.values())];
+  state.ownedSandboxes.clear();
+  state.xcodeMcpCache.clear();
+  state.xcodeMcpApprovalSessions.clear();
+  await Promise.all(sandboxPaths.map((sandboxPath) => removeManagedSandbox(sandboxPath, state.instanceID)));
+}
+
+async function sweepStaleSandboxes(sandboxRoot) {
+  let entries;
+  try {
+    entries = await fs.promises.readdir(sandboxRoot, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.isDirectory() || !SAFE_ID_RE.test(entry.name)) return;
+
+      const sandboxPath = path.join(sandboxRoot, entry.name);
+      const owner = await readSandboxOwner(sandboxPath);
+      if (!owner || (await sandboxOwnerIsActive(owner))) return;
+
+      await removeManagedSandbox(sandboxPath);
+    }),
+  );
+}
+
+async function readSandboxOwner(sandboxPath) {
+  try {
+    const content = await fs.promises.readFile(path.join(sandboxPath, "owner.pid"), "utf8");
+    const lines = content.split(/\r?\n/);
+    const firstLine = lines[0];
+    if (!/^\d+$/.test(firstLine)) return null;
+
+    const pid = Number(firstLine);
+    if (!Number.isSafeInteger(pid) || pid <= 0) return null;
+
+    return {
+      pid,
+      processStartToken: lines[2] ?? "",
+      instanceID: lines[3] ?? "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+async function sandboxOwnerIsActive(owner) {
+  if (!processExists(owner.pid)) return false;
+  if (!owner.processStartToken) return true;
+
+  const currentStartToken = await readProcessStartToken(owner.pid);
+  if (!currentStartToken) return true;
+  return currentStartToken === owner.processStartToken;
+}
+
+function readProcessStartToken(pid) {
+  return new Promise((resolve) => {
+    let settled = false;
+    let stdout = "";
+    let child;
+
+    try {
+      child = spawn("ps", ["-p", String(pid), "-o", "lstart="], {
+        env: {
+          ...process.env,
+          LC_ALL: "C",
+          LANG: "C",
+          TZ: "UTC",
+        },
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+    } catch {
+      resolve("");
+      return;
+    }
+
+    child.stdout?.setEncoding?.("utf8");
+    child.stdout?.on?.("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.on("error", () => finish(""));
+    child.on("close", (code) => finish(code === 0 ? stdout.trim() : ""));
+
+    function finish(value) {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    }
+  });
+}
+
+async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
+  const sandboxRoot = path.resolve(os.tmpdir(), XCODE_SANDBOX_DIR);
+  const candidate = path.resolve(sandboxPath);
+  const relative = path.relative(sandboxRoot, candidate);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return;
+
+  if (expectedInstanceID) {
+    const owner = await readSandboxOwner(candidate);
+    if (!owner || owner.instanceID !== expectedInstanceID) return;
+  }
+
+  try {
+    await fs.promises.rm(candidate, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  } catch {
+    // Best-effort cleanup; the next plugin instance will retry through the stale-owner sweep.
+  }
 }
 
 function prependPath(entry, current) {

--- a/SwiftScaffolding/common/opencode-plugin.js
+++ b/SwiftScaffolding/common/opencode-plugin.js
@@ -7,8 +7,23 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const PROCESS_START_OUTPUT_MAX_CHARS = 256;
+const PROCESS_START_TIMEOUT_MS = 5_000;
 const XCODE_MCP_CACHE_TTL_MS = 30_000;
 const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
+const XCODE_SANDBOX_OWNER_GRACE_MS = 60_000;
+const XCODE_SANDBOX_OWNER_LOCK = ".owner.lock";
+const XCODE_SANDBOX_QUARANTINE_RE =
+  /^\.quarantine-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const XCODE_SANDBOX_PENDING_CLEANUPS_KEY = Symbol.for(
+  "opencode.xcodebuildtools.pending-cleanups",
+);
+const pendingSandboxCleanups =
+  globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] instanceof Set
+    ? globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY]
+    : new Set();
+globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] = pendingSandboxCleanups;
 
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
@@ -23,7 +38,9 @@ export function createOpenCodePlugin(pluginRootUrl) {
       xcodeMcpCache: new Map(),
       xcodeMcpApprovalSessions: new Set(),
       ownedSandboxes: new Map(),
+      deletedSandboxSessions: new Set(),
       sandboxSweepDone: false,
+      disposed: false,
     };
 
     return {
@@ -62,7 +79,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       },
 
       dispose: async () => {
-        await removeOwnedSandboxes(state);
+        await detachOwnedSandboxes(state);
       },
     };
   };
@@ -335,6 +352,7 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   if (state.pluginJson.name !== "XcodeBuildTools") return;
 
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
+  if (state.disposed || state.deletedSandboxSessions.has(sessionID)) return;
   const sandboxRoot = path.join(os.tmpdir(), XCODE_SANDBOX_DIR);
   // Plugin instances never reuse a sandbox path, so an older instance cannot
   // delete a replacement instance's active sandbox after an ownership check.
@@ -344,27 +362,201 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   if (!state.processStartToken) {
     state.processStartToken = await readProcessStartToken(process.pid);
   }
-  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+  if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
 
   if (!state.sandboxSweepDone) {
     await sweepStaleSandboxes(sandboxRoot);
     state.sandboxSweepDone = true;
   }
-  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+  if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
 
   const buildDir = path.join(sandboxBase, "build");
   const packagesDir = path.join(sandboxBase, "packages");
 
   fs.mkdirSync(buildDir, { recursive: true });
   fs.mkdirSync(packagesDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(sandboxBase, "owner.pid"),
-    `${process.pid}\n${process.argv[0] ?? "opencode"}\n${state.processStartToken}\n${state.instanceID}\n`,
-    "utf8",
-  );
+  writeSandboxOwner(sandboxBase, state.processStartToken, state.instanceID);
 
   output.env.SANDBOX_DERIVED_DATA = buildDir;
   output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+function sandboxSetupIsCancelled(state, sessionID, sandboxBase) {
+  return (
+    state.disposed ||
+    state.deletedSandboxSessions.has(sessionID) ||
+    state.ownedSandboxes.get(sessionID) !== sandboxBase
+  );
+}
+
+function writeSandboxOwner(sandboxBase, processStartToken, instanceID) {
+  const ownerPath = path.join(sandboxBase, "owner.pid");
+  const temporaryPath = path.join(sandboxBase, `owner.pid.${instanceID}.tmp`);
+  const content = `${process.pid}\n${process.argv[0] ?? "opencode"}\n${processStartToken}\n${instanceID}\n`;
+  const ownerLock = acquireSandboxOwnerLock(sandboxBase);
+  if (!ownerLock) throw new Error("Sandbox owner is being updated or removed");
+
+  try {
+    fs.writeFileSync(temporaryPath, content, "utf8");
+    if (!sandboxOwnerLockIsHeld(ownerLock)) {
+      throw new Error("Sandbox owner lock changed during update");
+    }
+    fs.renameSync(temporaryPath, ownerPath);
+  } catch (error) {
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch {
+      // The stale-sandbox sweep handles any temporary file left behind.
+    }
+    throw error;
+  } finally {
+    releaseSandboxOwnerLock(ownerLock);
+  }
+}
+
+function markSandboxCleanupPending(sandboxBase, instanceID, ownerLock) {
+  const ownerPath = path.join(sandboxBase, "owner.pid");
+  const temporaryPath = path.join(sandboxBase, `owner.pid.${instanceID}.cleanup.tmp`);
+  const content = `${process.pid}\ncleanup-pending\n\n${instanceID}\ncleanup-pending\n`;
+
+  try {
+    fs.writeFileSync(temporaryPath, content, "utf8");
+    if (!sandboxOwnerLockIsHeld(ownerLock)) return false;
+    fs.renameSync(temporaryPath, ownerPath);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch {
+      // A successful rename removes the temporary path.
+    }
+  }
+}
+
+function acquireSandboxOwnerLock(sandboxBase) {
+  const lockPath = path.join(sandboxBase, XCODE_SANDBOX_OWNER_LOCK);
+  const token = randomUUID();
+  const createdLock = createSandboxOwnerLock(lockPath, token);
+  if (createdLock) return createdLock;
+
+  const observedLock = readSandboxOwnerLock(lockPath);
+  if (!observedLock) return null;
+  if (Date.now() - observedLock.mtimeMs < XCODE_SANDBOX_OWNER_GRACE_MS) return null;
+
+  const claimedPath = `${lockPath}.${token}.stale`;
+  try {
+    fs.renameSync(lockPath, claimedPath);
+  } catch {
+    return null;
+  }
+
+  const claimedLock = readSandboxOwnerLock(claimedPath);
+  if (!sameSandboxOwnerLock(observedLock, claimedLock)) {
+    restoreClaimedSandboxOwnerLock(claimedPath, lockPath);
+    return null;
+  }
+
+  try {
+    fs.unlinkSync(claimedPath);
+  } catch {
+    restoreClaimedSandboxOwnerLock(claimedPath, lockPath);
+    return null;
+  }
+
+  return createSandboxOwnerLock(lockPath, token);
+}
+
+function createSandboxOwnerLock(lockPath, token) {
+  try {
+    fs.writeFileSync(lockPath, `${token}\n`, { encoding: "utf8", flag: "wx" });
+  } catch {
+    return null;
+  }
+
+  const ownerLock = readSandboxOwnerLock(lockPath);
+  if (!ownerLock || ownerLock.token !== token) return null;
+  return ownerLock;
+}
+
+function readSandboxOwnerLock(lockPath) {
+  try {
+    const before = fs.statSync(lockPath);
+    if (!before.isFile()) return null;
+    const beforeToken = fs.readFileSync(lockPath, "utf8").trim();
+    const after = fs.statSync(lockPath);
+    const afterToken = fs.readFileSync(lockPath, "utf8").trim();
+    if (!sameSandboxOwnerLockVersion(before, after) || beforeToken !== afterToken) return null;
+
+    return {
+      path: lockPath,
+      token: afterToken,
+      dev: after.dev,
+      ino: after.ino,
+      mtimeMs: after.mtimeMs,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function sameSandboxOwnerLockVersion(left, right) {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs &&
+    left.ctimeMs === right.ctimeMs
+  );
+}
+
+function sameSandboxOwnerLock(left, right) {
+  return Boolean(
+    left &&
+      right &&
+      left.dev === right.dev &&
+      left.ino === right.ino &&
+      left.token === right.token,
+  );
+}
+
+function sandboxOwnerLockIsHeld(ownerLock) {
+  return sameSandboxOwnerLock(ownerLock, readSandboxOwnerLock(ownerLock.path));
+}
+
+function restoreClaimedSandboxOwnerLock(claimedPath, lockPath) {
+  try {
+    // A hard link restores the claimed inode only when the lock path is still
+    // absent, without overwriting a lock another actor acquired meanwhile.
+    fs.linkSync(claimedPath, lockPath);
+    fs.unlinkSync(claimedPath);
+  } catch {
+    // Leave the uniquely named claim in place if ownership cannot be restored.
+  }
+}
+
+function releaseSandboxOwnerLock(ownerLock) {
+  if (!sandboxOwnerLockIsHeld(ownerLock)) return;
+
+  const claimedPath = `${ownerLock.path}.${randomUUID()}.release`;
+  try {
+    fs.renameSync(ownerLock.path, claimedPath);
+  } catch {
+    return;
+  }
+
+  const claimedLock = readSandboxOwnerLock(claimedPath);
+  if (!sameSandboxOwnerLock(ownerLock, claimedLock)) {
+    restoreClaimedSandboxOwnerLock(claimedPath, ownerLock.path);
+    return;
+  }
+
+  try {
+    fs.unlinkSync(claimedPath);
+  } catch {
+    // The sandbox may already have been removed with the lock inside it.
+  }
 }
 
 async function handlePluginEvent(state, event) {
@@ -374,6 +566,7 @@ async function handlePluginEvent(state, event) {
   if (typeof sessionID !== "string" || !sessionID) return;
 
   const safeID = safeSessionID(sessionID);
+  state.deletedSandboxSessions.add(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
   await removeOwnedSandbox(state, safeID);
@@ -383,16 +576,36 @@ async function removeOwnedSandbox(state, sessionID) {
   const sandboxPath = state.ownedSandboxes.get(sessionID);
   if (!sandboxPath) return;
 
+  markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.delete(sessionID);
-  await removeManagedSandbox(sandboxPath, state.instanceID);
+  const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+  await removeManagedSandbox(
+    quarantinedPath || sandboxPath,
+    quarantinedPath ? "" : state.instanceID,
+  );
 }
 
-async function removeOwnedSandboxes(state) {
+async function detachOwnedSandboxes(state) {
+  state.disposed = true;
   const sandboxPaths = [...new Set(state.ownedSandboxes.values())];
+  for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
-  await Promise.all(sandboxPaths.map((sandboxPath) => removeManagedSandbox(sandboxPath, state.instanceID)));
+  const cleanupTargets = await Promise.all(
+    sandboxPaths.map(async (sandboxPath) => {
+      const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+      return {
+        path: quarantinedPath || sandboxPath,
+        expectedInstanceID: quarantinedPath ? "" : state.instanceID,
+      };
+    }),
+  );
+  await Promise.all(
+    cleanupTargets.map(({ path: sandboxPath, expectedInstanceID }) =>
+      detachManagedSandbox(sandboxPath, expectedInstanceID),
+    ),
+  );
 }
 
 async function sweepStaleSandboxes(sandboxRoot) {
@@ -405,11 +618,43 @@ async function sweepStaleSandboxes(sandboxRoot) {
 
   await Promise.all(
     entries.map(async (entry) => {
-      if (!entry.isDirectory() || !SAFE_ID_RE.test(entry.name)) return;
+      const isQuarantine = XCODE_SANDBOX_QUARANTINE_RE.test(entry.name);
+      if (!entry.isDirectory() || (!SAFE_ID_RE.test(entry.name) && !isQuarantine)) return;
 
       const sandboxPath = path.join(sandboxRoot, entry.name);
       const owner = await readSandboxOwner(sandboxPath);
-      if (!owner || (await sandboxOwnerIsActive(owner))) return;
+      const cleanupPending = owner?.cleanupPending || sandboxCleanupIsPending(sandboxPath);
+      if (!owner || cleanupPending) {
+        if (!cleanupPending && !isQuarantine && !(await sandboxIsPastOwnerGracePeriod(sandboxPath))) {
+          return;
+        }
+
+        const ownerLock = acquireSandboxOwnerLock(sandboxPath);
+        if (!ownerLock) return;
+        let releaseLock = ownerLock;
+        try {
+          // A writer may have published an owner after the initial read or
+          // stale-stat snapshot. Only remove while the publication lock is
+          // held and the marker is still invalid.
+          const currentOwner = await readSandboxOwner(sandboxPath);
+          const currentCleanupPending =
+            currentOwner?.cleanupPending || sandboxCleanupIsPending(sandboxPath);
+          if (
+            (!currentOwner || currentCleanupPending) &&
+            sandboxOwnerLockIsHeld(ownerLock)
+          ) {
+            const quarantined = await quarantineManagedSandbox(sandboxPath, ownerLock);
+            releaseLock = quarantined.ownerLock;
+            if (quarantined.path) {
+              await removeManagedSandbox(quarantined.path);
+            }
+          }
+        } finally {
+          releaseSandboxOwnerLock(releaseLock);
+        }
+        return;
+      }
+      if (await sandboxOwnerIsActive(owner)) return;
 
       await removeManagedSandbox(sandboxPath);
     }),
@@ -426,13 +671,26 @@ async function readSandboxOwner(sandboxPath) {
     const pid = Number(firstLine);
     if (!Number.isSafeInteger(pid) || pid <= 0) return null;
 
+    const instanceID = lines[3] ?? "";
+    if (!UUID_V4_RE.test(instanceID)) return null;
+
     return {
       pid,
       processStartToken: lines[2] ?? "",
-      instanceID: lines[3] ?? "",
+      instanceID,
+      cleanupPending: lines[4] === "cleanup-pending",
     };
   } catch {
     return null;
+  }
+}
+
+async function sandboxIsPastOwnerGracePeriod(sandboxPath) {
+  try {
+    const stat = await fs.promises.stat(sandboxPath);
+    return Date.now() - stat.mtimeMs >= XCODE_SANDBOX_OWNER_GRACE_MS;
+  } catch {
+    return false;
   }
 }
 
@@ -459,9 +717,10 @@ function readProcessStartToken(pid) {
     let settled = false;
     let stdout = "";
     let child;
+    let timer;
 
     try {
-      child = spawn("ps", ["-p", String(pid), "-o", "lstart="], {
+      child = spawn("/bin/ps", ["-p", String(pid), "-o", "lstart="], {
         env: {
           ...process.env,
           LC_ALL: "C",
@@ -477,24 +736,156 @@ function readProcessStartToken(pid) {
 
     child.stdout?.setEncoding?.("utf8");
     child.stdout?.on?.("data", (chunk) => {
-      stdout += chunk;
+      const remaining = PROCESS_START_OUTPUT_MAX_CHARS - stdout.length;
+      if (remaining > 0) stdout += String(chunk).slice(0, remaining);
     });
     child.on("error", () => finish(""));
-    child.on("close", (code) => finish(code === 0 ? stdout.trim() : ""));
+    child.on("close", (code) => {
+      const firstLine = stdout.trim().split(/\r?\n/, 1)[0] ?? "";
+      finish(code === 0 ? firstLine : "");
+    });
+    timer = setTimeout(() => {
+      try {
+        child.kill?.("SIGTERM");
+      } catch {
+        // Resolving the hook is more important than terminating a broken ps shim.
+      }
+      finish("");
+    }, PROCESS_START_TIMEOUT_MS);
 
     function finish(value) {
       if (settled) return;
       settled = true;
+      clearTimeout(timer);
       resolve(value);
     }
   });
 }
 
 async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
-  const sandboxRoot = path.resolve(os.tmpdir(), XCODE_SANDBOX_DIR);
-  const candidate = path.resolve(sandboxPath);
-  const relative = path.relative(sandboxRoot, candidate);
-  if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return;
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate) return false;
+
+  if (expectedInstanceID) {
+    const owner = await readSandboxOwner(candidate);
+    if (!owner || owner.instanceID !== expectedInstanceID) return false;
+  }
+
+  try {
+    await fs.promises.rm(candidate, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    clearPendingSandboxCleanup(candidate);
+    return true;
+  } catch {
+    // Best-effort cleanup; the next plugin instance will retry through the stale-owner sweep.
+    return false;
+  }
+}
+
+async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate) return "";
+
+  const ownerLock = acquireSandboxOwnerLock(candidate);
+  if (!ownerLock) return "";
+  let releaseLock = ownerLock;
+
+  try {
+    const currentOwner = await readSandboxOwner(candidate);
+    if (!currentOwner || currentOwner.instanceID !== expectedInstanceID) return "";
+    if (!markSandboxCleanupPending(candidate, expectedInstanceID, ownerLock)) return "";
+
+    const quarantinePath = path.join(path.dirname(candidate), `.quarantine-${randomUUID()}`);
+    if (!managedSandboxCandidate(quarantinePath)) return "";
+
+    try {
+      fs.renameSync(candidate, quarantinePath);
+      movePendingSandboxCleanup(candidate, quarantinePath);
+    } catch {
+      return "";
+    }
+
+    releaseLock = {
+      ...ownerLock,
+      path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+    };
+    const relocatedOwner = await readSandboxOwner(quarantinePath);
+    if (
+      !sandboxOwnerLockIsHeld(releaseLock) ||
+      !relocatedOwner ||
+      relocatedOwner.instanceID !== expectedInstanceID ||
+      !relocatedOwner.cleanupPending
+    ) {
+      if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+        movePendingSandboxCleanup(quarantinePath, candidate);
+        releaseLock = { ...releaseLock, path: ownerLock.path };
+      }
+      return "";
+    }
+
+    const ownerPath = path.join(quarantinePath, "owner.pid");
+    const retiredOwnerPath = path.join(quarantinePath, `owner.pid.retired-${randomUUID()}`);
+    try {
+      fs.renameSync(ownerPath, retiredOwnerPath);
+    } catch (error) {
+      if (error?.code !== "ENOENT") return quarantinePath;
+    }
+
+    return quarantinePath;
+  } finally {
+    releaseSandboxOwnerLock(releaseLock);
+  }
+}
+
+async function quarantineManagedSandbox(sandboxPath, ownerLock) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate || !sandboxOwnerLockIsHeld(ownerLock)) {
+    return { path: "", ownerLock };
+  }
+
+  const quarantinePath = path.join(path.dirname(candidate), `.quarantine-${randomUUID()}`);
+  if (!managedSandboxCandidate(quarantinePath)) return { path: "", ownerLock };
+
+  try {
+    fs.renameSync(candidate, quarantinePath);
+    movePendingSandboxCleanup(candidate, quarantinePath);
+  } catch {
+    return { path: "", ownerLock };
+  }
+
+  const relocatedLock = {
+    ...ownerLock,
+    path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+  };
+  const publishedOwner = await readSandboxOwner(quarantinePath);
+  const cleanupPending =
+    publishedOwner?.cleanupPending || sandboxCleanupIsPending(quarantinePath);
+  if (
+    !sandboxOwnerLockIsHeld(relocatedLock) ||
+    (publishedOwner && !cleanupPending)
+  ) {
+    if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+      movePendingSandboxCleanup(quarantinePath, candidate);
+      return { path: "", ownerLock };
+    }
+    // Preserve the quarantine when the original path has already been reused.
+    return { path: "", ownerLock: relocatedLock };
+  }
+
+  return { path: quarantinePath, ownerLock: relocatedLock };
+}
+
+function restoreQuarantinedSandbox(quarantinePath, originalPath) {
+  try {
+    fs.renameSync(quarantinePath, originalPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function detachManagedSandbox(sandboxPath, expectedInstanceID = "") {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate) return;
 
   if (expectedInstanceID) {
     const owner = await readSandboxOwner(candidate);
@@ -502,10 +893,48 @@ async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
   }
 
   try {
-    await fs.promises.rm(candidate, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    const child = spawn("/bin/rm", ["-rf", candidate], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.on("error", () => {});
+    child.on("exit", (code) => {
+      if (code === 0) clearPendingSandboxCleanup(candidate);
+    });
+    child.unref();
   } catch {
     // Best-effort cleanup; the next plugin instance will retry through the stale-owner sweep.
   }
+}
+
+function managedSandboxCandidate(sandboxPath) {
+  const sandboxRoot = path.resolve(os.tmpdir(), XCODE_SANDBOX_DIR);
+  const candidate = path.resolve(sandboxPath);
+  const relative = path.relative(sandboxRoot, candidate);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return "";
+  return candidate;
+}
+
+function markPendingSandboxCleanup(sandboxPath) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (candidate) pendingSandboxCleanups.add(candidate);
+}
+
+function clearPendingSandboxCleanup(sandboxPath) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (candidate) pendingSandboxCleanups.delete(candidate);
+}
+
+function movePendingSandboxCleanup(sourcePath, destinationPath) {
+  const source = managedSandboxCandidate(sourcePath);
+  const destination = managedSandboxCandidate(destinationPath);
+  if (!source || !destination || !pendingSandboxCleanups.delete(source)) return;
+  pendingSandboxCleanups.add(destination);
+}
+
+function sandboxCleanupIsPending(sandboxPath) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  return Boolean(candidate && pendingSandboxCleanups.has(candidate));
 }
 
 function prependPath(entry, current) {

--- a/SwiftScaffolding/common/opencode-plugin.js
+++ b/SwiftScaffolding/common/opencode-plugin.js
@@ -7,6 +7,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const MCP_PLACEHOLDER_RE = /\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}/g;
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const PROCESS_START_OUTPUT_MAX_CHARS = 256;
 const PROCESS_START_TIMEOUT_MS = 5_000;
@@ -27,7 +28,11 @@ globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] = pendingSandboxCleanups;
 
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
-  return async () => {
+  return async (input = {}) => {
+    const mcpContext = {
+      pluginRoot,
+      projectDir: input?.worktree || input?.directory,
+    };
     const state = {
       pluginJson: null,
       infoJson: null,
@@ -47,7 +52,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       config: async (config) => {
         loadMetadata(pluginRoot, state);
         registerSkills(config, pluginRoot);
-        registerMcpServers(config, pluginRoot);
+        registerMcpServers(config, pluginRoot, mcpContext);
         state.config = config;
       },
 
@@ -115,7 +120,7 @@ function registerSkills(config, pluginRoot) {
   if (!config.skills.paths.includes(skillsDir)) config.skills.paths.push(skillsDir);
 }
 
-function registerMcpServers(config, pluginRoot) {
+function registerMcpServers(config, pluginRoot, context) {
   const mcpConfig = readJsonFile(path.join(pluginRoot, ".mcp.json"));
   const servers = mcpConfig?.mcpServers;
   if (!isObject(servers)) return;
@@ -125,58 +130,117 @@ function registerMcpServers(config, pluginRoot) {
   for (const [name, server] of Object.entries(servers)) {
     if (!isObject(server) || config.mcp[name]) continue;
 
-    const translated = translateMcpServer(server);
+    const translated = translateMcpServer(server, context);
     if (translated) config.mcp[name] = translated;
   }
 }
 
-function translateMcpServer(server) {
+function translateMcpServer(server, context) {
   if (typeof server.url === "string") {
     const translated = {
       type: "remote",
-      url: server.url,
+      url: expandMcpString(server.url, context),
     };
-    copyOptionalFields(server, translated, ["enabled", "headers", "timeout"]);
+    copyOptionalFields(server, translated, ["enabled", "headers", "timeout"], context);
+    const oauth = translateMcpOAuth(server.oauth);
+    if (oauth !== undefined) translated.oauth = oauth;
     return translated;
   }
 
-  const command = normalizeCommand(server.command, server.args);
+  const command = normalizeCommand(server.command, server.args, context);
   if (!command) return null;
 
   const translated = {
     type: "local",
     command,
   };
-  copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"]);
+  copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"], context);
 
   const environment = isObject(server.environment) ? server.environment : server.env;
-  if (isObject(environment)) translated.environment = stringifyRecord(environment);
+  if (isObject(environment)) translated.environment = expandMcpRecord(environment, context);
 
   return translated;
 }
 
-function normalizeCommand(command, args) {
+function translateMcpOAuth(oauth) {
+  if (oauth === false) return false;
+  if (!isObject(oauth)) return undefined;
+
+  const translated = {};
+  for (const key of ["clientId", "clientSecret", "redirectUri"]) {
+    if (typeof oauth[key] === "string") translated[key] = oauth[key];
+  }
+
+  if (
+    Number.isInteger(oauth.callbackPort) &&
+    oauth.callbackPort >= 1 &&
+    oauth.callbackPort <= 65_535
+  ) {
+    translated.callbackPort = oauth.callbackPort;
+  }
+
+  if (typeof oauth.scopes === "string") {
+    translated.scope = oauth.scopes;
+  } else if (typeof oauth.scope === "string") {
+    translated.scope = oauth.scope;
+  }
+
+  return translated;
+}
+
+function normalizeCommand(command, args, context) {
   if (Array.isArray(command) && command.every((item) => typeof item === "string")) {
-    return command;
+    return command.map((item) => expandMcpString(item, context));
   }
 
   if (typeof command !== "string") return null;
 
-  const result = [command];
   if (Array.isArray(args)) {
-    for (const arg of args) {
-      if (typeof arg !== "string") return null;
-      result.push(arg);
-    }
+    if (!args.every((arg) => typeof arg === "string")) return null;
+    return [command, ...args].map((item) => expandMcpString(item, context));
   }
-  return result;
+  return [expandMcpString(command, context)];
 }
 
-function copyOptionalFields(source, target, keys) {
+function copyOptionalFields(source, target, keys, context) {
   for (const key of keys) {
     if (source[key] === undefined) continue;
-    target[key] = key === "headers" && isObject(source[key]) ? stringifyRecord(source[key]) : source[key];
+    if (key === "headers" && isObject(source[key])) {
+      target[key] = expandMcpRecord(source[key], context);
+    } else if (key === "cwd" && typeof source[key] === "string") {
+      target[key] = expandMcpString(source[key], context);
+    } else {
+      target[key] = source[key];
+    }
   }
+}
+
+function expandMcpRecord(value, context) {
+  return Object.fromEntries(
+    Object.entries(stringifyRecord(value)).map(([key, item]) => [
+      key,
+      expandMcpString(item, context),
+    ]),
+  );
+}
+
+function expandMcpString(value, context) {
+  return value.replace(MCP_PLACEHOLDER_RE, (_, name, defaultValue) => {
+    const resolved = mcpVariable(name, context);
+    if (defaultValue !== undefined && (resolved === undefined || resolved === "")) {
+      return defaultValue;
+    }
+    if (resolved === undefined) {
+      throw new Error(`MCP configuration references unset variable: ${name}`);
+    }
+    return resolved;
+  });
+}
+
+function mcpVariable(name, context) {
+  if (name === "CLAUDE_PLUGIN_ROOT") return context.pluginRoot;
+  if (name === "CLAUDE_PROJECT_DIR") return context.projectDir;
+  return process.env[name];
 }
 
 async function appendSystemContext(pluginRoot, state, input, output) {

--- a/SwiftScaffolding/common/opencode-plugin.js
+++ b/SwiftScaffolding/common/opencode-plugin.js
@@ -29,13 +29,10 @@ globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] = pendingSandboxCleanups;
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
   return async (input = {}) => {
-    const mcpContext = {
-      pluginRoot,
-      projectDir: input?.worktree || input?.directory,
-    };
     const state = {
       pluginJson: null,
       infoJson: null,
+      pluginData: null,
       config: null,
       instanceID: randomUUID(),
       processStartToken: null,
@@ -46,6 +43,11 @@ export function createOpenCodePlugin(pluginRootUrl) {
       deletedSandboxSessions: new Set(),
       sandboxSweepDone: false,
       disposed: false,
+    };
+    const mcpContext = {
+      pluginRoot,
+      pluginData: () => pluginDataDirectory(pluginRoot, state),
+      projectDir: input?.worktree || input?.directory,
     };
 
     return {
@@ -111,6 +113,19 @@ function loadMetadata(pluginRoot, state) {
   }
 }
 
+function pluginDataDirectory(pluginRoot, state) {
+  if (state.pluginData) return state.pluginData;
+
+  loadMetadata(pluginRoot, state);
+  const pluginName = state.pluginJson.name || path.basename(pluginRoot) || "plugin";
+  const pluginID = String(pluginName).replace(/[^A-Za-z0-9_-]/g, "-");
+  const dataHome = process.env.XDG_DATA_HOME || path.join(os.homedir(), ".local", "share");
+  const pluginData = path.resolve(dataHome, "opencode", "plugin-data", pluginID);
+  fs.mkdirSync(pluginData, { recursive: true });
+  state.pluginData = pluginData;
+  return pluginData;
+}
+
 function registerSkills(config, pluginRoot) {
   const skillsDir = path.join(pluginRoot, "skills");
   if (!hasSkillDirectories(skillsDir)) return;
@@ -157,7 +172,17 @@ function translateMcpServer(server, context) {
   copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"], context);
 
   const environment = isObject(server.environment) ? server.environment : server.env;
-  if (isObject(environment)) translated.environment = expandMcpRecord(environment, context);
+  translated.environment = {
+    ...(isObject(environment) ? expandMcpRecord(environment, context) : {}),
+    ...expandMcpRecord(
+      {
+        CLAUDE_PLUGIN_ROOT: "${CLAUDE_PLUGIN_ROOT}",
+        CLAUDE_PLUGIN_DATA: "${CLAUDE_PLUGIN_DATA}",
+        CLAUDE_PROJECT_DIR: "${CLAUDE_PROJECT_DIR}",
+      },
+      context,
+    ),
+  };
 
   return translated;
 }
@@ -239,6 +264,7 @@ function expandMcpString(value, context) {
 
 function mcpVariable(name, context) {
   if (name === "CLAUDE_PLUGIN_ROOT") return context.pluginRoot;
+  if (name === "CLAUDE_PLUGIN_DATA") return context.pluginData();
   if (name === "CLAUDE_PROJECT_DIR") return context.projectDir;
   return process.env[name];
 }

--- a/SwiftScaffolding/common/opencode-plugin.js
+++ b/SwiftScaffolding/common/opencode-plugin.js
@@ -8,11 +8,47 @@ import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
 const MCP_PLACEHOLDER_RE = /\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}/g;
+const MCP_COMPATIBILITY_ENVIRONMENT_KEYS = new Set([
+  "CLAUDE_PLUGIN_ROOT",
+  "CLAUDE_PLUGIN_DATA",
+  "CLAUDE_PROJECT_DIR",
+]);
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const PROCESS_START_OUTPUT_MAX_CHARS = 256;
 const PROCESS_START_TIMEOUT_MS = 5_000;
+const PROCESS_TERMINATION_GRACE_MS = 250;
 const XCODE_MCP_CACHE_TTL_MS = 30_000;
+const XCRUN_OPTIONS_WITH_VALUE = new Set([
+  "--sdk",
+  "-sdk",
+  "--toolchain",
+  "-toolchain",
+]);
+const XCRUN_OPTIONS_WITHOUT_VALUE = new Set([
+  "-h",
+  "--help",
+  "--version",
+  "-v",
+  "--verbose",
+  "-l",
+  "--log",
+  "-f",
+  "--find",
+  "-r",
+  "--run",
+  "-n",
+  "--no-cache",
+  "-k",
+  "--kill-cache",
+  "--show-sdk-path",
+  "--show-sdk-version",
+  "--show-sdk-build-version",
+  "--show-sdk-platform-path",
+  "--show-sdk-platform-version",
+  "--show-toolchain-path",
+]);
 const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
+const XCODE_SANDBOX_MODE = 0o700;
 const XCODE_SANDBOX_OWNER_GRACE_MS = 60_000;
 const XCODE_SANDBOX_OWNER_LOCK = ".owner.lock";
 const XCODE_SANDBOX_QUARANTINE_RE =
@@ -39,7 +75,9 @@ export function createOpenCodePlugin(pluginRootUrl) {
       deniedOnce: new Set(),
       xcodeMcpCache: new Map(),
       xcodeMcpApprovalSessions: new Set(),
+      sandboxRoot: null,
       ownedSandboxes: new Map(),
+      ownedSandboxIdentities: new Map(),
       deletedSandboxSessions: new Set(),
       sandboxSweepDone: false,
       disposed: false,
@@ -146,8 +184,45 @@ function registerMcpServers(config, pluginRoot, context) {
     if (!isObject(server) || config.mcp[name]) continue;
 
     const translated = translateMcpServer(server, context);
-    if (translated) config.mcp[name] = translated;
+    if (translated && !hasMcpEndpoint(config.mcp, translated)) {
+      config.mcp[name] = translated;
+    }
   }
+}
+
+function hasMcpEndpoint(servers, candidate) {
+  return Object.values(servers).some((server) => {
+    if (!isObject(server) || server.type !== candidate.type) return false;
+    if (candidate.type === "remote") return server.url === candidate.url;
+    if (candidate.type !== "local") return false;
+    if (!Array.isArray(server.command) || !Array.isArray(candidate.command)) return false;
+    return (
+      server.command.length === candidate.command.length &&
+      server.command.every((item, index) => item === candidate.command[index]) &&
+      server.cwd === candidate.cwd &&
+      mcpEnvironmentMatches(server.environment, candidate.environment)
+    );
+  });
+}
+
+function mcpEnvironmentMatches(left, right) {
+  const leftEntries = comparableMcpEnvironment(left);
+  const rightEntries = comparableMcpEnvironment(right);
+  if (!leftEntries || !rightEntries || leftEntries.length !== rightEntries.length) {
+    return false;
+  }
+  return leftEntries.every(([key, value], index) => {
+    const [rightKey, rightValue] = rightEntries[index];
+    return key === rightKey && value === rightValue;
+  });
+}
+
+function comparableMcpEnvironment(environment) {
+  if (environment === undefined) return [];
+  if (!isObject(environment)) return null;
+  return Object.entries(environment)
+    .filter(([key]) => !MCP_COMPATIBILITY_ENVIRONMENT_KEYS.has(key))
+    .sort(([left], [right]) => left.localeCompare(right));
 }
 
 function translateMcpServer(server, context) {
@@ -338,14 +413,40 @@ function hasConfiguredMcpbridge(config) {
     if (!isObject(server) || server.enabled === false || server.type !== "local") return false;
 
     const command = Array.isArray(server.command) ? server.command : [server.command];
-    return command.some((part) => {
-      if (typeof part !== "string") return false;
-      return part
-        .trim()
-        .split(/\s+/)
-        .some((token) => path.basename(token.replace(/^['"]|['"]$/g, "")) === "mcpbridge");
-    });
+    const executable = commandBasename(command[0]);
+    if (executable === "mcpbridge") return true;
+    if (executable !== "xcrun") return false;
+    return xcrunToolBasename(command.slice(1)) === "mcpbridge";
   });
+}
+
+function commandBasename(value) {
+  const commandPart = normalizedCommandPart(value);
+  return commandPart ? path.basename(commandPart) : "";
+}
+
+function normalizedCommandPart(value) {
+  if (typeof value !== "string") return "";
+  return value.trim().replace(/^['"]|['"]$/g, "");
+}
+
+function xcrunToolBasename(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = normalizedCommandPart(args[index]);
+    if (!argument) return "";
+    if (argument === "--") {
+      return commandBasename(args[index + 1]);
+    }
+    if (XCRUN_OPTIONS_WITH_VALUE.has(argument)) {
+      index += 1;
+      continue;
+    }
+    if (/^(?:--?sdk|--?toolchain)=/.test(argument)) continue;
+    if (XCRUN_OPTIONS_WITHOUT_VALUE.has(argument)) continue;
+    if (argument.startsWith("-")) return "";
+    return path.basename(argument);
+  }
+  return "";
 }
 
 function startXcodeMcpApproval(pluginRoot, state, sessionID) {
@@ -378,22 +479,74 @@ function startXcodeMcpApproval(pluginRoot, state, sessionID) {
 function commandSucceeds(command, args, timeoutMs) {
   return new Promise((resolve) => {
     let settled = false;
-    const child = spawn(command, args, { stdio: "ignore" });
-    const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      finish(false);
-    }, timeoutMs);
+    let timedOut = false;
+    let timeoutTimer;
+    let forceKillTimer;
+    let child;
 
-    child.on("error", () => finish(false));
-    child.on("exit", (code) => finish(code === 0));
+    try {
+      child = spawn(command, args, { stdio: "ignore" });
+    } catch {
+      resolve(false);
+      return;
+    }
+
+    const onError = () => finish(false);
+    const onExit = (code) => finish(!timedOut && code === 0);
+    child.on("error", onError);
+    child.on("exit", onExit);
+    timeoutTimer = setTimeout(beginTermination, timeoutMs);
+
+    function beginTermination() {
+      if (settled) return;
+      timedOut = true;
+      forceKillTimer = terminateChildAfterGrace(
+        child,
+        () => !settled,
+        () => finish(false),
+      );
+    }
 
     function finish(result) {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      clearTimeout(timeoutTimer);
+      clearTimeout(forceKillTimer);
+      child.removeListener?.("error", onError);
+      child.removeListener?.("exit", onExit);
       resolve(result);
     }
   });
+}
+
+function terminateChildAfterGrace(child, isPending, onForcedTermination) {
+  try {
+    child.kill("SIGTERM");
+  } catch {
+    // Continue to forced termination so the timed-out child is detached.
+  }
+  if (!isPending()) return undefined;
+
+  return setTimeout(() => {
+    if (!isPending()) return;
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // The process may have exited between the grace timer and this call.
+    }
+    try {
+      child.stdout?.destroy?.();
+      child.stderr?.destroy?.();
+    } catch {
+      // Detaching the child still allows the parent to continue.
+    }
+    try {
+      child.unref();
+    } catch {
+      // Resolving the caller is more important than detaching a broken shim.
+    }
+    onForcedTermination();
+  }, PROCESS_TERMINATION_GRACE_MS);
 }
 
 function applyPreToolUseRules(state, input, output) {
@@ -443,10 +596,10 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
 
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
   if (state.disposed || state.deletedSandboxSessions.has(sessionID)) return;
-  const sandboxRoot = path.join(os.tmpdir(), XCODE_SANDBOX_DIR);
+  const sandboxRoot = secureSandboxRoot(state);
   // Plugin instances never reuse a sandbox path, so an older instance cannot
   // delete a replacement instance's active sandbox after an ownership check.
-  const sandboxBase = path.join(sandboxRoot, `${sessionID}-${state.instanceID}`);
+  const sandboxBase = path.join(sandboxRoot.path, `${sessionID}-${state.instanceID}`);
   state.ownedSandboxes.set(sessionID, sandboxBase);
 
   if (!state.processStartToken) {
@@ -463,12 +616,146 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   const buildDir = path.join(sandboxBase, "build");
   const packagesDir = path.join(sandboxBase, "packages");
 
-  fs.mkdirSync(buildDir, { recursive: true });
-  fs.mkdirSync(packagesDir, { recursive: true });
-  writeSandboxOwner(sandboxBase, state.processStartToken, state.instanceID);
+  const sandboxIdentity = secureSandboxDirectory(sandboxBase, sandboxRoot);
+  state.ownedSandboxIdentities.set(sessionID, sandboxIdentity);
+  if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
+  secureSandboxDirectory(buildDir, sandboxIdentity);
+  secureSandboxDirectory(packagesDir, sandboxIdentity);
+  writeSandboxOwner(
+    sandboxIdentity,
+    state.processStartToken,
+    state.instanceID,
+  );
 
   output.env.SANDBOX_DERIVED_DATA = buildDir;
   output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+function secureSandboxRoot(state) {
+  if (state.sandboxRoot) {
+    revalidateSandboxDirectory(state.sandboxRoot);
+    return state.sandboxRoot;
+  }
+
+  const temporaryDirectory = path.resolve(os.tmpdir());
+  const canonicalTemporaryDirectory = canonicalPath(temporaryDirectory);
+  const sandboxRoot = path.join(temporaryDirectory, XCODE_SANDBOX_DIR);
+  const expectedCanonicalPath = path.join(
+    canonicalTemporaryDirectory,
+    XCODE_SANDBOX_DIR,
+  );
+
+  createDirectoryNonRecursively(sandboxRoot);
+  const identity = inspectSandboxDirectory(
+    sandboxRoot,
+    expectedCanonicalPath,
+    null,
+  );
+  state.sandboxRoot = identity;
+  return identity;
+}
+
+function secureSandboxDirectory(directoryPath, parentIdentity) {
+  revalidateSandboxDirectory(parentIdentity);
+
+  const candidate = path.resolve(directoryPath);
+  const parentPath = path.resolve(parentIdentity.path);
+  if (path.dirname(candidate) !== parentPath) {
+    throw new Error("Sandbox directory must be a direct child of its trusted parent");
+  }
+
+  const name = path.basename(candidate);
+  if (!SAFE_ID_RE.test(name)) {
+    throw new Error("Sandbox directory has an unsafe name");
+  }
+
+  createDirectoryNonRecursively(candidate);
+  return inspectSandboxDirectory(
+    candidate,
+    path.join(parentIdentity.canonicalPath, name),
+    parentIdentity,
+  );
+}
+
+function createDirectoryNonRecursively(directoryPath) {
+  try {
+    fs.mkdirSync(directoryPath, { mode: XCODE_SANDBOX_MODE });
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+}
+
+function inspectSandboxDirectory(directoryPath, expectedCanonicalPath, parentIdentity) {
+  if (typeof process.getuid !== "function") {
+    throw new Error("Xcode sandbox setup requires POSIX ownership checks");
+  }
+
+  const directoryFlags =
+    fs.constants.O_RDONLY |
+    (fs.constants.O_DIRECTORY ?? 0) |
+    (fs.constants.O_NOFOLLOW ?? 0);
+  const descriptor = fs.openSync(directoryPath, directoryFlags);
+  try {
+    const before = fs.fstatSync(descriptor);
+    if (!before.isDirectory() || before.uid !== process.getuid()) {
+      throw new Error("Sandbox directory is not owned by the current user");
+    }
+
+    fs.fchmodSync(descriptor, XCODE_SANDBOX_MODE);
+    const after = fs.fstatSync(descriptor);
+    const link = fs.lstatSync(directoryPath);
+    if (
+      !after.isDirectory() ||
+      !link.isDirectory() ||
+      link.isSymbolicLink() ||
+      after.uid !== process.getuid() ||
+      link.uid !== process.getuid() ||
+      after.dev !== link.dev ||
+      after.ino !== link.ino ||
+      (after.mode & 0o777) !== XCODE_SANDBOX_MODE
+    ) {
+      throw new Error("Sandbox directory identity changed during validation");
+    }
+
+    const resolved = canonicalPath(directoryPath);
+    if (resolved !== path.resolve(expectedCanonicalPath)) {
+      throw new Error("Sandbox directory escaped its trusted parent");
+    }
+
+    return {
+      path: path.resolve(directoryPath),
+      canonicalPath: resolved,
+      dev: after.dev,
+      ino: after.ino,
+      uid: after.uid,
+      parent: parentIdentity,
+    };
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function revalidateSandboxDirectory(identity) {
+  if (!identity) throw new Error("Sandbox directory identity is unavailable");
+  if (identity.parent) revalidateSandboxDirectory(identity.parent);
+
+  const current = inspectSandboxDirectory(
+    identity.path,
+    identity.canonicalPath,
+    identity.parent,
+  );
+  if (
+    current.dev !== identity.dev ||
+    current.ino !== identity.ino ||
+    current.uid !== identity.uid
+  ) {
+    throw new Error("Sandbox directory was replaced");
+  }
+  return current;
+}
+
+function canonicalPath(filePath) {
+  return fs.realpathSync.native?.(filePath) ?? fs.realpathSync(filePath);
 }
 
 function sandboxSetupIsCancelled(state, sessionID, sandboxBase) {
@@ -479,15 +766,25 @@ function sandboxSetupIsCancelled(state, sessionID, sandboxBase) {
   );
 }
 
-function writeSandboxOwner(sandboxBase, processStartToken, instanceID) {
+function writeSandboxOwner(sandboxIdentity, processStartToken, instanceID) {
+  revalidateSandboxDirectory(sandboxIdentity);
+  const sandboxBase = sandboxIdentity.path;
   const ownerPath = path.join(sandboxBase, "owner.pid");
   const temporaryPath = path.join(sandboxBase, `owner.pid.${instanceID}.tmp`);
   const content = `${process.pid}\n${process.argv[0] ?? "opencode"}\n${processStartToken}\n${instanceID}\n`;
-  const ownerLock = acquireSandboxOwnerLock(sandboxBase);
+  const ownerLock = acquireSandboxOwnerLock(
+    sandboxBase,
+    sandboxIdentity.parent,
+    sandboxIdentity,
+  );
   if (!ownerLock) throw new Error("Sandbox owner is being updated or removed");
 
   try {
-    fs.writeFileSync(temporaryPath, content, "utf8");
+    fs.writeFileSync(temporaryPath, content, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
     if (!sandboxOwnerLockIsHeld(ownerLock)) {
       throw new Error("Sandbox owner lock changed during update");
     }
@@ -510,7 +807,11 @@ function markSandboxCleanupPending(sandboxBase, instanceID, ownerLock) {
   const content = `${process.pid}\ncleanup-pending\n\n${instanceID}\ncleanup-pending\n`;
 
   try {
-    fs.writeFileSync(temporaryPath, content, "utf8");
+    fs.writeFileSync(temporaryPath, content, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
     if (!sandboxOwnerLockIsHeld(ownerLock)) return false;
     fs.renameSync(temporaryPath, ownerPath);
     return true;
@@ -525,11 +826,31 @@ function markSandboxCleanupPending(sandboxBase, instanceID, ownerLock) {
   }
 }
 
-function acquireSandboxOwnerLock(sandboxBase) {
+function acquireSandboxOwnerLock(
+  sandboxBase,
+  sandboxRootIdentity = null,
+  expectedSandboxIdentity = null,
+) {
+  let sandboxIdentity = null;
+  if (sandboxRootIdentity) {
+    sandboxIdentity = secureExistingManagedSandbox(
+      sandboxBase,
+      sandboxRootIdentity,
+      expectedSandboxIdentity,
+    );
+    if (!sandboxIdentity) return null;
+  }
+
   const lockPath = path.join(sandboxBase, XCODE_SANDBOX_OWNER_LOCK);
   const token = randomUUID();
   const createdLock = createSandboxOwnerLock(lockPath, token);
-  if (createdLock) return createdLock;
+  if (createdLock) {
+    return attachSandboxIdentityToLock(
+      createdLock,
+      sandboxRootIdentity,
+      sandboxIdentity,
+    );
+  }
 
   const observedLock = readSandboxOwnerLock(lockPath);
   if (!observedLock) return null;
@@ -555,7 +876,16 @@ function acquireSandboxOwnerLock(sandboxBase) {
     return null;
   }
 
-  return createSandboxOwnerLock(lockPath, token);
+  return attachSandboxIdentityToLock(
+    createSandboxOwnerLock(lockPath, token),
+    sandboxRootIdentity,
+    sandboxIdentity,
+  );
+}
+
+function attachSandboxIdentityToLock(ownerLock, sandboxRootIdentity, sandboxIdentity) {
+  if (!ownerLock || !sandboxRootIdentity || !sandboxIdentity) return ownerLock;
+  return { ...ownerLock, sandboxRootIdentity, sandboxIdentity };
 }
 
 function createSandboxOwnerLock(lockPath, token) {
@@ -612,6 +942,16 @@ function sameSandboxOwnerLock(left, right) {
 }
 
 function sandboxOwnerLockIsHeld(ownerLock) {
+  if (
+    ownerLock?.sandboxRootIdentity &&
+    !secureExistingManagedSandbox(
+      ownerLock.sandboxIdentity.path,
+      ownerLock.sandboxRootIdentity,
+      ownerLock.sandboxIdentity,
+    )
+  ) {
+    return false;
+  }
   return sameSandboxOwnerLock(ownerLock, readSandboxOwnerLock(ownerLock.path));
 }
 
@@ -666,42 +1006,78 @@ async function removeOwnedSandbox(state, sessionID) {
   const sandboxPath = state.ownedSandboxes.get(sessionID);
   if (!sandboxPath) return;
 
+  const sandboxIdentity = state.ownedSandboxIdentities.get(sessionID);
   markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.delete(sessionID);
-  const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+  state.ownedSandboxIdentities.delete(sessionID);
+  if (!state.sandboxRoot || !sandboxIdentity) return;
+
+  const quarantinedPath = await quarantineOwnedSandbox(
+    sandboxPath,
+    state.instanceID,
+    state.sandboxRoot,
+    sandboxIdentity,
+  );
+  const cleanupIdentity = quarantinedPath
+    ? relocatedSandboxIdentity(sandboxIdentity, quarantinedPath)
+    : sandboxIdentity;
   await removeManagedSandbox(
     quarantinedPath || sandboxPath,
     quarantinedPath ? "" : state.instanceID,
+    state.sandboxRoot,
+    cleanupIdentity,
   );
 }
 
 async function detachOwnedSandboxes(state) {
   state.disposed = true;
-  const sandboxPaths = [...new Set(state.ownedSandboxes.values())];
+  const sandboxes = [...state.ownedSandboxes.entries()].map(([sessionID, sandboxPath]) => ({
+    sandboxPath,
+    sandboxIdentity: state.ownedSandboxIdentities.get(sessionID),
+  }));
+  const sandboxPaths = [...new Set(sandboxes.map(({ sandboxPath }) => sandboxPath))];
   for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
+  state.ownedSandboxIdentities.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
   const cleanupTargets = await Promise.all(
-    sandboxPaths.map(async (sandboxPath) => {
-      const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+    sandboxes.map(async ({ sandboxPath, sandboxIdentity }) => {
+      if (!state.sandboxRoot || !sandboxIdentity) return null;
+      const quarantinedPath = await quarantineOwnedSandbox(
+        sandboxPath,
+        state.instanceID,
+        state.sandboxRoot,
+        sandboxIdentity,
+      );
       return {
         path: quarantinedPath || sandboxPath,
         expectedInstanceID: quarantinedPath ? "" : state.instanceID,
+        identity: quarantinedPath
+          ? relocatedSandboxIdentity(sandboxIdentity, quarantinedPath)
+          : sandboxIdentity,
       };
     }),
   );
   await Promise.all(
-    cleanupTargets.map(({ path: sandboxPath, expectedInstanceID }) =>
-      detachManagedSandbox(sandboxPath, expectedInstanceID),
+    cleanupTargets.filter(Boolean).map(({ path: sandboxPath, expectedInstanceID, identity }) =>
+      detachManagedSandbox(
+        sandboxPath,
+        expectedInstanceID,
+        state.sandboxRoot,
+        identity,
+      ),
     ),
   );
 }
 
-async function sweepStaleSandboxes(sandboxRoot) {
+async function sweepStaleSandboxes(sandboxRootIdentity) {
   let entries;
   try {
-    entries = await fs.promises.readdir(sandboxRoot, { withFileTypes: true });
+    revalidateSandboxDirectory(sandboxRootIdentity);
+    entries = await fs.promises.readdir(sandboxRootIdentity.path, {
+      withFileTypes: true,
+    });
   } catch {
     return;
   }
@@ -711,7 +1087,12 @@ async function sweepStaleSandboxes(sandboxRoot) {
       const isQuarantine = XCODE_SANDBOX_QUARANTINE_RE.test(entry.name);
       if (!entry.isDirectory() || (!SAFE_ID_RE.test(entry.name) && !isQuarantine)) return;
 
-      const sandboxPath = path.join(sandboxRoot, entry.name);
+      const sandboxPath = path.join(sandboxRootIdentity.path, entry.name);
+      const sandboxIdentity = secureExistingManagedSandbox(
+        sandboxPath,
+        sandboxRootIdentity,
+      );
+      if (!sandboxIdentity) return;
       const owner = await readSandboxOwner(sandboxPath);
       const cleanupPending = owner?.cleanupPending || sandboxCleanupIsPending(sandboxPath);
       if (!owner || cleanupPending) {
@@ -719,7 +1100,11 @@ async function sweepStaleSandboxes(sandboxRoot) {
           return;
         }
 
-        const ownerLock = acquireSandboxOwnerLock(sandboxPath);
+        const ownerLock = acquireSandboxOwnerLock(
+          sandboxPath,
+          sandboxRootIdentity,
+          sandboxIdentity,
+        );
         if (!ownerLock) return;
         let releaseLock = ownerLock;
         try {
@@ -733,10 +1118,20 @@ async function sweepStaleSandboxes(sandboxRoot) {
             (!currentOwner || currentCleanupPending) &&
             sandboxOwnerLockIsHeld(ownerLock)
           ) {
-            const quarantined = await quarantineManagedSandbox(sandboxPath, ownerLock);
+            const quarantined = await quarantineManagedSandbox(
+              sandboxPath,
+              ownerLock,
+              sandboxRootIdentity,
+              sandboxIdentity,
+            );
             releaseLock = quarantined.ownerLock;
             if (quarantined.path) {
-              await removeManagedSandbox(quarantined.path);
+              await removeManagedSandbox(
+                quarantined.path,
+                "",
+                sandboxRootIdentity,
+                relocatedSandboxIdentity(sandboxIdentity, quarantined.path),
+              );
             }
           }
         } finally {
@@ -746,7 +1141,12 @@ async function sweepStaleSandboxes(sandboxRoot) {
       }
       if (await sandboxOwnerIsActive(owner)) return;
 
-      await removeManagedSandbox(sandboxPath);
+      await removeManagedSandbox(
+        sandboxPath,
+        "",
+        sandboxRootIdentity,
+        sandboxIdentity,
+      );
     }),
   );
 }
@@ -805,9 +1205,11 @@ async function sandboxOwnerIsActive(owner) {
 function readProcessStartToken(pid) {
   return new Promise((resolve) => {
     let settled = false;
+    let timedOut = false;
     let stdout = "";
     let child;
-    let timer;
+    let timeoutTimer;
+    let forceKillTimer;
 
     try {
       child = spawn("/bin/ps", ["-p", String(pid), "-o", "lstart="], {
@@ -824,37 +1226,61 @@ function readProcessStartToken(pid) {
       return;
     }
 
-    child.stdout?.setEncoding?.("utf8");
-    child.stdout?.on?.("data", (chunk) => {
+    const onData = (chunk) => {
       const remaining = PROCESS_START_OUTPUT_MAX_CHARS - stdout.length;
       if (remaining > 0) stdout += String(chunk).slice(0, remaining);
-    });
-    child.on("error", () => finish(""));
-    child.on("close", (code) => {
+    };
+    const onError = () => finish("");
+    const onClose = (code) => {
       const firstLine = stdout.trim().split(/\r?\n/, 1)[0] ?? "";
-      finish(code === 0 ? firstLine : "");
-    });
-    timer = setTimeout(() => {
-      try {
-        child.kill?.("SIGTERM");
-      } catch {
-        // Resolving the hook is more important than terminating a broken ps shim.
-      }
-      finish("");
+      finish(!timedOut && code === 0 ? firstLine : "");
+    };
+
+    child.stdout?.setEncoding?.("utf8");
+    child.stdout?.on?.("data", onData);
+    child.on("error", onError);
+    child.on("close", onClose);
+    timeoutTimer = setTimeout(() => {
+      if (settled) return;
+      timedOut = true;
+      forceKillTimer = terminateChildAfterGrace(
+        child,
+        () => !settled,
+        () => finish(""),
+      );
     }, PROCESS_START_TIMEOUT_MS);
 
     function finish(value) {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      clearTimeout(timeoutTimer);
+      clearTimeout(forceKillTimer);
+      child.stdout?.removeListener?.("data", onData);
+      child.removeListener?.("error", onError);
+      child.removeListener?.("close", onClose);
       resolve(value);
     }
   });
 }
 
-async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
+async function removeManagedSandbox(
+  sandboxPath,
+  expectedInstanceID = "",
+  sandboxRootIdentity = null,
+  expectedSandboxIdentity = null,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
   if (!candidate) return false;
+  if (
+    !sandboxRootIdentity ||
+    !secureExistingManagedSandbox(
+      candidate,
+      sandboxRootIdentity,
+      expectedSandboxIdentity,
+    )
+  ) {
+    return false;
+  }
 
   if (expectedInstanceID) {
     const owner = await readSandboxOwner(candidate);
@@ -871,11 +1297,26 @@ async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
   }
 }
 
-async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
+async function quarantineOwnedSandbox(
+  sandboxPath,
+  expectedInstanceID,
+  sandboxRootIdentity,
+  expectedSandboxIdentity,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
   if (!candidate) return "";
+  const sandboxIdentity = secureExistingManagedSandbox(
+    candidate,
+    sandboxRootIdentity,
+    expectedSandboxIdentity,
+  );
+  if (!sandboxIdentity) return "";
 
-  const ownerLock = acquireSandboxOwnerLock(candidate);
+  const ownerLock = acquireSandboxOwnerLock(
+    candidate,
+    sandboxRootIdentity,
+    sandboxIdentity,
+  );
   if (!ownerLock) return "";
   let releaseLock = ownerLock;
 
@@ -897,7 +1338,21 @@ async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
     releaseLock = {
       ...ownerLock,
       path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+      sandboxIdentity: relocatedSandboxIdentity(sandboxIdentity, quarantinePath),
     };
+    if (
+      !secureExistingManagedSandbox(
+        quarantinePath,
+        sandboxRootIdentity,
+        releaseLock.sandboxIdentity,
+      )
+    ) {
+      if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+        movePendingSandboxCleanup(quarantinePath, candidate);
+        releaseLock = ownerLock;
+      }
+      return "";
+    }
     const relocatedOwner = await readSandboxOwner(quarantinePath);
     if (
       !sandboxOwnerLockIsHeld(releaseLock) ||
@@ -907,7 +1362,7 @@ async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
     ) {
       if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
         movePendingSandboxCleanup(quarantinePath, candidate);
-        releaseLock = { ...releaseLock, path: ownerLock.path };
+        releaseLock = ownerLock;
       }
       return "";
     }
@@ -926,9 +1381,21 @@ async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
   }
 }
 
-async function quarantineManagedSandbox(sandboxPath, ownerLock) {
+async function quarantineManagedSandbox(
+  sandboxPath,
+  ownerLock,
+  sandboxRootIdentity,
+  expectedSandboxIdentity,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
-  if (!candidate || !sandboxOwnerLockIsHeld(ownerLock)) {
+  const sandboxIdentity = candidate
+    ? secureExistingManagedSandbox(
+        candidate,
+        sandboxRootIdentity,
+        expectedSandboxIdentity,
+      )
+    : null;
+  if (!candidate || !sandboxIdentity || !sandboxOwnerLockIsHeld(ownerLock)) {
     return { path: "", ownerLock };
   }
 
@@ -945,7 +1412,21 @@ async function quarantineManagedSandbox(sandboxPath, ownerLock) {
   const relocatedLock = {
     ...ownerLock,
     path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+    sandboxIdentity: relocatedSandboxIdentity(sandboxIdentity, quarantinePath),
   };
+  if (
+    !secureExistingManagedSandbox(
+      quarantinePath,
+      sandboxRootIdentity,
+      relocatedLock.sandboxIdentity,
+    )
+  ) {
+    if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+      movePendingSandboxCleanup(quarantinePath, candidate);
+      return { path: "", ownerLock };
+    }
+    return { path: "", ownerLock: relocatedLock };
+  }
   const publishedOwner = await readSandboxOwner(quarantinePath);
   const cleanupPending =
     publishedOwner?.cleanupPending || sandboxCleanupIsPending(quarantinePath);
@@ -973,9 +1454,24 @@ function restoreQuarantinedSandbox(quarantinePath, originalPath) {
   }
 }
 
-async function detachManagedSandbox(sandboxPath, expectedInstanceID = "") {
+async function detachManagedSandbox(
+  sandboxPath,
+  expectedInstanceID = "",
+  sandboxRootIdentity = null,
+  expectedSandboxIdentity = null,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
   if (!candidate) return;
+  if (
+    !sandboxRootIdentity ||
+    !secureExistingManagedSandbox(
+      candidate,
+      sandboxRootIdentity,
+      expectedSandboxIdentity,
+    )
+  ) {
+    return;
+  }
 
   if (expectedInstanceID) {
     const owner = await readSandboxOwner(candidate);
@@ -1003,6 +1499,49 @@ function managedSandboxCandidate(sandboxPath) {
   const relative = path.relative(sandboxRoot, candidate);
   if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return "";
   return candidate;
+}
+
+function secureExistingManagedSandbox(
+  sandboxPath,
+  sandboxRootIdentity,
+  expectedSandboxIdentity = null,
+) {
+  try {
+    revalidateSandboxDirectory(sandboxRootIdentity);
+    const candidate = managedSandboxCandidate(sandboxPath);
+    if (!candidate || path.dirname(candidate) !== sandboxRootIdentity.path) return null;
+
+    const name = path.basename(candidate);
+    if (!SAFE_ID_RE.test(name) && !XCODE_SANDBOX_QUARANTINE_RE.test(name)) {
+      return null;
+    }
+
+    const current = inspectSandboxDirectory(
+      candidate,
+      path.join(sandboxRootIdentity.canonicalPath, name),
+      sandboxRootIdentity,
+    );
+    if (
+      expectedSandboxIdentity &&
+      (current.dev !== expectedSandboxIdentity.dev ||
+        current.ino !== expectedSandboxIdentity.ino ||
+        current.uid !== expectedSandboxIdentity.uid)
+    ) {
+      return null;
+    }
+    return current;
+  } catch {
+    return null;
+  }
+}
+
+function relocatedSandboxIdentity(identity, destinationPath) {
+  const name = path.basename(destinationPath);
+  return {
+    ...identity,
+    path: path.resolve(destinationPath),
+    canonicalPath: path.join(identity.parent.canonicalPath, name),
+  };
 }
 
 function markPendingSandboxCleanup(sandboxPath) {

--- a/SwiftScaffolding/info.json
+++ b/SwiftScaffolding/info.json
@@ -5,6 +5,10 @@
     "welcomeMessage": "You can scaffold Swift projects using the scaffolding skill.",
     "versions": [
         {
+            "version": "0.4.4",
+            "changes": "Added OpenCode support through an opencode-plugin.js entry point that registers skills, MCP servers, session-start context, and pre-tool-use command guardrails."
+        },
+        {
             "version": "0.4.3",
             "changes": "Migrated the legacy scaffolding command prompt to the scaffolding skill and registered it in info.json. Released self-contained common helper copies so the plugin package no longer depends on repository-level symlinks, while keeping hook configuration in hooks/hooks.json instead of generated common/hooks.json templates."
         },

--- a/SwiftScaffolding/info.json
+++ b/SwiftScaffolding/info.json
@@ -6,7 +6,7 @@
     "versions": [
         {
             "version": "0.4.4",
-            "changes": "Added OpenCode support through an opencode-plugin.js entry point that registers skills, MCP servers, session-start context, and pre-tool-use command guardrails."
+            "changes": "Added OpenCode support through an opencode-plugin.js entry point that registers skills, MCP servers, and session-start context."
         },
         {
             "version": "0.4.3",

--- a/SwiftScaffolding/opencode-plugin.js
+++ b/SwiftScaffolding/opencode-plugin.js
@@ -1,0 +1,6 @@
+import { createOpenCodePlugin } from "./common/opencode-plugin.js";
+
+export default {
+  id: "SwiftScaffolding",
+  server: createOpenCodePlugin(new URL(".", import.meta.url)),
+};

--- a/XcodeBuildTools/.claude-plugin/plugin.json
+++ b/XcodeBuildTools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "XcodeBuildTools",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "Xcode development tools: build/test/run Swift packages, discover projects and schemes, build for simulator/device/macOS, run tests, manage device apps, capture simulator logs",
   "author": {
     "name": "Gustavo Ambrozio"

--- a/XcodeBuildTools/README.md
+++ b/XcodeBuildTools/README.md
@@ -4,10 +4,25 @@ Xcode development tools for Claude Code-compatible agents. Build/test tools use 
 
 ## Installation
 
+Claude Code:
+
 ```bash
 /plugin marketplace add gpambrozio/ClaudeCodePlugins
 /plugin install XcodeBuildTools@ClaudeCodePlugins
 ```
+
+OpenCode:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    "/path/to/ClaudeCodePlugins/XcodeBuildTools/opencode-plugin.js"
+  ]
+}
+```
+
+Restart OpenCode after changing config. The OpenCode entry point registers this plugin's skills, `sosumi` MCP server, session context, command guardrails, Xcode MCP auto-approval helper, and Xcode build sandbox environment.
 
 ## Prerequisites
 
@@ -64,6 +79,10 @@ The plugin includes a backgrounded SessionStart hook that automatically clicks "
 - **SwiftScaffolding** - Swift project scaffolding through XcodeBuildMCP
 
 ## Changelog
+
+### 0.5.11
+- Added `opencode-plugin.js` for OpenCode users
+- The OpenCode entry point registers skills, MCP servers, session-start context, pre-tool-use command guardrails, the Xcode MCP auto-approval helper, and the Xcode build sandbox shell environment
 
 ### 0.5.10
 - Migrated the legacy analyze and SwiftUI modernization prompts to `swift-code-analysis` and `swiftui-modernize` skills

--- a/XcodeBuildTools/common/opencode-plugin.js
+++ b/XcodeBuildTools/common/opencode-plugin.js
@@ -271,7 +271,7 @@ function applyPreToolUseRules(state, input, output) {
     if (decision === "deny") throw new Error(message);
 
     const ruleName = typeof rule.name === "string" && rule.name ? rule.name : matchPattern;
-    const key = `${input.sessionID ?? "global"}:${ruleName}`;
+    const key = `${safeSessionID(input.sessionID ?? "global")}:${ruleName}`;
     if (state.deniedOnce.has(key)) continue;
 
     state.deniedOnce.add(key);

--- a/XcodeBuildTools/common/opencode-plugin.js
+++ b/XcodeBuildTools/common/opencode-plugin.js
@@ -85,7 +85,10 @@ export function createOpenCodePlugin(pluginRootUrl) {
     const mcpContext = {
       pluginRoot,
       pluginData: () => pluginDataDirectory(pluginRoot, state),
-      projectDir: input?.worktree || input?.directory,
+      projectDir:
+        input?.worktree !== "/" || input?.project?.vcs === "git"
+          ? input?.worktree || input?.directory
+          : input?.directory || input?.worktree,
     };
 
     return {

--- a/XcodeBuildTools/common/opencode-plugin.js
+++ b/XcodeBuildTools/common/opencode-plugin.js
@@ -17,6 +17,9 @@ const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9
 const PROCESS_START_OUTPUT_MAX_CHARS = 256;
 const PROCESS_START_TIMEOUT_MS = 5_000;
 const PROCESS_TERMINATION_GRACE_MS = 250;
+const SYSTEM_EXECUTABLE_PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+const SYSTEM_PGREP = "/usr/bin/pgrep";
+const SYSTEM_XCRUN = "/usr/bin/xcrun";
 const XCODE_MCP_CACHE_TTL_MS = 30_000;
 const XCRUN_OPTIONS_WITH_VALUE = new Set([
   "--sdk",
@@ -75,6 +78,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       deniedOnce: new Set(),
       xcodeMcpCache: new Map(),
       xcodeMcpApprovalSessions: new Set(),
+      xcodeMcpApprovalHelpers: new Map(),
       sandboxRoot: null,
       ownedSandboxes: new Map(),
       ownedSandboxIdentities: new Map(),
@@ -127,6 +131,8 @@ export function createOpenCodePlugin(pluginRootUrl) {
       },
 
       dispose: async () => {
+        state.disposed = true;
+        await stopAllXcodeMcpApprovals(state);
         await detachOwnedSandboxes(state);
       },
     };
@@ -353,8 +359,11 @@ async function appendSystemContext(pluginRoot, state, input, output) {
   const pluginName = state.pluginJson.name ?? path.basename(pluginRoot);
   const welcomeMessage = typeof state.infoJson.welcomeMessage === "string" ? state.infoJson.welcomeMessage : "";
   const sessionID = safeSessionID(input?.sessionID ?? "global");
-  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state, sessionID);
-  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state, sessionID);
+  let xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state, sessionID);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) xcodeMcpLikely = false;
+  if (xcodeMcpLikely && !xcodeMcpLifecycleCancelled(state, sessionID)) {
+    startXcodeMcpApproval(pluginRoot, state, sessionID);
+  }
   const sessionStart = renderSessionStart(pluginRoot, xcodeMcpLikely);
 
   let systemMessage = `The ${pluginName} plugin is loaded and ready.`;
@@ -386,6 +395,7 @@ function processConditionalBlocks(content, xcodeMcpLikely) {
 }
 
 async function getXcodeMcpLikely(pluginName, state, sessionID) {
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
   if (pluginName !== "XcodeBuildTools") return false;
   if (!hasConfiguredMcpbridge(state.config)) {
     state.xcodeMcpCache.delete(sessionID);
@@ -396,17 +406,26 @@ async function getXcodeMcpLikely(pluginName, state, sessionID) {
   const cached = state.xcodeMcpCache.get(sessionID);
   if (cached && now - cached.checkedAt < XCODE_MCP_CACHE_TTL_MS) return cached.value;
 
-  const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
+  const installed = await commandSucceeds(SYSTEM_XCRUN, ["--find", "mcpbridge"], 5000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
   if (!installed) {
     state.xcodeMcpCache.set(sessionID, { checkedAt: now, value: false });
     return false;
   }
 
-  const xcodeRunning = await commandSucceeds("pgrep", ["-x", "Xcode"], 3000);
-  const bridgeRunning = await commandSucceeds("pgrep", ["-f", "mcpbridge"], 3000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
+  const xcodeRunning = await commandSucceeds(SYSTEM_PGREP, ["-x", "Xcode"], 3000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
+  const bridgeRunning = await commandSucceeds(SYSTEM_PGREP, ["-f", "mcpbridge"], 3000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
   const value = xcodeRunning || bridgeRunning;
   state.xcodeMcpCache.set(sessionID, { checkedAt: now, value });
   return value;
+}
+
+function xcodeMcpLifecycleCancelled(state, sessionID) {
+  return state.disposed || state.deletedSandboxSessions.has(sessionID);
 }
 
 function hasConfiguredMcpbridge(config) {
@@ -453,30 +472,148 @@ function xcrunToolBasename(args) {
 }
 
 function startXcodeMcpApproval(pluginRoot, state, sessionID) {
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return;
   if (state.xcodeMcpApprovalSessions.has(sessionID)) return;
 
-  const runner = path.join(pluginRoot, "hooks", "run-background.sh");
-  const target = path.join("hooks", "approve-xcode-mcp.sh");
-  if (!fs.existsSync(runner)) return;
+  const helper = path.join(pluginRoot, "hooks", "approve-xcode-mcp.sh");
+  if (!fs.existsSync(helper)) return;
 
   try {
+    if (xcodeMcpLifecycleCancelled(state, sessionID)) return;
     state.xcodeMcpApprovalSessions.add(sessionID);
-    const child = spawn(runner, [target], {
+    const child = spawn(helper, [], {
       cwd: pluginRoot,
       detached: true,
       env: {
         ...process.env,
+        PATH: SYSTEM_EXECUTABLE_PATH,
         CLAUDE_HOOK_OWNER_PID: String(process.pid),
         CLAUDE_PLUGIN_ROOT: pluginRoot,
       },
       stdio: "ignore",
     });
-    child.on("error", () => state.xcodeMcpApprovalSessions.delete(sessionID));
+    trackXcodeMcpApprovalHelper(state, sessionID, child);
     child.unref();
   } catch {
     state.xcodeMcpApprovalSessions.delete(sessionID);
     // Auto-approval is best-effort; users can still approve Xcode manually.
   }
+}
+
+function trackXcodeMcpApprovalHelper(state, sessionID, child) {
+  let resolveDone;
+  const record = {
+    child,
+    done: new Promise((resolve) => {
+      resolveDone = resolve;
+    }),
+    pending: true,
+    terminating: false,
+    terminationPromise: null,
+    finish: null,
+    removeFromState: null,
+  };
+
+  const removeFromState = () => {
+    if (state.xcodeMcpApprovalHelpers.get(sessionID) === record) {
+      state.xcodeMcpApprovalHelpers.delete(sessionID);
+    }
+  };
+  const onError = () => finish(true);
+  const onExit = () => finish(false);
+  const finish = (allowRetry) => {
+    if (!record.pending) return;
+    record.pending = false;
+    child.removeListener?.("error", onError);
+    child.removeListener?.("exit", onExit);
+    if (!record.terminating) removeFromState();
+    if (allowRetry) state.xcodeMcpApprovalSessions.delete(sessionID);
+    resolveDone();
+  };
+  record.finish = finish;
+  record.removeFromState = removeFromState;
+
+  state.xcodeMcpApprovalHelpers.set(sessionID, record);
+  child.on("error", onError);
+  child.on("exit", onExit);
+}
+
+function stopXcodeMcpApproval(record) {
+  if (!record) return Promise.resolve();
+  if (!record.terminationPromise) {
+    record.terminating = true;
+    record.terminationPromise = terminateXcodeMcpApproval(record).finally(() => {
+      record.terminating = false;
+      record.removeFromState();
+    });
+  }
+  return record.terminationPromise;
+}
+
+async function terminateXcodeMcpApproval(record) {
+  if (!record.pending) return;
+
+  signalDetachedProcessGroup(record.child, "SIGTERM");
+  let forceKillTimer;
+  await new Promise((resolve) => {
+    let completed = false;
+    const complete = () => {
+      if (completed) return;
+      completed = true;
+      clearTimeout(forceKillTimer);
+      resolve();
+    };
+    const completeIfGroupExited = () => {
+      if (!detachedProcessGroupExists(record.child)) complete();
+    };
+
+    record.done.then(completeIfGroupExited);
+    if (!detachedProcessGroupExists(record.child)) {
+      record.finish(false);
+      complete();
+      return;
+    }
+
+    forceKillTimer = setTimeout(() => {
+      if (detachedProcessGroupExists(record.child)) {
+        signalDetachedProcessGroup(record.child, "SIGKILL");
+      }
+      record.finish(false);
+      complete();
+    }, PROCESS_TERMINATION_GRACE_MS);
+  });
+}
+
+function detachedProcessGroupExists(child) {
+  const pid = Number(child?.pid);
+  if (!Number.isSafeInteger(pid) || pid <= 0) return child != null;
+
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function signalDetachedProcessGroup(child, signal) {
+  const pid = Number(child?.pid);
+  try {
+    if (Number.isSafeInteger(pid) && pid > 0) {
+      process.kill(-pid, signal);
+    } else {
+      child?.kill?.(signal);
+    }
+  } catch {
+    // The helper may have exited between the lifecycle check and the signal.
+  }
+}
+
+async function stopAllXcodeMcpApprovals(state) {
+  const activeHelpers = [...state.xcodeMcpApprovalHelpers.values()];
+  state.xcodeMcpApprovalSessions.clear();
+  await Promise.all(activeHelpers.map((record) => stopXcodeMcpApproval(record)));
+  state.xcodeMcpApprovalHelpers.clear();
 }
 
 function commandSucceeds(command, args, timeoutMs) {
@@ -1002,6 +1139,8 @@ async function handlePluginEvent(state, event) {
   state.deletedSandboxSessions.add(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
+  const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
+  await stopXcodeMcpApproval(activeApproval);
   await removeOwnedSandbox(state, safeID);
 }
 
@@ -1044,6 +1183,7 @@ async function detachOwnedSandboxes(state) {
   state.ownedSandboxIdentities.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
+  state.xcodeMcpApprovalHelpers.clear();
   const cleanupTargets = await Promise.all(
     sandboxes.map(async ({ sandboxPath, sandboxIdentity }) => {
       if (!state.sandboxRoot || !sandboxIdentity) return null;

--- a/XcodeBuildTools/common/opencode-plugin.js
+++ b/XcodeBuildTools/common/opencode-plugin.js
@@ -183,6 +183,7 @@ function processConditionalBlocks(content, xcodeMcpLikely) {
 
 async function getXcodeMcpLikely(pluginName, state) {
   if (pluginName !== "XcodeBuildTools") return false;
+  if (state.xcodeMcpLikely !== undefined) return state.xcodeMcpLikely;
 
   const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
   if (!installed) {

--- a/XcodeBuildTools/common/opencode-plugin.js
+++ b/XcodeBuildTools/common/opencode-plugin.js
@@ -1,0 +1,361 @@
+// Generated from common/opencode-plugin.js by scripts/sync-plugin-common.py. Do not edit this copy; edit common/opencode-plugin.js and rerun scripts/sync-plugin-common.py.
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+export function createOpenCodePlugin(pluginRootUrl) {
+  const pluginRoot = normalizePluginRoot(pluginRootUrl);
+  const state = {
+    pluginJson: null,
+    infoJson: null,
+    deniedOnce: new Set(),
+    xcodeMcpLikely: undefined,
+    xcodeMcpApprovalStarted: false,
+  };
+
+  return async () => ({
+    config: async (config) => {
+      loadMetadata(pluginRoot, state);
+      registerSkills(config, pluginRoot);
+      registerMcpServers(config, pluginRoot);
+    },
+
+    "experimental.chat.system.transform": async (_input, output) => {
+      try {
+        loadMetadata(pluginRoot, state);
+        await appendSystemContext(pluginRoot, state, output);
+      } catch {
+        // Fail open. Plugin context should never block a chat request.
+      }
+    },
+
+    "tool.execute.before": async (input, output) => {
+      loadMetadata(pluginRoot, state);
+      applyPreToolUseRules(state, input, output);
+    },
+
+    "shell.env": async (input, output) => {
+      try {
+        loadMetadata(pluginRoot, state);
+        configureShellEnvironment(pluginRoot, state, input, output);
+      } catch {
+        // Fail open. Shell commands should still run if setup is unavailable.
+      }
+    },
+  });
+}
+
+function normalizePluginRoot(pluginRootUrl) {
+  if (pluginRootUrl instanceof URL) {
+    return path.resolve(fileURLToPath(pluginRootUrl));
+  }
+
+  if (typeof pluginRootUrl === "string" && pluginRootUrl.startsWith("file:")) {
+    return path.resolve(fileURLToPath(pluginRootUrl));
+  }
+
+  return path.resolve(String(pluginRootUrl));
+}
+
+function loadMetadata(pluginRoot, state) {
+  if (!state.pluginJson) {
+    state.pluginJson = readJsonFile(path.join(pluginRoot, ".claude-plugin", "plugin.json")) ?? {};
+  }
+  if (!state.infoJson) {
+    state.infoJson = readJsonFile(path.join(pluginRoot, "info.json")) ?? {};
+  }
+}
+
+function registerSkills(config, pluginRoot) {
+  const skillsDir = path.join(pluginRoot, "skills");
+  if (!hasSkillDirectories(skillsDir)) return;
+
+  if (!isObject(config.skills)) config.skills = {};
+  if (!Array.isArray(config.skills.paths)) config.skills.paths = [];
+  if (!config.skills.paths.includes(skillsDir)) config.skills.paths.push(skillsDir);
+}
+
+function registerMcpServers(config, pluginRoot) {
+  const mcpConfig = readJsonFile(path.join(pluginRoot, ".mcp.json"));
+  const servers = mcpConfig?.mcpServers;
+  if (!isObject(servers)) return;
+
+  if (!isObject(config.mcp)) config.mcp = {};
+
+  for (const [name, server] of Object.entries(servers)) {
+    if (!isObject(server) || config.mcp[name]) continue;
+
+    const translated = translateMcpServer(server);
+    if (translated) config.mcp[name] = translated;
+  }
+}
+
+function translateMcpServer(server) {
+  if (typeof server.url === "string") {
+    const translated = {
+      type: "remote",
+      url: server.url,
+    };
+    copyOptionalFields(server, translated, ["enabled", "headers", "timeout"]);
+    return translated;
+  }
+
+  const command = normalizeCommand(server.command, server.args);
+  if (!command) return null;
+
+  const translated = {
+    type: "local",
+    command,
+  };
+  copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"]);
+
+  const environment = isObject(server.environment) ? server.environment : server.env;
+  if (isObject(environment)) translated.environment = stringifyRecord(environment);
+
+  return translated;
+}
+
+function normalizeCommand(command, args) {
+  if (Array.isArray(command) && command.every((item) => typeof item === "string")) {
+    return command;
+  }
+
+  if (typeof command !== "string") return null;
+
+  const result = [command];
+  if (Array.isArray(args)) {
+    for (const arg of args) {
+      if (typeof arg !== "string") return null;
+      result.push(arg);
+    }
+  }
+  return result;
+}
+
+function copyOptionalFields(source, target, keys) {
+  for (const key of keys) {
+    if (source[key] === undefined) continue;
+    target[key] = key === "headers" && isObject(source[key]) ? stringifyRecord(source[key]) : source[key];
+  }
+}
+
+async function appendSystemContext(pluginRoot, state, output) {
+  if (!Array.isArray(output.system)) output.system = [];
+
+  const pluginName = state.pluginJson.name ?? path.basename(pluginRoot);
+  const welcomeMessage = typeof state.infoJson.welcomeMessage === "string" ? state.infoJson.welcomeMessage : "";
+  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state);
+  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state);
+  const sessionStart = renderSessionStart(pluginRoot, xcodeMcpLikely);
+
+  let systemMessage = `The ${pluginName} plugin is loaded and ready.`;
+  if (xcodeMcpLikely) systemMessage += " Xcode MCP server detected.";
+  if (welcomeMessage) systemMessage += ` ${welcomeMessage}`;
+
+  output.system.push([systemMessage, sessionStart].filter(Boolean).join("\n\n"));
+}
+
+function renderSessionStart(pluginRoot, xcodeMcpLikely) {
+  const sessionStartPath = path.join(pluginRoot, "session-start.md");
+  const content = readTextFile(sessionStartPath);
+  if (!content) return "";
+  return processConditionalBlocks(content, xcodeMcpLikely);
+}
+
+function processConditionalBlocks(content, xcodeMcpLikely) {
+  if (xcodeMcpLikely) {
+    return content
+      .replace(/<!-- IF_XCODE_MCP -->\n?/g, "")
+      .replace(/<!-- END_XCODE_MCP -->\n?/g, "")
+      .replace(/<!-- IF_NO_XCODE_MCP -->[\s\S]*?<!-- END_NO_XCODE_MCP -->\n?/g, "");
+  }
+
+  return content
+    .replace(/<!-- IF_NO_XCODE_MCP -->\n?/g, "")
+    .replace(/<!-- END_NO_XCODE_MCP -->\n?/g, "")
+    .replace(/<!-- IF_XCODE_MCP -->[\s\S]*?<!-- END_XCODE_MCP -->\n?/g, "");
+}
+
+async function getXcodeMcpLikely(pluginName, state) {
+  if (pluginName !== "XcodeBuildTools") return false;
+
+  const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
+  if (!installed) {
+    state.xcodeMcpLikely = false;
+    return state.xcodeMcpLikely;
+  }
+
+  const xcodeRunning = await commandSucceeds("pgrep", ["-x", "Xcode"], 3000);
+  const bridgeRunning = await commandSucceeds("pgrep", ["-f", "mcpbridge"], 3000);
+  state.xcodeMcpLikely = xcodeRunning || bridgeRunning;
+  return state.xcodeMcpLikely;
+}
+
+function startXcodeMcpApproval(pluginRoot, state) {
+  if (state.xcodeMcpApprovalStarted) return;
+  state.xcodeMcpApprovalStarted = true;
+
+  const runner = path.join(pluginRoot, "hooks", "run-background.sh");
+  const target = path.join("hooks", "approve-xcode-mcp.sh");
+  if (!fs.existsSync(runner)) return;
+
+  try {
+    const child = spawn(runner, [target], {
+      cwd: pluginRoot,
+      detached: true,
+      env: {
+        ...process.env,
+        CLAUDE_HOOK_OWNER_PID: String(process.pid),
+        CLAUDE_PLUGIN_ROOT: pluginRoot,
+      },
+      stdio: "ignore",
+    });
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+    // Auto-approval is best-effort; users can still approve Xcode manually.
+  }
+}
+
+function commandSucceeds(command, args, timeoutMs) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const child = spawn(command, args, { stdio: "ignore" });
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish(false);
+    }, timeoutMs);
+
+    child.on("error", () => finish(false));
+    child.on("exit", (code) => finish(code === 0));
+
+    function finish(result) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    }
+  });
+}
+
+function applyPreToolUseRules(state, input, output) {
+  const tool = String(input.tool ?? "").toLowerCase();
+  if (tool !== "bash") return;
+
+  const command = output?.args?.command;
+  if (typeof command !== "string" || !command) return;
+
+  const rules = Array.isArray(state.infoJson["pre-tool-use-rules"])
+    ? state.infoJson["pre-tool-use-rules"]
+    : [];
+
+  for (const rule of rules) {
+    if (!isObject(rule)) continue;
+
+    const matchPattern = rule.match;
+    if (typeof matchPattern !== "string" || !regexMatches(matchPattern, command)) continue;
+
+    const notMatchPattern = rule.not_match;
+    if (typeof notMatchPattern === "string" && regexMatches(notMatchPattern, command)) continue;
+
+    const decision = rule.decision ?? "deny";
+    if (decision === "allow") return;
+
+    const message = typeof rule.message === "string" ? rule.message : "Command denied by plugin rule";
+    if (decision === "deny") throw new Error(message);
+
+    const ruleName = typeof rule.name === "string" && rule.name ? rule.name : matchPattern;
+    const key = `${input.sessionID ?? "global"}:${ruleName}`;
+    if (state.deniedOnce.has(key)) continue;
+
+    state.deniedOnce.add(key);
+    throw new Error(message);
+  }
+}
+
+function configureShellEnvironment(pluginRoot, state, input, output) {
+  if (!isObject(output.env)) output.env = {};
+
+  const binDir = path.join(pluginRoot, "bin");
+  if (fs.existsSync(binDir)) {
+    output.env.PATH = prependPath(binDir, output.env.PATH ?? process.env.PATH ?? "");
+  }
+
+  if (state.pluginJson.name !== "XcodeBuildTools") return;
+
+  const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
+  const sandboxBase = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox", sessionID);
+  const buildDir = path.join(sandboxBase, "build");
+  const packagesDir = path.join(sandboxBase, "packages");
+
+  fs.mkdirSync(buildDir, { recursive: true });
+  fs.mkdirSync(packagesDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(sandboxBase, "owner.pid"),
+    `${process.pid}\n${process.argv[0] ?? "opencode"}\n`,
+    "utf8",
+  );
+
+  output.env.SANDBOX_DERIVED_DATA = buildDir;
+  output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+function prependPath(entry, current) {
+  const parts = current.split(path.delimiter).filter(Boolean).filter((part) => part !== entry);
+  return [entry, ...parts].join(path.delimiter);
+}
+
+function safeSessionID(value) {
+  const raw = String(value ?? "");
+  if (SAFE_ID_RE.test(raw)) return raw;
+
+  const hash = createHash("sha256").update(raw || "default").digest("hex").slice(0, 16);
+  return `opencode-${hash}`;
+}
+
+function regexMatches(pattern, value) {
+  try {
+    return new RegExp(pattern).test(value);
+  } catch {
+    return false;
+  }
+}
+
+function hasSkillDirectories(skillsDir) {
+  try {
+    return fs.readdirSync(skillsDir, { withFileTypes: true }).some((entry) => {
+      return entry.isDirectory() && fs.existsSync(path.join(skillsDir, entry.name, "SKILL.md"));
+    });
+  } catch {
+    return false;
+  }
+}
+
+function readJsonFile(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function readTextFile(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function stringifyRecord(value) {
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, String(item)]));
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/XcodeBuildTools/common/opencode-plugin.js
+++ b/XcodeBuildTools/common/opencode-plugin.js
@@ -1,53 +1,71 @@
 // Generated from common/opencode-plugin.js by scripts/sync-plugin-common.py. Do not edit this copy; edit common/opencode-plugin.js and rerun scripts/sync-plugin-common.py.
 import { spawn } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const XCODE_MCP_CACHE_TTL_MS = 30_000;
+const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
 
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
-  const state = {
-    pluginJson: null,
-    infoJson: null,
-    deniedOnce: new Set(),
-    xcodeMcpLikely: undefined,
-    xcodeMcpApprovalStarted: false,
+  return async () => {
+    const state = {
+      pluginJson: null,
+      infoJson: null,
+      config: null,
+      instanceID: randomUUID(),
+      processStartToken: null,
+      deniedOnce: new Set(),
+      xcodeMcpCache: new Map(),
+      xcodeMcpApprovalSessions: new Set(),
+      ownedSandboxes: new Map(),
+      sandboxSweepDone: false,
+    };
+
+    return {
+      config: async (config) => {
+        loadMetadata(pluginRoot, state);
+        registerSkills(config, pluginRoot);
+        registerMcpServers(config, pluginRoot);
+        state.config = config;
+      },
+
+      "experimental.chat.system.transform": async (input, output) => {
+        try {
+          loadMetadata(pluginRoot, state);
+          await appendSystemContext(pluginRoot, state, input, output);
+        } catch {
+          // Fail open. Plugin context should never block a chat request.
+        }
+      },
+
+      "tool.execute.before": async (input, output) => {
+        loadMetadata(pluginRoot, state);
+        applyPreToolUseRules(state, input, output);
+      },
+
+      "shell.env": async (input, output) => {
+        try {
+          loadMetadata(pluginRoot, state);
+          await configureShellEnvironment(pluginRoot, state, input, output);
+        } catch {
+          // Fail open. Shell commands should still run if setup is unavailable.
+        }
+      },
+
+      event: async ({ event }) => {
+        await handlePluginEvent(state, event);
+      },
+
+      dispose: async () => {
+        await removeOwnedSandboxes(state);
+      },
+    };
   };
-
-  return async () => ({
-    config: async (config) => {
-      loadMetadata(pluginRoot, state);
-      registerSkills(config, pluginRoot);
-      registerMcpServers(config, pluginRoot);
-    },
-
-    "experimental.chat.system.transform": async (_input, output) => {
-      try {
-        loadMetadata(pluginRoot, state);
-        await appendSystemContext(pluginRoot, state, output);
-      } catch {
-        // Fail open. Plugin context should never block a chat request.
-      }
-    },
-
-    "tool.execute.before": async (input, output) => {
-      loadMetadata(pluginRoot, state);
-      applyPreToolUseRules(state, input, output);
-    },
-
-    "shell.env": async (input, output) => {
-      try {
-        loadMetadata(pluginRoot, state);
-        configureShellEnvironment(pluginRoot, state, input, output);
-      } catch {
-        // Fail open. Shell commands should still run if setup is unavailable.
-      }
-    },
-  });
 }
 
 function normalizePluginRoot(pluginRootUrl) {
@@ -144,13 +162,14 @@ function copyOptionalFields(source, target, keys) {
   }
 }
 
-async function appendSystemContext(pluginRoot, state, output) {
+async function appendSystemContext(pluginRoot, state, input, output) {
   if (!Array.isArray(output.system)) output.system = [];
 
   const pluginName = state.pluginJson.name ?? path.basename(pluginRoot);
   const welcomeMessage = typeof state.infoJson.welcomeMessage === "string" ? state.infoJson.welcomeMessage : "";
-  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state);
-  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state);
+  const sessionID = safeSessionID(input?.sessionID ?? "global");
+  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state, sessionID);
+  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state, sessionID);
   const sessionStart = renderSessionStart(pluginRoot, xcodeMcpLikely);
 
   let systemMessage = `The ${pluginName} plugin is loaded and ready.`;
@@ -181,31 +200,56 @@ function processConditionalBlocks(content, xcodeMcpLikely) {
     .replace(/<!-- IF_XCODE_MCP -->[\s\S]*?<!-- END_XCODE_MCP -->\n?/g, "");
 }
 
-async function getXcodeMcpLikely(pluginName, state) {
+async function getXcodeMcpLikely(pluginName, state, sessionID) {
   if (pluginName !== "XcodeBuildTools") return false;
-  if (state.xcodeMcpLikely !== undefined) return state.xcodeMcpLikely;
+  if (!hasConfiguredMcpbridge(state.config)) {
+    state.xcodeMcpCache.delete(sessionID);
+    return false;
+  }
+
+  const now = Date.now();
+  const cached = state.xcodeMcpCache.get(sessionID);
+  if (cached && now - cached.checkedAt < XCODE_MCP_CACHE_TTL_MS) return cached.value;
 
   const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
   if (!installed) {
-    state.xcodeMcpLikely = false;
-    return state.xcodeMcpLikely;
+    state.xcodeMcpCache.set(sessionID, { checkedAt: now, value: false });
+    return false;
   }
 
   const xcodeRunning = await commandSucceeds("pgrep", ["-x", "Xcode"], 3000);
   const bridgeRunning = await commandSucceeds("pgrep", ["-f", "mcpbridge"], 3000);
-  state.xcodeMcpLikely = xcodeRunning || bridgeRunning;
-  return state.xcodeMcpLikely;
+  const value = xcodeRunning || bridgeRunning;
+  state.xcodeMcpCache.set(sessionID, { checkedAt: now, value });
+  return value;
 }
 
-function startXcodeMcpApproval(pluginRoot, state) {
-  if (state.xcodeMcpApprovalStarted) return;
-  state.xcodeMcpApprovalStarted = true;
+function hasConfiguredMcpbridge(config) {
+  if (!isObject(config?.mcp)) return false;
+
+  return Object.values(config.mcp).some((server) => {
+    if (!isObject(server) || server.enabled === false || server.type !== "local") return false;
+
+    const command = Array.isArray(server.command) ? server.command : [server.command];
+    return command.some((part) => {
+      if (typeof part !== "string") return false;
+      return part
+        .trim()
+        .split(/\s+/)
+        .some((token) => path.basename(token.replace(/^['"]|['"]$/g, "")) === "mcpbridge");
+    });
+  });
+}
+
+function startXcodeMcpApproval(pluginRoot, state, sessionID) {
+  if (state.xcodeMcpApprovalSessions.has(sessionID)) return;
 
   const runner = path.join(pluginRoot, "hooks", "run-background.sh");
   const target = path.join("hooks", "approve-xcode-mcp.sh");
   if (!fs.existsSync(runner)) return;
 
   try {
+    state.xcodeMcpApprovalSessions.add(sessionID);
     const child = spawn(runner, [target], {
       cwd: pluginRoot,
       detached: true,
@@ -216,9 +260,10 @@ function startXcodeMcpApproval(pluginRoot, state) {
       },
       stdio: "ignore",
     });
-    child.on("error", () => {});
+    child.on("error", () => state.xcodeMcpApprovalSessions.delete(sessionID));
     child.unref();
   } catch {
+    state.xcodeMcpApprovalSessions.delete(sessionID);
     // Auto-approval is best-effort; users can still approve Xcode manually.
   }
 }
@@ -279,7 +324,7 @@ function applyPreToolUseRules(state, input, output) {
   }
 }
 
-function configureShellEnvironment(pluginRoot, state, input, output) {
+async function configureShellEnvironment(pluginRoot, state, input, output) {
   if (!isObject(output.env)) output.env = {};
 
   const binDir = path.join(pluginRoot, "bin");
@@ -290,7 +335,23 @@ function configureShellEnvironment(pluginRoot, state, input, output) {
   if (state.pluginJson.name !== "XcodeBuildTools") return;
 
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
-  const sandboxBase = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox", sessionID);
+  const sandboxRoot = path.join(os.tmpdir(), XCODE_SANDBOX_DIR);
+  // Plugin instances never reuse a sandbox path, so an older instance cannot
+  // delete a replacement instance's active sandbox after an ownership check.
+  const sandboxBase = path.join(sandboxRoot, `${sessionID}-${state.instanceID}`);
+  state.ownedSandboxes.set(sessionID, sandboxBase);
+
+  if (!state.processStartToken) {
+    state.processStartToken = await readProcessStartToken(process.pid);
+  }
+  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+
+  if (!state.sandboxSweepDone) {
+    await sweepStaleSandboxes(sandboxRoot);
+    state.sandboxSweepDone = true;
+  }
+  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+
   const buildDir = path.join(sandboxBase, "build");
   const packagesDir = path.join(sandboxBase, "packages");
 
@@ -298,12 +359,153 @@ function configureShellEnvironment(pluginRoot, state, input, output) {
   fs.mkdirSync(packagesDir, { recursive: true });
   fs.writeFileSync(
     path.join(sandboxBase, "owner.pid"),
-    `${process.pid}\n${process.argv[0] ?? "opencode"}\n`,
+    `${process.pid}\n${process.argv[0] ?? "opencode"}\n${state.processStartToken}\n${state.instanceID}\n`,
     "utf8",
   );
 
   output.env.SANDBOX_DERIVED_DATA = buildDir;
   output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+async function handlePluginEvent(state, event) {
+  if (event?.type !== "session.deleted") return;
+
+  const sessionID = event.properties?.info?.id;
+  if (typeof sessionID !== "string" || !sessionID) return;
+
+  const safeID = safeSessionID(sessionID);
+  state.xcodeMcpCache.delete(safeID);
+  state.xcodeMcpApprovalSessions.delete(safeID);
+  await removeOwnedSandbox(state, safeID);
+}
+
+async function removeOwnedSandbox(state, sessionID) {
+  const sandboxPath = state.ownedSandboxes.get(sessionID);
+  if (!sandboxPath) return;
+
+  state.ownedSandboxes.delete(sessionID);
+  await removeManagedSandbox(sandboxPath, state.instanceID);
+}
+
+async function removeOwnedSandboxes(state) {
+  const sandboxPaths = [...new Set(state.ownedSandboxes.values())];
+  state.ownedSandboxes.clear();
+  state.xcodeMcpCache.clear();
+  state.xcodeMcpApprovalSessions.clear();
+  await Promise.all(sandboxPaths.map((sandboxPath) => removeManagedSandbox(sandboxPath, state.instanceID)));
+}
+
+async function sweepStaleSandboxes(sandboxRoot) {
+  let entries;
+  try {
+    entries = await fs.promises.readdir(sandboxRoot, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.isDirectory() || !SAFE_ID_RE.test(entry.name)) return;
+
+      const sandboxPath = path.join(sandboxRoot, entry.name);
+      const owner = await readSandboxOwner(sandboxPath);
+      if (!owner || (await sandboxOwnerIsActive(owner))) return;
+
+      await removeManagedSandbox(sandboxPath);
+    }),
+  );
+}
+
+async function readSandboxOwner(sandboxPath) {
+  try {
+    const content = await fs.promises.readFile(path.join(sandboxPath, "owner.pid"), "utf8");
+    const lines = content.split(/\r?\n/);
+    const firstLine = lines[0];
+    if (!/^\d+$/.test(firstLine)) return null;
+
+    const pid = Number(firstLine);
+    if (!Number.isSafeInteger(pid) || pid <= 0) return null;
+
+    return {
+      pid,
+      processStartToken: lines[2] ?? "",
+      instanceID: lines[3] ?? "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+async function sandboxOwnerIsActive(owner) {
+  if (!processExists(owner.pid)) return false;
+  if (!owner.processStartToken) return true;
+
+  const currentStartToken = await readProcessStartToken(owner.pid);
+  if (!currentStartToken) return true;
+  return currentStartToken === owner.processStartToken;
+}
+
+function readProcessStartToken(pid) {
+  return new Promise((resolve) => {
+    let settled = false;
+    let stdout = "";
+    let child;
+
+    try {
+      child = spawn("ps", ["-p", String(pid), "-o", "lstart="], {
+        env: {
+          ...process.env,
+          LC_ALL: "C",
+          LANG: "C",
+          TZ: "UTC",
+        },
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+    } catch {
+      resolve("");
+      return;
+    }
+
+    child.stdout?.setEncoding?.("utf8");
+    child.stdout?.on?.("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.on("error", () => finish(""));
+    child.on("close", (code) => finish(code === 0 ? stdout.trim() : ""));
+
+    function finish(value) {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    }
+  });
+}
+
+async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
+  const sandboxRoot = path.resolve(os.tmpdir(), XCODE_SANDBOX_DIR);
+  const candidate = path.resolve(sandboxPath);
+  const relative = path.relative(sandboxRoot, candidate);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return;
+
+  if (expectedInstanceID) {
+    const owner = await readSandboxOwner(candidate);
+    if (!owner || owner.instanceID !== expectedInstanceID) return;
+  }
+
+  try {
+    await fs.promises.rm(candidate, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  } catch {
+    // Best-effort cleanup; the next plugin instance will retry through the stale-owner sweep.
+  }
 }
 
 function prependPath(entry, current) {

--- a/XcodeBuildTools/common/opencode-plugin.js
+++ b/XcodeBuildTools/common/opencode-plugin.js
@@ -7,8 +7,23 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const PROCESS_START_OUTPUT_MAX_CHARS = 256;
+const PROCESS_START_TIMEOUT_MS = 5_000;
 const XCODE_MCP_CACHE_TTL_MS = 30_000;
 const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
+const XCODE_SANDBOX_OWNER_GRACE_MS = 60_000;
+const XCODE_SANDBOX_OWNER_LOCK = ".owner.lock";
+const XCODE_SANDBOX_QUARANTINE_RE =
+  /^\.quarantine-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const XCODE_SANDBOX_PENDING_CLEANUPS_KEY = Symbol.for(
+  "opencode.xcodebuildtools.pending-cleanups",
+);
+const pendingSandboxCleanups =
+  globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] instanceof Set
+    ? globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY]
+    : new Set();
+globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] = pendingSandboxCleanups;
 
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
@@ -23,7 +38,9 @@ export function createOpenCodePlugin(pluginRootUrl) {
       xcodeMcpCache: new Map(),
       xcodeMcpApprovalSessions: new Set(),
       ownedSandboxes: new Map(),
+      deletedSandboxSessions: new Set(),
       sandboxSweepDone: false,
+      disposed: false,
     };
 
     return {
@@ -62,7 +79,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       },
 
       dispose: async () => {
-        await removeOwnedSandboxes(state);
+        await detachOwnedSandboxes(state);
       },
     };
   };
@@ -335,6 +352,7 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   if (state.pluginJson.name !== "XcodeBuildTools") return;
 
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
+  if (state.disposed || state.deletedSandboxSessions.has(sessionID)) return;
   const sandboxRoot = path.join(os.tmpdir(), XCODE_SANDBOX_DIR);
   // Plugin instances never reuse a sandbox path, so an older instance cannot
   // delete a replacement instance's active sandbox after an ownership check.
@@ -344,27 +362,201 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   if (!state.processStartToken) {
     state.processStartToken = await readProcessStartToken(process.pid);
   }
-  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+  if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
 
   if (!state.sandboxSweepDone) {
     await sweepStaleSandboxes(sandboxRoot);
     state.sandboxSweepDone = true;
   }
-  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+  if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
 
   const buildDir = path.join(sandboxBase, "build");
   const packagesDir = path.join(sandboxBase, "packages");
 
   fs.mkdirSync(buildDir, { recursive: true });
   fs.mkdirSync(packagesDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(sandboxBase, "owner.pid"),
-    `${process.pid}\n${process.argv[0] ?? "opencode"}\n${state.processStartToken}\n${state.instanceID}\n`,
-    "utf8",
-  );
+  writeSandboxOwner(sandboxBase, state.processStartToken, state.instanceID);
 
   output.env.SANDBOX_DERIVED_DATA = buildDir;
   output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+function sandboxSetupIsCancelled(state, sessionID, sandboxBase) {
+  return (
+    state.disposed ||
+    state.deletedSandboxSessions.has(sessionID) ||
+    state.ownedSandboxes.get(sessionID) !== sandboxBase
+  );
+}
+
+function writeSandboxOwner(sandboxBase, processStartToken, instanceID) {
+  const ownerPath = path.join(sandboxBase, "owner.pid");
+  const temporaryPath = path.join(sandboxBase, `owner.pid.${instanceID}.tmp`);
+  const content = `${process.pid}\n${process.argv[0] ?? "opencode"}\n${processStartToken}\n${instanceID}\n`;
+  const ownerLock = acquireSandboxOwnerLock(sandboxBase);
+  if (!ownerLock) throw new Error("Sandbox owner is being updated or removed");
+
+  try {
+    fs.writeFileSync(temporaryPath, content, "utf8");
+    if (!sandboxOwnerLockIsHeld(ownerLock)) {
+      throw new Error("Sandbox owner lock changed during update");
+    }
+    fs.renameSync(temporaryPath, ownerPath);
+  } catch (error) {
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch {
+      // The stale-sandbox sweep handles any temporary file left behind.
+    }
+    throw error;
+  } finally {
+    releaseSandboxOwnerLock(ownerLock);
+  }
+}
+
+function markSandboxCleanupPending(sandboxBase, instanceID, ownerLock) {
+  const ownerPath = path.join(sandboxBase, "owner.pid");
+  const temporaryPath = path.join(sandboxBase, `owner.pid.${instanceID}.cleanup.tmp`);
+  const content = `${process.pid}\ncleanup-pending\n\n${instanceID}\ncleanup-pending\n`;
+
+  try {
+    fs.writeFileSync(temporaryPath, content, "utf8");
+    if (!sandboxOwnerLockIsHeld(ownerLock)) return false;
+    fs.renameSync(temporaryPath, ownerPath);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch {
+      // A successful rename removes the temporary path.
+    }
+  }
+}
+
+function acquireSandboxOwnerLock(sandboxBase) {
+  const lockPath = path.join(sandboxBase, XCODE_SANDBOX_OWNER_LOCK);
+  const token = randomUUID();
+  const createdLock = createSandboxOwnerLock(lockPath, token);
+  if (createdLock) return createdLock;
+
+  const observedLock = readSandboxOwnerLock(lockPath);
+  if (!observedLock) return null;
+  if (Date.now() - observedLock.mtimeMs < XCODE_SANDBOX_OWNER_GRACE_MS) return null;
+
+  const claimedPath = `${lockPath}.${token}.stale`;
+  try {
+    fs.renameSync(lockPath, claimedPath);
+  } catch {
+    return null;
+  }
+
+  const claimedLock = readSandboxOwnerLock(claimedPath);
+  if (!sameSandboxOwnerLock(observedLock, claimedLock)) {
+    restoreClaimedSandboxOwnerLock(claimedPath, lockPath);
+    return null;
+  }
+
+  try {
+    fs.unlinkSync(claimedPath);
+  } catch {
+    restoreClaimedSandboxOwnerLock(claimedPath, lockPath);
+    return null;
+  }
+
+  return createSandboxOwnerLock(lockPath, token);
+}
+
+function createSandboxOwnerLock(lockPath, token) {
+  try {
+    fs.writeFileSync(lockPath, `${token}\n`, { encoding: "utf8", flag: "wx" });
+  } catch {
+    return null;
+  }
+
+  const ownerLock = readSandboxOwnerLock(lockPath);
+  if (!ownerLock || ownerLock.token !== token) return null;
+  return ownerLock;
+}
+
+function readSandboxOwnerLock(lockPath) {
+  try {
+    const before = fs.statSync(lockPath);
+    if (!before.isFile()) return null;
+    const beforeToken = fs.readFileSync(lockPath, "utf8").trim();
+    const after = fs.statSync(lockPath);
+    const afterToken = fs.readFileSync(lockPath, "utf8").trim();
+    if (!sameSandboxOwnerLockVersion(before, after) || beforeToken !== afterToken) return null;
+
+    return {
+      path: lockPath,
+      token: afterToken,
+      dev: after.dev,
+      ino: after.ino,
+      mtimeMs: after.mtimeMs,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function sameSandboxOwnerLockVersion(left, right) {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs &&
+    left.ctimeMs === right.ctimeMs
+  );
+}
+
+function sameSandboxOwnerLock(left, right) {
+  return Boolean(
+    left &&
+      right &&
+      left.dev === right.dev &&
+      left.ino === right.ino &&
+      left.token === right.token,
+  );
+}
+
+function sandboxOwnerLockIsHeld(ownerLock) {
+  return sameSandboxOwnerLock(ownerLock, readSandboxOwnerLock(ownerLock.path));
+}
+
+function restoreClaimedSandboxOwnerLock(claimedPath, lockPath) {
+  try {
+    // A hard link restores the claimed inode only when the lock path is still
+    // absent, without overwriting a lock another actor acquired meanwhile.
+    fs.linkSync(claimedPath, lockPath);
+    fs.unlinkSync(claimedPath);
+  } catch {
+    // Leave the uniquely named claim in place if ownership cannot be restored.
+  }
+}
+
+function releaseSandboxOwnerLock(ownerLock) {
+  if (!sandboxOwnerLockIsHeld(ownerLock)) return;
+
+  const claimedPath = `${ownerLock.path}.${randomUUID()}.release`;
+  try {
+    fs.renameSync(ownerLock.path, claimedPath);
+  } catch {
+    return;
+  }
+
+  const claimedLock = readSandboxOwnerLock(claimedPath);
+  if (!sameSandboxOwnerLock(ownerLock, claimedLock)) {
+    restoreClaimedSandboxOwnerLock(claimedPath, ownerLock.path);
+    return;
+  }
+
+  try {
+    fs.unlinkSync(claimedPath);
+  } catch {
+    // The sandbox may already have been removed with the lock inside it.
+  }
 }
 
 async function handlePluginEvent(state, event) {
@@ -374,6 +566,7 @@ async function handlePluginEvent(state, event) {
   if (typeof sessionID !== "string" || !sessionID) return;
 
   const safeID = safeSessionID(sessionID);
+  state.deletedSandboxSessions.add(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
   await removeOwnedSandbox(state, safeID);
@@ -383,16 +576,36 @@ async function removeOwnedSandbox(state, sessionID) {
   const sandboxPath = state.ownedSandboxes.get(sessionID);
   if (!sandboxPath) return;
 
+  markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.delete(sessionID);
-  await removeManagedSandbox(sandboxPath, state.instanceID);
+  const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+  await removeManagedSandbox(
+    quarantinedPath || sandboxPath,
+    quarantinedPath ? "" : state.instanceID,
+  );
 }
 
-async function removeOwnedSandboxes(state) {
+async function detachOwnedSandboxes(state) {
+  state.disposed = true;
   const sandboxPaths = [...new Set(state.ownedSandboxes.values())];
+  for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
-  await Promise.all(sandboxPaths.map((sandboxPath) => removeManagedSandbox(sandboxPath, state.instanceID)));
+  const cleanupTargets = await Promise.all(
+    sandboxPaths.map(async (sandboxPath) => {
+      const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+      return {
+        path: quarantinedPath || sandboxPath,
+        expectedInstanceID: quarantinedPath ? "" : state.instanceID,
+      };
+    }),
+  );
+  await Promise.all(
+    cleanupTargets.map(({ path: sandboxPath, expectedInstanceID }) =>
+      detachManagedSandbox(sandboxPath, expectedInstanceID),
+    ),
+  );
 }
 
 async function sweepStaleSandboxes(sandboxRoot) {
@@ -405,11 +618,43 @@ async function sweepStaleSandboxes(sandboxRoot) {
 
   await Promise.all(
     entries.map(async (entry) => {
-      if (!entry.isDirectory() || !SAFE_ID_RE.test(entry.name)) return;
+      const isQuarantine = XCODE_SANDBOX_QUARANTINE_RE.test(entry.name);
+      if (!entry.isDirectory() || (!SAFE_ID_RE.test(entry.name) && !isQuarantine)) return;
 
       const sandboxPath = path.join(sandboxRoot, entry.name);
       const owner = await readSandboxOwner(sandboxPath);
-      if (!owner || (await sandboxOwnerIsActive(owner))) return;
+      const cleanupPending = owner?.cleanupPending || sandboxCleanupIsPending(sandboxPath);
+      if (!owner || cleanupPending) {
+        if (!cleanupPending && !isQuarantine && !(await sandboxIsPastOwnerGracePeriod(sandboxPath))) {
+          return;
+        }
+
+        const ownerLock = acquireSandboxOwnerLock(sandboxPath);
+        if (!ownerLock) return;
+        let releaseLock = ownerLock;
+        try {
+          // A writer may have published an owner after the initial read or
+          // stale-stat snapshot. Only remove while the publication lock is
+          // held and the marker is still invalid.
+          const currentOwner = await readSandboxOwner(sandboxPath);
+          const currentCleanupPending =
+            currentOwner?.cleanupPending || sandboxCleanupIsPending(sandboxPath);
+          if (
+            (!currentOwner || currentCleanupPending) &&
+            sandboxOwnerLockIsHeld(ownerLock)
+          ) {
+            const quarantined = await quarantineManagedSandbox(sandboxPath, ownerLock);
+            releaseLock = quarantined.ownerLock;
+            if (quarantined.path) {
+              await removeManagedSandbox(quarantined.path);
+            }
+          }
+        } finally {
+          releaseSandboxOwnerLock(releaseLock);
+        }
+        return;
+      }
+      if (await sandboxOwnerIsActive(owner)) return;
 
       await removeManagedSandbox(sandboxPath);
     }),
@@ -426,13 +671,26 @@ async function readSandboxOwner(sandboxPath) {
     const pid = Number(firstLine);
     if (!Number.isSafeInteger(pid) || pid <= 0) return null;
 
+    const instanceID = lines[3] ?? "";
+    if (!UUID_V4_RE.test(instanceID)) return null;
+
     return {
       pid,
       processStartToken: lines[2] ?? "",
-      instanceID: lines[3] ?? "",
+      instanceID,
+      cleanupPending: lines[4] === "cleanup-pending",
     };
   } catch {
     return null;
+  }
+}
+
+async function sandboxIsPastOwnerGracePeriod(sandboxPath) {
+  try {
+    const stat = await fs.promises.stat(sandboxPath);
+    return Date.now() - stat.mtimeMs >= XCODE_SANDBOX_OWNER_GRACE_MS;
+  } catch {
+    return false;
   }
 }
 
@@ -459,9 +717,10 @@ function readProcessStartToken(pid) {
     let settled = false;
     let stdout = "";
     let child;
+    let timer;
 
     try {
-      child = spawn("ps", ["-p", String(pid), "-o", "lstart="], {
+      child = spawn("/bin/ps", ["-p", String(pid), "-o", "lstart="], {
         env: {
           ...process.env,
           LC_ALL: "C",
@@ -477,24 +736,156 @@ function readProcessStartToken(pid) {
 
     child.stdout?.setEncoding?.("utf8");
     child.stdout?.on?.("data", (chunk) => {
-      stdout += chunk;
+      const remaining = PROCESS_START_OUTPUT_MAX_CHARS - stdout.length;
+      if (remaining > 0) stdout += String(chunk).slice(0, remaining);
     });
     child.on("error", () => finish(""));
-    child.on("close", (code) => finish(code === 0 ? stdout.trim() : ""));
+    child.on("close", (code) => {
+      const firstLine = stdout.trim().split(/\r?\n/, 1)[0] ?? "";
+      finish(code === 0 ? firstLine : "");
+    });
+    timer = setTimeout(() => {
+      try {
+        child.kill?.("SIGTERM");
+      } catch {
+        // Resolving the hook is more important than terminating a broken ps shim.
+      }
+      finish("");
+    }, PROCESS_START_TIMEOUT_MS);
 
     function finish(value) {
       if (settled) return;
       settled = true;
+      clearTimeout(timer);
       resolve(value);
     }
   });
 }
 
 async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
-  const sandboxRoot = path.resolve(os.tmpdir(), XCODE_SANDBOX_DIR);
-  const candidate = path.resolve(sandboxPath);
-  const relative = path.relative(sandboxRoot, candidate);
-  if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return;
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate) return false;
+
+  if (expectedInstanceID) {
+    const owner = await readSandboxOwner(candidate);
+    if (!owner || owner.instanceID !== expectedInstanceID) return false;
+  }
+
+  try {
+    await fs.promises.rm(candidate, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    clearPendingSandboxCleanup(candidate);
+    return true;
+  } catch {
+    // Best-effort cleanup; the next plugin instance will retry through the stale-owner sweep.
+    return false;
+  }
+}
+
+async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate) return "";
+
+  const ownerLock = acquireSandboxOwnerLock(candidate);
+  if (!ownerLock) return "";
+  let releaseLock = ownerLock;
+
+  try {
+    const currentOwner = await readSandboxOwner(candidate);
+    if (!currentOwner || currentOwner.instanceID !== expectedInstanceID) return "";
+    if (!markSandboxCleanupPending(candidate, expectedInstanceID, ownerLock)) return "";
+
+    const quarantinePath = path.join(path.dirname(candidate), `.quarantine-${randomUUID()}`);
+    if (!managedSandboxCandidate(quarantinePath)) return "";
+
+    try {
+      fs.renameSync(candidate, quarantinePath);
+      movePendingSandboxCleanup(candidate, quarantinePath);
+    } catch {
+      return "";
+    }
+
+    releaseLock = {
+      ...ownerLock,
+      path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+    };
+    const relocatedOwner = await readSandboxOwner(quarantinePath);
+    if (
+      !sandboxOwnerLockIsHeld(releaseLock) ||
+      !relocatedOwner ||
+      relocatedOwner.instanceID !== expectedInstanceID ||
+      !relocatedOwner.cleanupPending
+    ) {
+      if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+        movePendingSandboxCleanup(quarantinePath, candidate);
+        releaseLock = { ...releaseLock, path: ownerLock.path };
+      }
+      return "";
+    }
+
+    const ownerPath = path.join(quarantinePath, "owner.pid");
+    const retiredOwnerPath = path.join(quarantinePath, `owner.pid.retired-${randomUUID()}`);
+    try {
+      fs.renameSync(ownerPath, retiredOwnerPath);
+    } catch (error) {
+      if (error?.code !== "ENOENT") return quarantinePath;
+    }
+
+    return quarantinePath;
+  } finally {
+    releaseSandboxOwnerLock(releaseLock);
+  }
+}
+
+async function quarantineManagedSandbox(sandboxPath, ownerLock) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate || !sandboxOwnerLockIsHeld(ownerLock)) {
+    return { path: "", ownerLock };
+  }
+
+  const quarantinePath = path.join(path.dirname(candidate), `.quarantine-${randomUUID()}`);
+  if (!managedSandboxCandidate(quarantinePath)) return { path: "", ownerLock };
+
+  try {
+    fs.renameSync(candidate, quarantinePath);
+    movePendingSandboxCleanup(candidate, quarantinePath);
+  } catch {
+    return { path: "", ownerLock };
+  }
+
+  const relocatedLock = {
+    ...ownerLock,
+    path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+  };
+  const publishedOwner = await readSandboxOwner(quarantinePath);
+  const cleanupPending =
+    publishedOwner?.cleanupPending || sandboxCleanupIsPending(quarantinePath);
+  if (
+    !sandboxOwnerLockIsHeld(relocatedLock) ||
+    (publishedOwner && !cleanupPending)
+  ) {
+    if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+      movePendingSandboxCleanup(quarantinePath, candidate);
+      return { path: "", ownerLock };
+    }
+    // Preserve the quarantine when the original path has already been reused.
+    return { path: "", ownerLock: relocatedLock };
+  }
+
+  return { path: quarantinePath, ownerLock: relocatedLock };
+}
+
+function restoreQuarantinedSandbox(quarantinePath, originalPath) {
+  try {
+    fs.renameSync(quarantinePath, originalPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function detachManagedSandbox(sandboxPath, expectedInstanceID = "") {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate) return;
 
   if (expectedInstanceID) {
     const owner = await readSandboxOwner(candidate);
@@ -502,10 +893,48 @@ async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
   }
 
   try {
-    await fs.promises.rm(candidate, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    const child = spawn("/bin/rm", ["-rf", candidate], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.on("error", () => {});
+    child.on("exit", (code) => {
+      if (code === 0) clearPendingSandboxCleanup(candidate);
+    });
+    child.unref();
   } catch {
     // Best-effort cleanup; the next plugin instance will retry through the stale-owner sweep.
   }
+}
+
+function managedSandboxCandidate(sandboxPath) {
+  const sandboxRoot = path.resolve(os.tmpdir(), XCODE_SANDBOX_DIR);
+  const candidate = path.resolve(sandboxPath);
+  const relative = path.relative(sandboxRoot, candidate);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return "";
+  return candidate;
+}
+
+function markPendingSandboxCleanup(sandboxPath) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (candidate) pendingSandboxCleanups.add(candidate);
+}
+
+function clearPendingSandboxCleanup(sandboxPath) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (candidate) pendingSandboxCleanups.delete(candidate);
+}
+
+function movePendingSandboxCleanup(sourcePath, destinationPath) {
+  const source = managedSandboxCandidate(sourcePath);
+  const destination = managedSandboxCandidate(destinationPath);
+  if (!source || !destination || !pendingSandboxCleanups.delete(source)) return;
+  pendingSandboxCleanups.add(destination);
+}
+
+function sandboxCleanupIsPending(sandboxPath) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  return Boolean(candidate && pendingSandboxCleanups.has(candidate));
 }
 
 function prependPath(entry, current) {

--- a/XcodeBuildTools/common/opencode-plugin.js
+++ b/XcodeBuildTools/common/opencode-plugin.js
@@ -7,6 +7,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const MCP_PLACEHOLDER_RE = /\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}/g;
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const PROCESS_START_OUTPUT_MAX_CHARS = 256;
 const PROCESS_START_TIMEOUT_MS = 5_000;
@@ -27,7 +28,11 @@ globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] = pendingSandboxCleanups;
 
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
-  return async () => {
+  return async (input = {}) => {
+    const mcpContext = {
+      pluginRoot,
+      projectDir: input?.worktree || input?.directory,
+    };
     const state = {
       pluginJson: null,
       infoJson: null,
@@ -47,7 +52,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       config: async (config) => {
         loadMetadata(pluginRoot, state);
         registerSkills(config, pluginRoot);
-        registerMcpServers(config, pluginRoot);
+        registerMcpServers(config, pluginRoot, mcpContext);
         state.config = config;
       },
 
@@ -115,7 +120,7 @@ function registerSkills(config, pluginRoot) {
   if (!config.skills.paths.includes(skillsDir)) config.skills.paths.push(skillsDir);
 }
 
-function registerMcpServers(config, pluginRoot) {
+function registerMcpServers(config, pluginRoot, context) {
   const mcpConfig = readJsonFile(path.join(pluginRoot, ".mcp.json"));
   const servers = mcpConfig?.mcpServers;
   if (!isObject(servers)) return;
@@ -125,58 +130,117 @@ function registerMcpServers(config, pluginRoot) {
   for (const [name, server] of Object.entries(servers)) {
     if (!isObject(server) || config.mcp[name]) continue;
 
-    const translated = translateMcpServer(server);
+    const translated = translateMcpServer(server, context);
     if (translated) config.mcp[name] = translated;
   }
 }
 
-function translateMcpServer(server) {
+function translateMcpServer(server, context) {
   if (typeof server.url === "string") {
     const translated = {
       type: "remote",
-      url: server.url,
+      url: expandMcpString(server.url, context),
     };
-    copyOptionalFields(server, translated, ["enabled", "headers", "timeout"]);
+    copyOptionalFields(server, translated, ["enabled", "headers", "timeout"], context);
+    const oauth = translateMcpOAuth(server.oauth);
+    if (oauth !== undefined) translated.oauth = oauth;
     return translated;
   }
 
-  const command = normalizeCommand(server.command, server.args);
+  const command = normalizeCommand(server.command, server.args, context);
   if (!command) return null;
 
   const translated = {
     type: "local",
     command,
   };
-  copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"]);
+  copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"], context);
 
   const environment = isObject(server.environment) ? server.environment : server.env;
-  if (isObject(environment)) translated.environment = stringifyRecord(environment);
+  if (isObject(environment)) translated.environment = expandMcpRecord(environment, context);
 
   return translated;
 }
 
-function normalizeCommand(command, args) {
+function translateMcpOAuth(oauth) {
+  if (oauth === false) return false;
+  if (!isObject(oauth)) return undefined;
+
+  const translated = {};
+  for (const key of ["clientId", "clientSecret", "redirectUri"]) {
+    if (typeof oauth[key] === "string") translated[key] = oauth[key];
+  }
+
+  if (
+    Number.isInteger(oauth.callbackPort) &&
+    oauth.callbackPort >= 1 &&
+    oauth.callbackPort <= 65_535
+  ) {
+    translated.callbackPort = oauth.callbackPort;
+  }
+
+  if (typeof oauth.scopes === "string") {
+    translated.scope = oauth.scopes;
+  } else if (typeof oauth.scope === "string") {
+    translated.scope = oauth.scope;
+  }
+
+  return translated;
+}
+
+function normalizeCommand(command, args, context) {
   if (Array.isArray(command) && command.every((item) => typeof item === "string")) {
-    return command;
+    return command.map((item) => expandMcpString(item, context));
   }
 
   if (typeof command !== "string") return null;
 
-  const result = [command];
   if (Array.isArray(args)) {
-    for (const arg of args) {
-      if (typeof arg !== "string") return null;
-      result.push(arg);
-    }
+    if (!args.every((arg) => typeof arg === "string")) return null;
+    return [command, ...args].map((item) => expandMcpString(item, context));
   }
-  return result;
+  return [expandMcpString(command, context)];
 }
 
-function copyOptionalFields(source, target, keys) {
+function copyOptionalFields(source, target, keys, context) {
   for (const key of keys) {
     if (source[key] === undefined) continue;
-    target[key] = key === "headers" && isObject(source[key]) ? stringifyRecord(source[key]) : source[key];
+    if (key === "headers" && isObject(source[key])) {
+      target[key] = expandMcpRecord(source[key], context);
+    } else if (key === "cwd" && typeof source[key] === "string") {
+      target[key] = expandMcpString(source[key], context);
+    } else {
+      target[key] = source[key];
+    }
   }
+}
+
+function expandMcpRecord(value, context) {
+  return Object.fromEntries(
+    Object.entries(stringifyRecord(value)).map(([key, item]) => [
+      key,
+      expandMcpString(item, context),
+    ]),
+  );
+}
+
+function expandMcpString(value, context) {
+  return value.replace(MCP_PLACEHOLDER_RE, (_, name, defaultValue) => {
+    const resolved = mcpVariable(name, context);
+    if (defaultValue !== undefined && (resolved === undefined || resolved === "")) {
+      return defaultValue;
+    }
+    if (resolved === undefined) {
+      throw new Error(`MCP configuration references unset variable: ${name}`);
+    }
+    return resolved;
+  });
+}
+
+function mcpVariable(name, context) {
+  if (name === "CLAUDE_PLUGIN_ROOT") return context.pluginRoot;
+  if (name === "CLAUDE_PROJECT_DIR") return context.projectDir;
+  return process.env[name];
 }
 
 async function appendSystemContext(pluginRoot, state, input, output) {

--- a/XcodeBuildTools/common/opencode-plugin.js
+++ b/XcodeBuildTools/common/opencode-plugin.js
@@ -29,13 +29,10 @@ globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] = pendingSandboxCleanups;
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
   return async (input = {}) => {
-    const mcpContext = {
-      pluginRoot,
-      projectDir: input?.worktree || input?.directory,
-    };
     const state = {
       pluginJson: null,
       infoJson: null,
+      pluginData: null,
       config: null,
       instanceID: randomUUID(),
       processStartToken: null,
@@ -46,6 +43,11 @@ export function createOpenCodePlugin(pluginRootUrl) {
       deletedSandboxSessions: new Set(),
       sandboxSweepDone: false,
       disposed: false,
+    };
+    const mcpContext = {
+      pluginRoot,
+      pluginData: () => pluginDataDirectory(pluginRoot, state),
+      projectDir: input?.worktree || input?.directory,
     };
 
     return {
@@ -111,6 +113,19 @@ function loadMetadata(pluginRoot, state) {
   }
 }
 
+function pluginDataDirectory(pluginRoot, state) {
+  if (state.pluginData) return state.pluginData;
+
+  loadMetadata(pluginRoot, state);
+  const pluginName = state.pluginJson.name || path.basename(pluginRoot) || "plugin";
+  const pluginID = String(pluginName).replace(/[^A-Za-z0-9_-]/g, "-");
+  const dataHome = process.env.XDG_DATA_HOME || path.join(os.homedir(), ".local", "share");
+  const pluginData = path.resolve(dataHome, "opencode", "plugin-data", pluginID);
+  fs.mkdirSync(pluginData, { recursive: true });
+  state.pluginData = pluginData;
+  return pluginData;
+}
+
 function registerSkills(config, pluginRoot) {
   const skillsDir = path.join(pluginRoot, "skills");
   if (!hasSkillDirectories(skillsDir)) return;
@@ -157,7 +172,17 @@ function translateMcpServer(server, context) {
   copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"], context);
 
   const environment = isObject(server.environment) ? server.environment : server.env;
-  if (isObject(environment)) translated.environment = expandMcpRecord(environment, context);
+  translated.environment = {
+    ...(isObject(environment) ? expandMcpRecord(environment, context) : {}),
+    ...expandMcpRecord(
+      {
+        CLAUDE_PLUGIN_ROOT: "${CLAUDE_PLUGIN_ROOT}",
+        CLAUDE_PLUGIN_DATA: "${CLAUDE_PLUGIN_DATA}",
+        CLAUDE_PROJECT_DIR: "${CLAUDE_PROJECT_DIR}",
+      },
+      context,
+    ),
+  };
 
   return translated;
 }
@@ -239,6 +264,7 @@ function expandMcpString(value, context) {
 
 function mcpVariable(name, context) {
   if (name === "CLAUDE_PLUGIN_ROOT") return context.pluginRoot;
+  if (name === "CLAUDE_PLUGIN_DATA") return context.pluginData();
   if (name === "CLAUDE_PROJECT_DIR") return context.projectDir;
   return process.env[name];
 }

--- a/XcodeBuildTools/common/opencode-plugin.js
+++ b/XcodeBuildTools/common/opencode-plugin.js
@@ -8,11 +8,47 @@ import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
 const MCP_PLACEHOLDER_RE = /\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}/g;
+const MCP_COMPATIBILITY_ENVIRONMENT_KEYS = new Set([
+  "CLAUDE_PLUGIN_ROOT",
+  "CLAUDE_PLUGIN_DATA",
+  "CLAUDE_PROJECT_DIR",
+]);
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const PROCESS_START_OUTPUT_MAX_CHARS = 256;
 const PROCESS_START_TIMEOUT_MS = 5_000;
+const PROCESS_TERMINATION_GRACE_MS = 250;
 const XCODE_MCP_CACHE_TTL_MS = 30_000;
+const XCRUN_OPTIONS_WITH_VALUE = new Set([
+  "--sdk",
+  "-sdk",
+  "--toolchain",
+  "-toolchain",
+]);
+const XCRUN_OPTIONS_WITHOUT_VALUE = new Set([
+  "-h",
+  "--help",
+  "--version",
+  "-v",
+  "--verbose",
+  "-l",
+  "--log",
+  "-f",
+  "--find",
+  "-r",
+  "--run",
+  "-n",
+  "--no-cache",
+  "-k",
+  "--kill-cache",
+  "--show-sdk-path",
+  "--show-sdk-version",
+  "--show-sdk-build-version",
+  "--show-sdk-platform-path",
+  "--show-sdk-platform-version",
+  "--show-toolchain-path",
+]);
 const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
+const XCODE_SANDBOX_MODE = 0o700;
 const XCODE_SANDBOX_OWNER_GRACE_MS = 60_000;
 const XCODE_SANDBOX_OWNER_LOCK = ".owner.lock";
 const XCODE_SANDBOX_QUARANTINE_RE =
@@ -39,7 +75,9 @@ export function createOpenCodePlugin(pluginRootUrl) {
       deniedOnce: new Set(),
       xcodeMcpCache: new Map(),
       xcodeMcpApprovalSessions: new Set(),
+      sandboxRoot: null,
       ownedSandboxes: new Map(),
+      ownedSandboxIdentities: new Map(),
       deletedSandboxSessions: new Set(),
       sandboxSweepDone: false,
       disposed: false,
@@ -146,8 +184,45 @@ function registerMcpServers(config, pluginRoot, context) {
     if (!isObject(server) || config.mcp[name]) continue;
 
     const translated = translateMcpServer(server, context);
-    if (translated) config.mcp[name] = translated;
+    if (translated && !hasMcpEndpoint(config.mcp, translated)) {
+      config.mcp[name] = translated;
+    }
   }
+}
+
+function hasMcpEndpoint(servers, candidate) {
+  return Object.values(servers).some((server) => {
+    if (!isObject(server) || server.type !== candidate.type) return false;
+    if (candidate.type === "remote") return server.url === candidate.url;
+    if (candidate.type !== "local") return false;
+    if (!Array.isArray(server.command) || !Array.isArray(candidate.command)) return false;
+    return (
+      server.command.length === candidate.command.length &&
+      server.command.every((item, index) => item === candidate.command[index]) &&
+      server.cwd === candidate.cwd &&
+      mcpEnvironmentMatches(server.environment, candidate.environment)
+    );
+  });
+}
+
+function mcpEnvironmentMatches(left, right) {
+  const leftEntries = comparableMcpEnvironment(left);
+  const rightEntries = comparableMcpEnvironment(right);
+  if (!leftEntries || !rightEntries || leftEntries.length !== rightEntries.length) {
+    return false;
+  }
+  return leftEntries.every(([key, value], index) => {
+    const [rightKey, rightValue] = rightEntries[index];
+    return key === rightKey && value === rightValue;
+  });
+}
+
+function comparableMcpEnvironment(environment) {
+  if (environment === undefined) return [];
+  if (!isObject(environment)) return null;
+  return Object.entries(environment)
+    .filter(([key]) => !MCP_COMPATIBILITY_ENVIRONMENT_KEYS.has(key))
+    .sort(([left], [right]) => left.localeCompare(right));
 }
 
 function translateMcpServer(server, context) {
@@ -338,14 +413,40 @@ function hasConfiguredMcpbridge(config) {
     if (!isObject(server) || server.enabled === false || server.type !== "local") return false;
 
     const command = Array.isArray(server.command) ? server.command : [server.command];
-    return command.some((part) => {
-      if (typeof part !== "string") return false;
-      return part
-        .trim()
-        .split(/\s+/)
-        .some((token) => path.basename(token.replace(/^['"]|['"]$/g, "")) === "mcpbridge");
-    });
+    const executable = commandBasename(command[0]);
+    if (executable === "mcpbridge") return true;
+    if (executable !== "xcrun") return false;
+    return xcrunToolBasename(command.slice(1)) === "mcpbridge";
   });
+}
+
+function commandBasename(value) {
+  const commandPart = normalizedCommandPart(value);
+  return commandPart ? path.basename(commandPart) : "";
+}
+
+function normalizedCommandPart(value) {
+  if (typeof value !== "string") return "";
+  return value.trim().replace(/^['"]|['"]$/g, "");
+}
+
+function xcrunToolBasename(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = normalizedCommandPart(args[index]);
+    if (!argument) return "";
+    if (argument === "--") {
+      return commandBasename(args[index + 1]);
+    }
+    if (XCRUN_OPTIONS_WITH_VALUE.has(argument)) {
+      index += 1;
+      continue;
+    }
+    if (/^(?:--?sdk|--?toolchain)=/.test(argument)) continue;
+    if (XCRUN_OPTIONS_WITHOUT_VALUE.has(argument)) continue;
+    if (argument.startsWith("-")) return "";
+    return path.basename(argument);
+  }
+  return "";
 }
 
 function startXcodeMcpApproval(pluginRoot, state, sessionID) {
@@ -378,22 +479,74 @@ function startXcodeMcpApproval(pluginRoot, state, sessionID) {
 function commandSucceeds(command, args, timeoutMs) {
   return new Promise((resolve) => {
     let settled = false;
-    const child = spawn(command, args, { stdio: "ignore" });
-    const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      finish(false);
-    }, timeoutMs);
+    let timedOut = false;
+    let timeoutTimer;
+    let forceKillTimer;
+    let child;
 
-    child.on("error", () => finish(false));
-    child.on("exit", (code) => finish(code === 0));
+    try {
+      child = spawn(command, args, { stdio: "ignore" });
+    } catch {
+      resolve(false);
+      return;
+    }
+
+    const onError = () => finish(false);
+    const onExit = (code) => finish(!timedOut && code === 0);
+    child.on("error", onError);
+    child.on("exit", onExit);
+    timeoutTimer = setTimeout(beginTermination, timeoutMs);
+
+    function beginTermination() {
+      if (settled) return;
+      timedOut = true;
+      forceKillTimer = terminateChildAfterGrace(
+        child,
+        () => !settled,
+        () => finish(false),
+      );
+    }
 
     function finish(result) {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      clearTimeout(timeoutTimer);
+      clearTimeout(forceKillTimer);
+      child.removeListener?.("error", onError);
+      child.removeListener?.("exit", onExit);
       resolve(result);
     }
   });
+}
+
+function terminateChildAfterGrace(child, isPending, onForcedTermination) {
+  try {
+    child.kill("SIGTERM");
+  } catch {
+    // Continue to forced termination so the timed-out child is detached.
+  }
+  if (!isPending()) return undefined;
+
+  return setTimeout(() => {
+    if (!isPending()) return;
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // The process may have exited between the grace timer and this call.
+    }
+    try {
+      child.stdout?.destroy?.();
+      child.stderr?.destroy?.();
+    } catch {
+      // Detaching the child still allows the parent to continue.
+    }
+    try {
+      child.unref();
+    } catch {
+      // Resolving the caller is more important than detaching a broken shim.
+    }
+    onForcedTermination();
+  }, PROCESS_TERMINATION_GRACE_MS);
 }
 
 function applyPreToolUseRules(state, input, output) {
@@ -443,10 +596,10 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
 
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
   if (state.disposed || state.deletedSandboxSessions.has(sessionID)) return;
-  const sandboxRoot = path.join(os.tmpdir(), XCODE_SANDBOX_DIR);
+  const sandboxRoot = secureSandboxRoot(state);
   // Plugin instances never reuse a sandbox path, so an older instance cannot
   // delete a replacement instance's active sandbox after an ownership check.
-  const sandboxBase = path.join(sandboxRoot, `${sessionID}-${state.instanceID}`);
+  const sandboxBase = path.join(sandboxRoot.path, `${sessionID}-${state.instanceID}`);
   state.ownedSandboxes.set(sessionID, sandboxBase);
 
   if (!state.processStartToken) {
@@ -463,12 +616,146 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   const buildDir = path.join(sandboxBase, "build");
   const packagesDir = path.join(sandboxBase, "packages");
 
-  fs.mkdirSync(buildDir, { recursive: true });
-  fs.mkdirSync(packagesDir, { recursive: true });
-  writeSandboxOwner(sandboxBase, state.processStartToken, state.instanceID);
+  const sandboxIdentity = secureSandboxDirectory(sandboxBase, sandboxRoot);
+  state.ownedSandboxIdentities.set(sessionID, sandboxIdentity);
+  if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
+  secureSandboxDirectory(buildDir, sandboxIdentity);
+  secureSandboxDirectory(packagesDir, sandboxIdentity);
+  writeSandboxOwner(
+    sandboxIdentity,
+    state.processStartToken,
+    state.instanceID,
+  );
 
   output.env.SANDBOX_DERIVED_DATA = buildDir;
   output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+function secureSandboxRoot(state) {
+  if (state.sandboxRoot) {
+    revalidateSandboxDirectory(state.sandboxRoot);
+    return state.sandboxRoot;
+  }
+
+  const temporaryDirectory = path.resolve(os.tmpdir());
+  const canonicalTemporaryDirectory = canonicalPath(temporaryDirectory);
+  const sandboxRoot = path.join(temporaryDirectory, XCODE_SANDBOX_DIR);
+  const expectedCanonicalPath = path.join(
+    canonicalTemporaryDirectory,
+    XCODE_SANDBOX_DIR,
+  );
+
+  createDirectoryNonRecursively(sandboxRoot);
+  const identity = inspectSandboxDirectory(
+    sandboxRoot,
+    expectedCanonicalPath,
+    null,
+  );
+  state.sandboxRoot = identity;
+  return identity;
+}
+
+function secureSandboxDirectory(directoryPath, parentIdentity) {
+  revalidateSandboxDirectory(parentIdentity);
+
+  const candidate = path.resolve(directoryPath);
+  const parentPath = path.resolve(parentIdentity.path);
+  if (path.dirname(candidate) !== parentPath) {
+    throw new Error("Sandbox directory must be a direct child of its trusted parent");
+  }
+
+  const name = path.basename(candidate);
+  if (!SAFE_ID_RE.test(name)) {
+    throw new Error("Sandbox directory has an unsafe name");
+  }
+
+  createDirectoryNonRecursively(candidate);
+  return inspectSandboxDirectory(
+    candidate,
+    path.join(parentIdentity.canonicalPath, name),
+    parentIdentity,
+  );
+}
+
+function createDirectoryNonRecursively(directoryPath) {
+  try {
+    fs.mkdirSync(directoryPath, { mode: XCODE_SANDBOX_MODE });
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+}
+
+function inspectSandboxDirectory(directoryPath, expectedCanonicalPath, parentIdentity) {
+  if (typeof process.getuid !== "function") {
+    throw new Error("Xcode sandbox setup requires POSIX ownership checks");
+  }
+
+  const directoryFlags =
+    fs.constants.O_RDONLY |
+    (fs.constants.O_DIRECTORY ?? 0) |
+    (fs.constants.O_NOFOLLOW ?? 0);
+  const descriptor = fs.openSync(directoryPath, directoryFlags);
+  try {
+    const before = fs.fstatSync(descriptor);
+    if (!before.isDirectory() || before.uid !== process.getuid()) {
+      throw new Error("Sandbox directory is not owned by the current user");
+    }
+
+    fs.fchmodSync(descriptor, XCODE_SANDBOX_MODE);
+    const after = fs.fstatSync(descriptor);
+    const link = fs.lstatSync(directoryPath);
+    if (
+      !after.isDirectory() ||
+      !link.isDirectory() ||
+      link.isSymbolicLink() ||
+      after.uid !== process.getuid() ||
+      link.uid !== process.getuid() ||
+      after.dev !== link.dev ||
+      after.ino !== link.ino ||
+      (after.mode & 0o777) !== XCODE_SANDBOX_MODE
+    ) {
+      throw new Error("Sandbox directory identity changed during validation");
+    }
+
+    const resolved = canonicalPath(directoryPath);
+    if (resolved !== path.resolve(expectedCanonicalPath)) {
+      throw new Error("Sandbox directory escaped its trusted parent");
+    }
+
+    return {
+      path: path.resolve(directoryPath),
+      canonicalPath: resolved,
+      dev: after.dev,
+      ino: after.ino,
+      uid: after.uid,
+      parent: parentIdentity,
+    };
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function revalidateSandboxDirectory(identity) {
+  if (!identity) throw new Error("Sandbox directory identity is unavailable");
+  if (identity.parent) revalidateSandboxDirectory(identity.parent);
+
+  const current = inspectSandboxDirectory(
+    identity.path,
+    identity.canonicalPath,
+    identity.parent,
+  );
+  if (
+    current.dev !== identity.dev ||
+    current.ino !== identity.ino ||
+    current.uid !== identity.uid
+  ) {
+    throw new Error("Sandbox directory was replaced");
+  }
+  return current;
+}
+
+function canonicalPath(filePath) {
+  return fs.realpathSync.native?.(filePath) ?? fs.realpathSync(filePath);
 }
 
 function sandboxSetupIsCancelled(state, sessionID, sandboxBase) {
@@ -479,15 +766,25 @@ function sandboxSetupIsCancelled(state, sessionID, sandboxBase) {
   );
 }
 
-function writeSandboxOwner(sandboxBase, processStartToken, instanceID) {
+function writeSandboxOwner(sandboxIdentity, processStartToken, instanceID) {
+  revalidateSandboxDirectory(sandboxIdentity);
+  const sandboxBase = sandboxIdentity.path;
   const ownerPath = path.join(sandboxBase, "owner.pid");
   const temporaryPath = path.join(sandboxBase, `owner.pid.${instanceID}.tmp`);
   const content = `${process.pid}\n${process.argv[0] ?? "opencode"}\n${processStartToken}\n${instanceID}\n`;
-  const ownerLock = acquireSandboxOwnerLock(sandboxBase);
+  const ownerLock = acquireSandboxOwnerLock(
+    sandboxBase,
+    sandboxIdentity.parent,
+    sandboxIdentity,
+  );
   if (!ownerLock) throw new Error("Sandbox owner is being updated or removed");
 
   try {
-    fs.writeFileSync(temporaryPath, content, "utf8");
+    fs.writeFileSync(temporaryPath, content, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
     if (!sandboxOwnerLockIsHeld(ownerLock)) {
       throw new Error("Sandbox owner lock changed during update");
     }
@@ -510,7 +807,11 @@ function markSandboxCleanupPending(sandboxBase, instanceID, ownerLock) {
   const content = `${process.pid}\ncleanup-pending\n\n${instanceID}\ncleanup-pending\n`;
 
   try {
-    fs.writeFileSync(temporaryPath, content, "utf8");
+    fs.writeFileSync(temporaryPath, content, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
     if (!sandboxOwnerLockIsHeld(ownerLock)) return false;
     fs.renameSync(temporaryPath, ownerPath);
     return true;
@@ -525,11 +826,31 @@ function markSandboxCleanupPending(sandboxBase, instanceID, ownerLock) {
   }
 }
 
-function acquireSandboxOwnerLock(sandboxBase) {
+function acquireSandboxOwnerLock(
+  sandboxBase,
+  sandboxRootIdentity = null,
+  expectedSandboxIdentity = null,
+) {
+  let sandboxIdentity = null;
+  if (sandboxRootIdentity) {
+    sandboxIdentity = secureExistingManagedSandbox(
+      sandboxBase,
+      sandboxRootIdentity,
+      expectedSandboxIdentity,
+    );
+    if (!sandboxIdentity) return null;
+  }
+
   const lockPath = path.join(sandboxBase, XCODE_SANDBOX_OWNER_LOCK);
   const token = randomUUID();
   const createdLock = createSandboxOwnerLock(lockPath, token);
-  if (createdLock) return createdLock;
+  if (createdLock) {
+    return attachSandboxIdentityToLock(
+      createdLock,
+      sandboxRootIdentity,
+      sandboxIdentity,
+    );
+  }
 
   const observedLock = readSandboxOwnerLock(lockPath);
   if (!observedLock) return null;
@@ -555,7 +876,16 @@ function acquireSandboxOwnerLock(sandboxBase) {
     return null;
   }
 
-  return createSandboxOwnerLock(lockPath, token);
+  return attachSandboxIdentityToLock(
+    createSandboxOwnerLock(lockPath, token),
+    sandboxRootIdentity,
+    sandboxIdentity,
+  );
+}
+
+function attachSandboxIdentityToLock(ownerLock, sandboxRootIdentity, sandboxIdentity) {
+  if (!ownerLock || !sandboxRootIdentity || !sandboxIdentity) return ownerLock;
+  return { ...ownerLock, sandboxRootIdentity, sandboxIdentity };
 }
 
 function createSandboxOwnerLock(lockPath, token) {
@@ -612,6 +942,16 @@ function sameSandboxOwnerLock(left, right) {
 }
 
 function sandboxOwnerLockIsHeld(ownerLock) {
+  if (
+    ownerLock?.sandboxRootIdentity &&
+    !secureExistingManagedSandbox(
+      ownerLock.sandboxIdentity.path,
+      ownerLock.sandboxRootIdentity,
+      ownerLock.sandboxIdentity,
+    )
+  ) {
+    return false;
+  }
   return sameSandboxOwnerLock(ownerLock, readSandboxOwnerLock(ownerLock.path));
 }
 
@@ -666,42 +1006,78 @@ async function removeOwnedSandbox(state, sessionID) {
   const sandboxPath = state.ownedSandboxes.get(sessionID);
   if (!sandboxPath) return;
 
+  const sandboxIdentity = state.ownedSandboxIdentities.get(sessionID);
   markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.delete(sessionID);
-  const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+  state.ownedSandboxIdentities.delete(sessionID);
+  if (!state.sandboxRoot || !sandboxIdentity) return;
+
+  const quarantinedPath = await quarantineOwnedSandbox(
+    sandboxPath,
+    state.instanceID,
+    state.sandboxRoot,
+    sandboxIdentity,
+  );
+  const cleanupIdentity = quarantinedPath
+    ? relocatedSandboxIdentity(sandboxIdentity, quarantinedPath)
+    : sandboxIdentity;
   await removeManagedSandbox(
     quarantinedPath || sandboxPath,
     quarantinedPath ? "" : state.instanceID,
+    state.sandboxRoot,
+    cleanupIdentity,
   );
 }
 
 async function detachOwnedSandboxes(state) {
   state.disposed = true;
-  const sandboxPaths = [...new Set(state.ownedSandboxes.values())];
+  const sandboxes = [...state.ownedSandboxes.entries()].map(([sessionID, sandboxPath]) => ({
+    sandboxPath,
+    sandboxIdentity: state.ownedSandboxIdentities.get(sessionID),
+  }));
+  const sandboxPaths = [...new Set(sandboxes.map(({ sandboxPath }) => sandboxPath))];
   for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
+  state.ownedSandboxIdentities.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
   const cleanupTargets = await Promise.all(
-    sandboxPaths.map(async (sandboxPath) => {
-      const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+    sandboxes.map(async ({ sandboxPath, sandboxIdentity }) => {
+      if (!state.sandboxRoot || !sandboxIdentity) return null;
+      const quarantinedPath = await quarantineOwnedSandbox(
+        sandboxPath,
+        state.instanceID,
+        state.sandboxRoot,
+        sandboxIdentity,
+      );
       return {
         path: quarantinedPath || sandboxPath,
         expectedInstanceID: quarantinedPath ? "" : state.instanceID,
+        identity: quarantinedPath
+          ? relocatedSandboxIdentity(sandboxIdentity, quarantinedPath)
+          : sandboxIdentity,
       };
     }),
   );
   await Promise.all(
-    cleanupTargets.map(({ path: sandboxPath, expectedInstanceID }) =>
-      detachManagedSandbox(sandboxPath, expectedInstanceID),
+    cleanupTargets.filter(Boolean).map(({ path: sandboxPath, expectedInstanceID, identity }) =>
+      detachManagedSandbox(
+        sandboxPath,
+        expectedInstanceID,
+        state.sandboxRoot,
+        identity,
+      ),
     ),
   );
 }
 
-async function sweepStaleSandboxes(sandboxRoot) {
+async function sweepStaleSandboxes(sandboxRootIdentity) {
   let entries;
   try {
-    entries = await fs.promises.readdir(sandboxRoot, { withFileTypes: true });
+    revalidateSandboxDirectory(sandboxRootIdentity);
+    entries = await fs.promises.readdir(sandboxRootIdentity.path, {
+      withFileTypes: true,
+    });
   } catch {
     return;
   }
@@ -711,7 +1087,12 @@ async function sweepStaleSandboxes(sandboxRoot) {
       const isQuarantine = XCODE_SANDBOX_QUARANTINE_RE.test(entry.name);
       if (!entry.isDirectory() || (!SAFE_ID_RE.test(entry.name) && !isQuarantine)) return;
 
-      const sandboxPath = path.join(sandboxRoot, entry.name);
+      const sandboxPath = path.join(sandboxRootIdentity.path, entry.name);
+      const sandboxIdentity = secureExistingManagedSandbox(
+        sandboxPath,
+        sandboxRootIdentity,
+      );
+      if (!sandboxIdentity) return;
       const owner = await readSandboxOwner(sandboxPath);
       const cleanupPending = owner?.cleanupPending || sandboxCleanupIsPending(sandboxPath);
       if (!owner || cleanupPending) {
@@ -719,7 +1100,11 @@ async function sweepStaleSandboxes(sandboxRoot) {
           return;
         }
 
-        const ownerLock = acquireSandboxOwnerLock(sandboxPath);
+        const ownerLock = acquireSandboxOwnerLock(
+          sandboxPath,
+          sandboxRootIdentity,
+          sandboxIdentity,
+        );
         if (!ownerLock) return;
         let releaseLock = ownerLock;
         try {
@@ -733,10 +1118,20 @@ async function sweepStaleSandboxes(sandboxRoot) {
             (!currentOwner || currentCleanupPending) &&
             sandboxOwnerLockIsHeld(ownerLock)
           ) {
-            const quarantined = await quarantineManagedSandbox(sandboxPath, ownerLock);
+            const quarantined = await quarantineManagedSandbox(
+              sandboxPath,
+              ownerLock,
+              sandboxRootIdentity,
+              sandboxIdentity,
+            );
             releaseLock = quarantined.ownerLock;
             if (quarantined.path) {
-              await removeManagedSandbox(quarantined.path);
+              await removeManagedSandbox(
+                quarantined.path,
+                "",
+                sandboxRootIdentity,
+                relocatedSandboxIdentity(sandboxIdentity, quarantined.path),
+              );
             }
           }
         } finally {
@@ -746,7 +1141,12 @@ async function sweepStaleSandboxes(sandboxRoot) {
       }
       if (await sandboxOwnerIsActive(owner)) return;
 
-      await removeManagedSandbox(sandboxPath);
+      await removeManagedSandbox(
+        sandboxPath,
+        "",
+        sandboxRootIdentity,
+        sandboxIdentity,
+      );
     }),
   );
 }
@@ -805,9 +1205,11 @@ async function sandboxOwnerIsActive(owner) {
 function readProcessStartToken(pid) {
   return new Promise((resolve) => {
     let settled = false;
+    let timedOut = false;
     let stdout = "";
     let child;
-    let timer;
+    let timeoutTimer;
+    let forceKillTimer;
 
     try {
       child = spawn("/bin/ps", ["-p", String(pid), "-o", "lstart="], {
@@ -824,37 +1226,61 @@ function readProcessStartToken(pid) {
       return;
     }
 
-    child.stdout?.setEncoding?.("utf8");
-    child.stdout?.on?.("data", (chunk) => {
+    const onData = (chunk) => {
       const remaining = PROCESS_START_OUTPUT_MAX_CHARS - stdout.length;
       if (remaining > 0) stdout += String(chunk).slice(0, remaining);
-    });
-    child.on("error", () => finish(""));
-    child.on("close", (code) => {
+    };
+    const onError = () => finish("");
+    const onClose = (code) => {
       const firstLine = stdout.trim().split(/\r?\n/, 1)[0] ?? "";
-      finish(code === 0 ? firstLine : "");
-    });
-    timer = setTimeout(() => {
-      try {
-        child.kill?.("SIGTERM");
-      } catch {
-        // Resolving the hook is more important than terminating a broken ps shim.
-      }
-      finish("");
+      finish(!timedOut && code === 0 ? firstLine : "");
+    };
+
+    child.stdout?.setEncoding?.("utf8");
+    child.stdout?.on?.("data", onData);
+    child.on("error", onError);
+    child.on("close", onClose);
+    timeoutTimer = setTimeout(() => {
+      if (settled) return;
+      timedOut = true;
+      forceKillTimer = terminateChildAfterGrace(
+        child,
+        () => !settled,
+        () => finish(""),
+      );
     }, PROCESS_START_TIMEOUT_MS);
 
     function finish(value) {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      clearTimeout(timeoutTimer);
+      clearTimeout(forceKillTimer);
+      child.stdout?.removeListener?.("data", onData);
+      child.removeListener?.("error", onError);
+      child.removeListener?.("close", onClose);
       resolve(value);
     }
   });
 }
 
-async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
+async function removeManagedSandbox(
+  sandboxPath,
+  expectedInstanceID = "",
+  sandboxRootIdentity = null,
+  expectedSandboxIdentity = null,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
   if (!candidate) return false;
+  if (
+    !sandboxRootIdentity ||
+    !secureExistingManagedSandbox(
+      candidate,
+      sandboxRootIdentity,
+      expectedSandboxIdentity,
+    )
+  ) {
+    return false;
+  }
 
   if (expectedInstanceID) {
     const owner = await readSandboxOwner(candidate);
@@ -871,11 +1297,26 @@ async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
   }
 }
 
-async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
+async function quarantineOwnedSandbox(
+  sandboxPath,
+  expectedInstanceID,
+  sandboxRootIdentity,
+  expectedSandboxIdentity,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
   if (!candidate) return "";
+  const sandboxIdentity = secureExistingManagedSandbox(
+    candidate,
+    sandboxRootIdentity,
+    expectedSandboxIdentity,
+  );
+  if (!sandboxIdentity) return "";
 
-  const ownerLock = acquireSandboxOwnerLock(candidate);
+  const ownerLock = acquireSandboxOwnerLock(
+    candidate,
+    sandboxRootIdentity,
+    sandboxIdentity,
+  );
   if (!ownerLock) return "";
   let releaseLock = ownerLock;
 
@@ -897,7 +1338,21 @@ async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
     releaseLock = {
       ...ownerLock,
       path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+      sandboxIdentity: relocatedSandboxIdentity(sandboxIdentity, quarantinePath),
     };
+    if (
+      !secureExistingManagedSandbox(
+        quarantinePath,
+        sandboxRootIdentity,
+        releaseLock.sandboxIdentity,
+      )
+    ) {
+      if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+        movePendingSandboxCleanup(quarantinePath, candidate);
+        releaseLock = ownerLock;
+      }
+      return "";
+    }
     const relocatedOwner = await readSandboxOwner(quarantinePath);
     if (
       !sandboxOwnerLockIsHeld(releaseLock) ||
@@ -907,7 +1362,7 @@ async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
     ) {
       if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
         movePendingSandboxCleanup(quarantinePath, candidate);
-        releaseLock = { ...releaseLock, path: ownerLock.path };
+        releaseLock = ownerLock;
       }
       return "";
     }
@@ -926,9 +1381,21 @@ async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
   }
 }
 
-async function quarantineManagedSandbox(sandboxPath, ownerLock) {
+async function quarantineManagedSandbox(
+  sandboxPath,
+  ownerLock,
+  sandboxRootIdentity,
+  expectedSandboxIdentity,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
-  if (!candidate || !sandboxOwnerLockIsHeld(ownerLock)) {
+  const sandboxIdentity = candidate
+    ? secureExistingManagedSandbox(
+        candidate,
+        sandboxRootIdentity,
+        expectedSandboxIdentity,
+      )
+    : null;
+  if (!candidate || !sandboxIdentity || !sandboxOwnerLockIsHeld(ownerLock)) {
     return { path: "", ownerLock };
   }
 
@@ -945,7 +1412,21 @@ async function quarantineManagedSandbox(sandboxPath, ownerLock) {
   const relocatedLock = {
     ...ownerLock,
     path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+    sandboxIdentity: relocatedSandboxIdentity(sandboxIdentity, quarantinePath),
   };
+  if (
+    !secureExistingManagedSandbox(
+      quarantinePath,
+      sandboxRootIdentity,
+      relocatedLock.sandboxIdentity,
+    )
+  ) {
+    if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+      movePendingSandboxCleanup(quarantinePath, candidate);
+      return { path: "", ownerLock };
+    }
+    return { path: "", ownerLock: relocatedLock };
+  }
   const publishedOwner = await readSandboxOwner(quarantinePath);
   const cleanupPending =
     publishedOwner?.cleanupPending || sandboxCleanupIsPending(quarantinePath);
@@ -973,9 +1454,24 @@ function restoreQuarantinedSandbox(quarantinePath, originalPath) {
   }
 }
 
-async function detachManagedSandbox(sandboxPath, expectedInstanceID = "") {
+async function detachManagedSandbox(
+  sandboxPath,
+  expectedInstanceID = "",
+  sandboxRootIdentity = null,
+  expectedSandboxIdentity = null,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
   if (!candidate) return;
+  if (
+    !sandboxRootIdentity ||
+    !secureExistingManagedSandbox(
+      candidate,
+      sandboxRootIdentity,
+      expectedSandboxIdentity,
+    )
+  ) {
+    return;
+  }
 
   if (expectedInstanceID) {
     const owner = await readSandboxOwner(candidate);
@@ -1003,6 +1499,49 @@ function managedSandboxCandidate(sandboxPath) {
   const relative = path.relative(sandboxRoot, candidate);
   if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return "";
   return candidate;
+}
+
+function secureExistingManagedSandbox(
+  sandboxPath,
+  sandboxRootIdentity,
+  expectedSandboxIdentity = null,
+) {
+  try {
+    revalidateSandboxDirectory(sandboxRootIdentity);
+    const candidate = managedSandboxCandidate(sandboxPath);
+    if (!candidate || path.dirname(candidate) !== sandboxRootIdentity.path) return null;
+
+    const name = path.basename(candidate);
+    if (!SAFE_ID_RE.test(name) && !XCODE_SANDBOX_QUARANTINE_RE.test(name)) {
+      return null;
+    }
+
+    const current = inspectSandboxDirectory(
+      candidate,
+      path.join(sandboxRootIdentity.canonicalPath, name),
+      sandboxRootIdentity,
+    );
+    if (
+      expectedSandboxIdentity &&
+      (current.dev !== expectedSandboxIdentity.dev ||
+        current.ino !== expectedSandboxIdentity.ino ||
+        current.uid !== expectedSandboxIdentity.uid)
+    ) {
+      return null;
+    }
+    return current;
+  } catch {
+    return null;
+  }
+}
+
+function relocatedSandboxIdentity(identity, destinationPath) {
+  const name = path.basename(destinationPath);
+  return {
+    ...identity,
+    path: path.resolve(destinationPath),
+    canonicalPath: path.join(identity.parent.canonicalPath, name),
+  };
 }
 
 function markPendingSandboxCleanup(sandboxPath) {

--- a/XcodeBuildTools/info.json
+++ b/XcodeBuildTools/info.json
@@ -47,6 +47,10 @@
     ],
     "versions": [
         {
+            "version": "0.5.11",
+            "changes": "Added OpenCode support through an opencode-plugin.js entry point that registers skills, MCP servers, session-start context, pre-tool-use command guardrails, the Xcode MCP auto-approval helper, and Xcode build sandbox shell environment setup."
+        },
+        {
             "version": "0.5.10",
             "changes": "Migrated the legacy analyze and swiftui-modernize command prompts to skills and registered swift-code-analysis and swiftui-modernize in info.json. Released self-contained common helper copies so the plugin package no longer depends on repository-level symlinks, while keeping hook configuration in hooks/hooks.json instead of generated common/hooks.json templates. Preserved the host hook owner PID when launching SessionStart helpers in the background so sandbox inheritance across /clear can keep finding the prior anchor."
         },

--- a/XcodeBuildTools/opencode-plugin.js
+++ b/XcodeBuildTools/opencode-plugin.js
@@ -1,0 +1,6 @@
+import { createOpenCodePlugin } from "./common/opencode-plugin.js";
+
+export default {
+  id: "XcodeBuildTools",
+  server: createOpenCodePlugin(new URL(".", import.meta.url)),
+};

--- a/common/opencode-plugin.js
+++ b/common/opencode-plugin.js
@@ -182,6 +182,7 @@ function processConditionalBlocks(content, xcodeMcpLikely) {
 
 async function getXcodeMcpLikely(pluginName, state) {
   if (pluginName !== "XcodeBuildTools") return false;
+  if (state.xcodeMcpLikely !== undefined) return state.xcodeMcpLikely;
 
   const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
   if (!installed) {

--- a/common/opencode-plugin.js
+++ b/common/opencode-plugin.js
@@ -84,7 +84,10 @@ export function createOpenCodePlugin(pluginRootUrl) {
     const mcpContext = {
       pluginRoot,
       pluginData: () => pluginDataDirectory(pluginRoot, state),
-      projectDir: input?.worktree || input?.directory,
+      projectDir:
+        input?.worktree !== "/" || input?.project?.vcs === "git"
+          ? input?.worktree || input?.directory
+          : input?.directory || input?.worktree,
     };
 
     return {

--- a/common/opencode-plugin.js
+++ b/common/opencode-plugin.js
@@ -270,7 +270,7 @@ function applyPreToolUseRules(state, input, output) {
     if (decision === "deny") throw new Error(message);
 
     const ruleName = typeof rule.name === "string" && rule.name ? rule.name : matchPattern;
-    const key = `${input.sessionID ?? "global"}:${ruleName}`;
+    const key = `${safeSessionID(input.sessionID ?? "global")}:${ruleName}`;
     if (state.deniedOnce.has(key)) continue;
 
     state.deniedOnce.add(key);

--- a/common/opencode-plugin.js
+++ b/common/opencode-plugin.js
@@ -7,11 +7,47 @@ import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
 const MCP_PLACEHOLDER_RE = /\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}/g;
+const MCP_COMPATIBILITY_ENVIRONMENT_KEYS = new Set([
+  "CLAUDE_PLUGIN_ROOT",
+  "CLAUDE_PLUGIN_DATA",
+  "CLAUDE_PROJECT_DIR",
+]);
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const PROCESS_START_OUTPUT_MAX_CHARS = 256;
 const PROCESS_START_TIMEOUT_MS = 5_000;
+const PROCESS_TERMINATION_GRACE_MS = 250;
 const XCODE_MCP_CACHE_TTL_MS = 30_000;
+const XCRUN_OPTIONS_WITH_VALUE = new Set([
+  "--sdk",
+  "-sdk",
+  "--toolchain",
+  "-toolchain",
+]);
+const XCRUN_OPTIONS_WITHOUT_VALUE = new Set([
+  "-h",
+  "--help",
+  "--version",
+  "-v",
+  "--verbose",
+  "-l",
+  "--log",
+  "-f",
+  "--find",
+  "-r",
+  "--run",
+  "-n",
+  "--no-cache",
+  "-k",
+  "--kill-cache",
+  "--show-sdk-path",
+  "--show-sdk-version",
+  "--show-sdk-build-version",
+  "--show-sdk-platform-path",
+  "--show-sdk-platform-version",
+  "--show-toolchain-path",
+]);
 const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
+const XCODE_SANDBOX_MODE = 0o700;
 const XCODE_SANDBOX_OWNER_GRACE_MS = 60_000;
 const XCODE_SANDBOX_OWNER_LOCK = ".owner.lock";
 const XCODE_SANDBOX_QUARANTINE_RE =
@@ -38,7 +74,9 @@ export function createOpenCodePlugin(pluginRootUrl) {
       deniedOnce: new Set(),
       xcodeMcpCache: new Map(),
       xcodeMcpApprovalSessions: new Set(),
+      sandboxRoot: null,
       ownedSandboxes: new Map(),
+      ownedSandboxIdentities: new Map(),
       deletedSandboxSessions: new Set(),
       sandboxSweepDone: false,
       disposed: false,
@@ -145,8 +183,45 @@ function registerMcpServers(config, pluginRoot, context) {
     if (!isObject(server) || config.mcp[name]) continue;
 
     const translated = translateMcpServer(server, context);
-    if (translated) config.mcp[name] = translated;
+    if (translated && !hasMcpEndpoint(config.mcp, translated)) {
+      config.mcp[name] = translated;
+    }
   }
+}
+
+function hasMcpEndpoint(servers, candidate) {
+  return Object.values(servers).some((server) => {
+    if (!isObject(server) || server.type !== candidate.type) return false;
+    if (candidate.type === "remote") return server.url === candidate.url;
+    if (candidate.type !== "local") return false;
+    if (!Array.isArray(server.command) || !Array.isArray(candidate.command)) return false;
+    return (
+      server.command.length === candidate.command.length &&
+      server.command.every((item, index) => item === candidate.command[index]) &&
+      server.cwd === candidate.cwd &&
+      mcpEnvironmentMatches(server.environment, candidate.environment)
+    );
+  });
+}
+
+function mcpEnvironmentMatches(left, right) {
+  const leftEntries = comparableMcpEnvironment(left);
+  const rightEntries = comparableMcpEnvironment(right);
+  if (!leftEntries || !rightEntries || leftEntries.length !== rightEntries.length) {
+    return false;
+  }
+  return leftEntries.every(([key, value], index) => {
+    const [rightKey, rightValue] = rightEntries[index];
+    return key === rightKey && value === rightValue;
+  });
+}
+
+function comparableMcpEnvironment(environment) {
+  if (environment === undefined) return [];
+  if (!isObject(environment)) return null;
+  return Object.entries(environment)
+    .filter(([key]) => !MCP_COMPATIBILITY_ENVIRONMENT_KEYS.has(key))
+    .sort(([left], [right]) => left.localeCompare(right));
 }
 
 function translateMcpServer(server, context) {
@@ -337,14 +412,40 @@ function hasConfiguredMcpbridge(config) {
     if (!isObject(server) || server.enabled === false || server.type !== "local") return false;
 
     const command = Array.isArray(server.command) ? server.command : [server.command];
-    return command.some((part) => {
-      if (typeof part !== "string") return false;
-      return part
-        .trim()
-        .split(/\s+/)
-        .some((token) => path.basename(token.replace(/^['"]|['"]$/g, "")) === "mcpbridge");
-    });
+    const executable = commandBasename(command[0]);
+    if (executable === "mcpbridge") return true;
+    if (executable !== "xcrun") return false;
+    return xcrunToolBasename(command.slice(1)) === "mcpbridge";
   });
+}
+
+function commandBasename(value) {
+  const commandPart = normalizedCommandPart(value);
+  return commandPart ? path.basename(commandPart) : "";
+}
+
+function normalizedCommandPart(value) {
+  if (typeof value !== "string") return "";
+  return value.trim().replace(/^['"]|['"]$/g, "");
+}
+
+function xcrunToolBasename(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = normalizedCommandPart(args[index]);
+    if (!argument) return "";
+    if (argument === "--") {
+      return commandBasename(args[index + 1]);
+    }
+    if (XCRUN_OPTIONS_WITH_VALUE.has(argument)) {
+      index += 1;
+      continue;
+    }
+    if (/^(?:--?sdk|--?toolchain)=/.test(argument)) continue;
+    if (XCRUN_OPTIONS_WITHOUT_VALUE.has(argument)) continue;
+    if (argument.startsWith("-")) return "";
+    return path.basename(argument);
+  }
+  return "";
 }
 
 function startXcodeMcpApproval(pluginRoot, state, sessionID) {
@@ -377,22 +478,74 @@ function startXcodeMcpApproval(pluginRoot, state, sessionID) {
 function commandSucceeds(command, args, timeoutMs) {
   return new Promise((resolve) => {
     let settled = false;
-    const child = spawn(command, args, { stdio: "ignore" });
-    const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      finish(false);
-    }, timeoutMs);
+    let timedOut = false;
+    let timeoutTimer;
+    let forceKillTimer;
+    let child;
 
-    child.on("error", () => finish(false));
-    child.on("exit", (code) => finish(code === 0));
+    try {
+      child = spawn(command, args, { stdio: "ignore" });
+    } catch {
+      resolve(false);
+      return;
+    }
+
+    const onError = () => finish(false);
+    const onExit = (code) => finish(!timedOut && code === 0);
+    child.on("error", onError);
+    child.on("exit", onExit);
+    timeoutTimer = setTimeout(beginTermination, timeoutMs);
+
+    function beginTermination() {
+      if (settled) return;
+      timedOut = true;
+      forceKillTimer = terminateChildAfterGrace(
+        child,
+        () => !settled,
+        () => finish(false),
+      );
+    }
 
     function finish(result) {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      clearTimeout(timeoutTimer);
+      clearTimeout(forceKillTimer);
+      child.removeListener?.("error", onError);
+      child.removeListener?.("exit", onExit);
       resolve(result);
     }
   });
+}
+
+function terminateChildAfterGrace(child, isPending, onForcedTermination) {
+  try {
+    child.kill("SIGTERM");
+  } catch {
+    // Continue to forced termination so the timed-out child is detached.
+  }
+  if (!isPending()) return undefined;
+
+  return setTimeout(() => {
+    if (!isPending()) return;
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // The process may have exited between the grace timer and this call.
+    }
+    try {
+      child.stdout?.destroy?.();
+      child.stderr?.destroy?.();
+    } catch {
+      // Detaching the child still allows the parent to continue.
+    }
+    try {
+      child.unref();
+    } catch {
+      // Resolving the caller is more important than detaching a broken shim.
+    }
+    onForcedTermination();
+  }, PROCESS_TERMINATION_GRACE_MS);
 }
 
 function applyPreToolUseRules(state, input, output) {
@@ -442,10 +595,10 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
 
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
   if (state.disposed || state.deletedSandboxSessions.has(sessionID)) return;
-  const sandboxRoot = path.join(os.tmpdir(), XCODE_SANDBOX_DIR);
+  const sandboxRoot = secureSandboxRoot(state);
   // Plugin instances never reuse a sandbox path, so an older instance cannot
   // delete a replacement instance's active sandbox after an ownership check.
-  const sandboxBase = path.join(sandboxRoot, `${sessionID}-${state.instanceID}`);
+  const sandboxBase = path.join(sandboxRoot.path, `${sessionID}-${state.instanceID}`);
   state.ownedSandboxes.set(sessionID, sandboxBase);
 
   if (!state.processStartToken) {
@@ -462,12 +615,146 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   const buildDir = path.join(sandboxBase, "build");
   const packagesDir = path.join(sandboxBase, "packages");
 
-  fs.mkdirSync(buildDir, { recursive: true });
-  fs.mkdirSync(packagesDir, { recursive: true });
-  writeSandboxOwner(sandboxBase, state.processStartToken, state.instanceID);
+  const sandboxIdentity = secureSandboxDirectory(sandboxBase, sandboxRoot);
+  state.ownedSandboxIdentities.set(sessionID, sandboxIdentity);
+  if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
+  secureSandboxDirectory(buildDir, sandboxIdentity);
+  secureSandboxDirectory(packagesDir, sandboxIdentity);
+  writeSandboxOwner(
+    sandboxIdentity,
+    state.processStartToken,
+    state.instanceID,
+  );
 
   output.env.SANDBOX_DERIVED_DATA = buildDir;
   output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+function secureSandboxRoot(state) {
+  if (state.sandboxRoot) {
+    revalidateSandboxDirectory(state.sandboxRoot);
+    return state.sandboxRoot;
+  }
+
+  const temporaryDirectory = path.resolve(os.tmpdir());
+  const canonicalTemporaryDirectory = canonicalPath(temporaryDirectory);
+  const sandboxRoot = path.join(temporaryDirectory, XCODE_SANDBOX_DIR);
+  const expectedCanonicalPath = path.join(
+    canonicalTemporaryDirectory,
+    XCODE_SANDBOX_DIR,
+  );
+
+  createDirectoryNonRecursively(sandboxRoot);
+  const identity = inspectSandboxDirectory(
+    sandboxRoot,
+    expectedCanonicalPath,
+    null,
+  );
+  state.sandboxRoot = identity;
+  return identity;
+}
+
+function secureSandboxDirectory(directoryPath, parentIdentity) {
+  revalidateSandboxDirectory(parentIdentity);
+
+  const candidate = path.resolve(directoryPath);
+  const parentPath = path.resolve(parentIdentity.path);
+  if (path.dirname(candidate) !== parentPath) {
+    throw new Error("Sandbox directory must be a direct child of its trusted parent");
+  }
+
+  const name = path.basename(candidate);
+  if (!SAFE_ID_RE.test(name)) {
+    throw new Error("Sandbox directory has an unsafe name");
+  }
+
+  createDirectoryNonRecursively(candidate);
+  return inspectSandboxDirectory(
+    candidate,
+    path.join(parentIdentity.canonicalPath, name),
+    parentIdentity,
+  );
+}
+
+function createDirectoryNonRecursively(directoryPath) {
+  try {
+    fs.mkdirSync(directoryPath, { mode: XCODE_SANDBOX_MODE });
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+}
+
+function inspectSandboxDirectory(directoryPath, expectedCanonicalPath, parentIdentity) {
+  if (typeof process.getuid !== "function") {
+    throw new Error("Xcode sandbox setup requires POSIX ownership checks");
+  }
+
+  const directoryFlags =
+    fs.constants.O_RDONLY |
+    (fs.constants.O_DIRECTORY ?? 0) |
+    (fs.constants.O_NOFOLLOW ?? 0);
+  const descriptor = fs.openSync(directoryPath, directoryFlags);
+  try {
+    const before = fs.fstatSync(descriptor);
+    if (!before.isDirectory() || before.uid !== process.getuid()) {
+      throw new Error("Sandbox directory is not owned by the current user");
+    }
+
+    fs.fchmodSync(descriptor, XCODE_SANDBOX_MODE);
+    const after = fs.fstatSync(descriptor);
+    const link = fs.lstatSync(directoryPath);
+    if (
+      !after.isDirectory() ||
+      !link.isDirectory() ||
+      link.isSymbolicLink() ||
+      after.uid !== process.getuid() ||
+      link.uid !== process.getuid() ||
+      after.dev !== link.dev ||
+      after.ino !== link.ino ||
+      (after.mode & 0o777) !== XCODE_SANDBOX_MODE
+    ) {
+      throw new Error("Sandbox directory identity changed during validation");
+    }
+
+    const resolved = canonicalPath(directoryPath);
+    if (resolved !== path.resolve(expectedCanonicalPath)) {
+      throw new Error("Sandbox directory escaped its trusted parent");
+    }
+
+    return {
+      path: path.resolve(directoryPath),
+      canonicalPath: resolved,
+      dev: after.dev,
+      ino: after.ino,
+      uid: after.uid,
+      parent: parentIdentity,
+    };
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function revalidateSandboxDirectory(identity) {
+  if (!identity) throw new Error("Sandbox directory identity is unavailable");
+  if (identity.parent) revalidateSandboxDirectory(identity.parent);
+
+  const current = inspectSandboxDirectory(
+    identity.path,
+    identity.canonicalPath,
+    identity.parent,
+  );
+  if (
+    current.dev !== identity.dev ||
+    current.ino !== identity.ino ||
+    current.uid !== identity.uid
+  ) {
+    throw new Error("Sandbox directory was replaced");
+  }
+  return current;
+}
+
+function canonicalPath(filePath) {
+  return fs.realpathSync.native?.(filePath) ?? fs.realpathSync(filePath);
 }
 
 function sandboxSetupIsCancelled(state, sessionID, sandboxBase) {
@@ -478,15 +765,25 @@ function sandboxSetupIsCancelled(state, sessionID, sandboxBase) {
   );
 }
 
-function writeSandboxOwner(sandboxBase, processStartToken, instanceID) {
+function writeSandboxOwner(sandboxIdentity, processStartToken, instanceID) {
+  revalidateSandboxDirectory(sandboxIdentity);
+  const sandboxBase = sandboxIdentity.path;
   const ownerPath = path.join(sandboxBase, "owner.pid");
   const temporaryPath = path.join(sandboxBase, `owner.pid.${instanceID}.tmp`);
   const content = `${process.pid}\n${process.argv[0] ?? "opencode"}\n${processStartToken}\n${instanceID}\n`;
-  const ownerLock = acquireSandboxOwnerLock(sandboxBase);
+  const ownerLock = acquireSandboxOwnerLock(
+    sandboxBase,
+    sandboxIdentity.parent,
+    sandboxIdentity,
+  );
   if (!ownerLock) throw new Error("Sandbox owner is being updated or removed");
 
   try {
-    fs.writeFileSync(temporaryPath, content, "utf8");
+    fs.writeFileSync(temporaryPath, content, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
     if (!sandboxOwnerLockIsHeld(ownerLock)) {
       throw new Error("Sandbox owner lock changed during update");
     }
@@ -509,7 +806,11 @@ function markSandboxCleanupPending(sandboxBase, instanceID, ownerLock) {
   const content = `${process.pid}\ncleanup-pending\n\n${instanceID}\ncleanup-pending\n`;
 
   try {
-    fs.writeFileSync(temporaryPath, content, "utf8");
+    fs.writeFileSync(temporaryPath, content, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
     if (!sandboxOwnerLockIsHeld(ownerLock)) return false;
     fs.renameSync(temporaryPath, ownerPath);
     return true;
@@ -524,11 +825,31 @@ function markSandboxCleanupPending(sandboxBase, instanceID, ownerLock) {
   }
 }
 
-function acquireSandboxOwnerLock(sandboxBase) {
+function acquireSandboxOwnerLock(
+  sandboxBase,
+  sandboxRootIdentity = null,
+  expectedSandboxIdentity = null,
+) {
+  let sandboxIdentity = null;
+  if (sandboxRootIdentity) {
+    sandboxIdentity = secureExistingManagedSandbox(
+      sandboxBase,
+      sandboxRootIdentity,
+      expectedSandboxIdentity,
+    );
+    if (!sandboxIdentity) return null;
+  }
+
   const lockPath = path.join(sandboxBase, XCODE_SANDBOX_OWNER_LOCK);
   const token = randomUUID();
   const createdLock = createSandboxOwnerLock(lockPath, token);
-  if (createdLock) return createdLock;
+  if (createdLock) {
+    return attachSandboxIdentityToLock(
+      createdLock,
+      sandboxRootIdentity,
+      sandboxIdentity,
+    );
+  }
 
   const observedLock = readSandboxOwnerLock(lockPath);
   if (!observedLock) return null;
@@ -554,7 +875,16 @@ function acquireSandboxOwnerLock(sandboxBase) {
     return null;
   }
 
-  return createSandboxOwnerLock(lockPath, token);
+  return attachSandboxIdentityToLock(
+    createSandboxOwnerLock(lockPath, token),
+    sandboxRootIdentity,
+    sandboxIdentity,
+  );
+}
+
+function attachSandboxIdentityToLock(ownerLock, sandboxRootIdentity, sandboxIdentity) {
+  if (!ownerLock || !sandboxRootIdentity || !sandboxIdentity) return ownerLock;
+  return { ...ownerLock, sandboxRootIdentity, sandboxIdentity };
 }
 
 function createSandboxOwnerLock(lockPath, token) {
@@ -611,6 +941,16 @@ function sameSandboxOwnerLock(left, right) {
 }
 
 function sandboxOwnerLockIsHeld(ownerLock) {
+  if (
+    ownerLock?.sandboxRootIdentity &&
+    !secureExistingManagedSandbox(
+      ownerLock.sandboxIdentity.path,
+      ownerLock.sandboxRootIdentity,
+      ownerLock.sandboxIdentity,
+    )
+  ) {
+    return false;
+  }
   return sameSandboxOwnerLock(ownerLock, readSandboxOwnerLock(ownerLock.path));
 }
 
@@ -665,42 +1005,78 @@ async function removeOwnedSandbox(state, sessionID) {
   const sandboxPath = state.ownedSandboxes.get(sessionID);
   if (!sandboxPath) return;
 
+  const sandboxIdentity = state.ownedSandboxIdentities.get(sessionID);
   markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.delete(sessionID);
-  const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+  state.ownedSandboxIdentities.delete(sessionID);
+  if (!state.sandboxRoot || !sandboxIdentity) return;
+
+  const quarantinedPath = await quarantineOwnedSandbox(
+    sandboxPath,
+    state.instanceID,
+    state.sandboxRoot,
+    sandboxIdentity,
+  );
+  const cleanupIdentity = quarantinedPath
+    ? relocatedSandboxIdentity(sandboxIdentity, quarantinedPath)
+    : sandboxIdentity;
   await removeManagedSandbox(
     quarantinedPath || sandboxPath,
     quarantinedPath ? "" : state.instanceID,
+    state.sandboxRoot,
+    cleanupIdentity,
   );
 }
 
 async function detachOwnedSandboxes(state) {
   state.disposed = true;
-  const sandboxPaths = [...new Set(state.ownedSandboxes.values())];
+  const sandboxes = [...state.ownedSandboxes.entries()].map(([sessionID, sandboxPath]) => ({
+    sandboxPath,
+    sandboxIdentity: state.ownedSandboxIdentities.get(sessionID),
+  }));
+  const sandboxPaths = [...new Set(sandboxes.map(({ sandboxPath }) => sandboxPath))];
   for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
+  state.ownedSandboxIdentities.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
   const cleanupTargets = await Promise.all(
-    sandboxPaths.map(async (sandboxPath) => {
-      const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+    sandboxes.map(async ({ sandboxPath, sandboxIdentity }) => {
+      if (!state.sandboxRoot || !sandboxIdentity) return null;
+      const quarantinedPath = await quarantineOwnedSandbox(
+        sandboxPath,
+        state.instanceID,
+        state.sandboxRoot,
+        sandboxIdentity,
+      );
       return {
         path: quarantinedPath || sandboxPath,
         expectedInstanceID: quarantinedPath ? "" : state.instanceID,
+        identity: quarantinedPath
+          ? relocatedSandboxIdentity(sandboxIdentity, quarantinedPath)
+          : sandboxIdentity,
       };
     }),
   );
   await Promise.all(
-    cleanupTargets.map(({ path: sandboxPath, expectedInstanceID }) =>
-      detachManagedSandbox(sandboxPath, expectedInstanceID),
+    cleanupTargets.filter(Boolean).map(({ path: sandboxPath, expectedInstanceID, identity }) =>
+      detachManagedSandbox(
+        sandboxPath,
+        expectedInstanceID,
+        state.sandboxRoot,
+        identity,
+      ),
     ),
   );
 }
 
-async function sweepStaleSandboxes(sandboxRoot) {
+async function sweepStaleSandboxes(sandboxRootIdentity) {
   let entries;
   try {
-    entries = await fs.promises.readdir(sandboxRoot, { withFileTypes: true });
+    revalidateSandboxDirectory(sandboxRootIdentity);
+    entries = await fs.promises.readdir(sandboxRootIdentity.path, {
+      withFileTypes: true,
+    });
   } catch {
     return;
   }
@@ -710,7 +1086,12 @@ async function sweepStaleSandboxes(sandboxRoot) {
       const isQuarantine = XCODE_SANDBOX_QUARANTINE_RE.test(entry.name);
       if (!entry.isDirectory() || (!SAFE_ID_RE.test(entry.name) && !isQuarantine)) return;
 
-      const sandboxPath = path.join(sandboxRoot, entry.name);
+      const sandboxPath = path.join(sandboxRootIdentity.path, entry.name);
+      const sandboxIdentity = secureExistingManagedSandbox(
+        sandboxPath,
+        sandboxRootIdentity,
+      );
+      if (!sandboxIdentity) return;
       const owner = await readSandboxOwner(sandboxPath);
       const cleanupPending = owner?.cleanupPending || sandboxCleanupIsPending(sandboxPath);
       if (!owner || cleanupPending) {
@@ -718,7 +1099,11 @@ async function sweepStaleSandboxes(sandboxRoot) {
           return;
         }
 
-        const ownerLock = acquireSandboxOwnerLock(sandboxPath);
+        const ownerLock = acquireSandboxOwnerLock(
+          sandboxPath,
+          sandboxRootIdentity,
+          sandboxIdentity,
+        );
         if (!ownerLock) return;
         let releaseLock = ownerLock;
         try {
@@ -732,10 +1117,20 @@ async function sweepStaleSandboxes(sandboxRoot) {
             (!currentOwner || currentCleanupPending) &&
             sandboxOwnerLockIsHeld(ownerLock)
           ) {
-            const quarantined = await quarantineManagedSandbox(sandboxPath, ownerLock);
+            const quarantined = await quarantineManagedSandbox(
+              sandboxPath,
+              ownerLock,
+              sandboxRootIdentity,
+              sandboxIdentity,
+            );
             releaseLock = quarantined.ownerLock;
             if (quarantined.path) {
-              await removeManagedSandbox(quarantined.path);
+              await removeManagedSandbox(
+                quarantined.path,
+                "",
+                sandboxRootIdentity,
+                relocatedSandboxIdentity(sandboxIdentity, quarantined.path),
+              );
             }
           }
         } finally {
@@ -745,7 +1140,12 @@ async function sweepStaleSandboxes(sandboxRoot) {
       }
       if (await sandboxOwnerIsActive(owner)) return;
 
-      await removeManagedSandbox(sandboxPath);
+      await removeManagedSandbox(
+        sandboxPath,
+        "",
+        sandboxRootIdentity,
+        sandboxIdentity,
+      );
     }),
   );
 }
@@ -804,9 +1204,11 @@ async function sandboxOwnerIsActive(owner) {
 function readProcessStartToken(pid) {
   return new Promise((resolve) => {
     let settled = false;
+    let timedOut = false;
     let stdout = "";
     let child;
-    let timer;
+    let timeoutTimer;
+    let forceKillTimer;
 
     try {
       child = spawn("/bin/ps", ["-p", String(pid), "-o", "lstart="], {
@@ -823,37 +1225,61 @@ function readProcessStartToken(pid) {
       return;
     }
 
-    child.stdout?.setEncoding?.("utf8");
-    child.stdout?.on?.("data", (chunk) => {
+    const onData = (chunk) => {
       const remaining = PROCESS_START_OUTPUT_MAX_CHARS - stdout.length;
       if (remaining > 0) stdout += String(chunk).slice(0, remaining);
-    });
-    child.on("error", () => finish(""));
-    child.on("close", (code) => {
+    };
+    const onError = () => finish("");
+    const onClose = (code) => {
       const firstLine = stdout.trim().split(/\r?\n/, 1)[0] ?? "";
-      finish(code === 0 ? firstLine : "");
-    });
-    timer = setTimeout(() => {
-      try {
-        child.kill?.("SIGTERM");
-      } catch {
-        // Resolving the hook is more important than terminating a broken ps shim.
-      }
-      finish("");
+      finish(!timedOut && code === 0 ? firstLine : "");
+    };
+
+    child.stdout?.setEncoding?.("utf8");
+    child.stdout?.on?.("data", onData);
+    child.on("error", onError);
+    child.on("close", onClose);
+    timeoutTimer = setTimeout(() => {
+      if (settled) return;
+      timedOut = true;
+      forceKillTimer = terminateChildAfterGrace(
+        child,
+        () => !settled,
+        () => finish(""),
+      );
     }, PROCESS_START_TIMEOUT_MS);
 
     function finish(value) {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      clearTimeout(timeoutTimer);
+      clearTimeout(forceKillTimer);
+      child.stdout?.removeListener?.("data", onData);
+      child.removeListener?.("error", onError);
+      child.removeListener?.("close", onClose);
       resolve(value);
     }
   });
 }
 
-async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
+async function removeManagedSandbox(
+  sandboxPath,
+  expectedInstanceID = "",
+  sandboxRootIdentity = null,
+  expectedSandboxIdentity = null,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
   if (!candidate) return false;
+  if (
+    !sandboxRootIdentity ||
+    !secureExistingManagedSandbox(
+      candidate,
+      sandboxRootIdentity,
+      expectedSandboxIdentity,
+    )
+  ) {
+    return false;
+  }
 
   if (expectedInstanceID) {
     const owner = await readSandboxOwner(candidate);
@@ -870,11 +1296,26 @@ async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
   }
 }
 
-async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
+async function quarantineOwnedSandbox(
+  sandboxPath,
+  expectedInstanceID,
+  sandboxRootIdentity,
+  expectedSandboxIdentity,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
   if (!candidate) return "";
+  const sandboxIdentity = secureExistingManagedSandbox(
+    candidate,
+    sandboxRootIdentity,
+    expectedSandboxIdentity,
+  );
+  if (!sandboxIdentity) return "";
 
-  const ownerLock = acquireSandboxOwnerLock(candidate);
+  const ownerLock = acquireSandboxOwnerLock(
+    candidate,
+    sandboxRootIdentity,
+    sandboxIdentity,
+  );
   if (!ownerLock) return "";
   let releaseLock = ownerLock;
 
@@ -896,7 +1337,21 @@ async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
     releaseLock = {
       ...ownerLock,
       path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+      sandboxIdentity: relocatedSandboxIdentity(sandboxIdentity, quarantinePath),
     };
+    if (
+      !secureExistingManagedSandbox(
+        quarantinePath,
+        sandboxRootIdentity,
+        releaseLock.sandboxIdentity,
+      )
+    ) {
+      if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+        movePendingSandboxCleanup(quarantinePath, candidate);
+        releaseLock = ownerLock;
+      }
+      return "";
+    }
     const relocatedOwner = await readSandboxOwner(quarantinePath);
     if (
       !sandboxOwnerLockIsHeld(releaseLock) ||
@@ -906,7 +1361,7 @@ async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
     ) {
       if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
         movePendingSandboxCleanup(quarantinePath, candidate);
-        releaseLock = { ...releaseLock, path: ownerLock.path };
+        releaseLock = ownerLock;
       }
       return "";
     }
@@ -925,9 +1380,21 @@ async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
   }
 }
 
-async function quarantineManagedSandbox(sandboxPath, ownerLock) {
+async function quarantineManagedSandbox(
+  sandboxPath,
+  ownerLock,
+  sandboxRootIdentity,
+  expectedSandboxIdentity,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
-  if (!candidate || !sandboxOwnerLockIsHeld(ownerLock)) {
+  const sandboxIdentity = candidate
+    ? secureExistingManagedSandbox(
+        candidate,
+        sandboxRootIdentity,
+        expectedSandboxIdentity,
+      )
+    : null;
+  if (!candidate || !sandboxIdentity || !sandboxOwnerLockIsHeld(ownerLock)) {
     return { path: "", ownerLock };
   }
 
@@ -944,7 +1411,21 @@ async function quarantineManagedSandbox(sandboxPath, ownerLock) {
   const relocatedLock = {
     ...ownerLock,
     path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+    sandboxIdentity: relocatedSandboxIdentity(sandboxIdentity, quarantinePath),
   };
+  if (
+    !secureExistingManagedSandbox(
+      quarantinePath,
+      sandboxRootIdentity,
+      relocatedLock.sandboxIdentity,
+    )
+  ) {
+    if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+      movePendingSandboxCleanup(quarantinePath, candidate);
+      return { path: "", ownerLock };
+    }
+    return { path: "", ownerLock: relocatedLock };
+  }
   const publishedOwner = await readSandboxOwner(quarantinePath);
   const cleanupPending =
     publishedOwner?.cleanupPending || sandboxCleanupIsPending(quarantinePath);
@@ -972,9 +1453,24 @@ function restoreQuarantinedSandbox(quarantinePath, originalPath) {
   }
 }
 
-async function detachManagedSandbox(sandboxPath, expectedInstanceID = "") {
+async function detachManagedSandbox(
+  sandboxPath,
+  expectedInstanceID = "",
+  sandboxRootIdentity = null,
+  expectedSandboxIdentity = null,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
   if (!candidate) return;
+  if (
+    !sandboxRootIdentity ||
+    !secureExistingManagedSandbox(
+      candidate,
+      sandboxRootIdentity,
+      expectedSandboxIdentity,
+    )
+  ) {
+    return;
+  }
 
   if (expectedInstanceID) {
     const owner = await readSandboxOwner(candidate);
@@ -1002,6 +1498,49 @@ function managedSandboxCandidate(sandboxPath) {
   const relative = path.relative(sandboxRoot, candidate);
   if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return "";
   return candidate;
+}
+
+function secureExistingManagedSandbox(
+  sandboxPath,
+  sandboxRootIdentity,
+  expectedSandboxIdentity = null,
+) {
+  try {
+    revalidateSandboxDirectory(sandboxRootIdentity);
+    const candidate = managedSandboxCandidate(sandboxPath);
+    if (!candidate || path.dirname(candidate) !== sandboxRootIdentity.path) return null;
+
+    const name = path.basename(candidate);
+    if (!SAFE_ID_RE.test(name) && !XCODE_SANDBOX_QUARANTINE_RE.test(name)) {
+      return null;
+    }
+
+    const current = inspectSandboxDirectory(
+      candidate,
+      path.join(sandboxRootIdentity.canonicalPath, name),
+      sandboxRootIdentity,
+    );
+    if (
+      expectedSandboxIdentity &&
+      (current.dev !== expectedSandboxIdentity.dev ||
+        current.ino !== expectedSandboxIdentity.ino ||
+        current.uid !== expectedSandboxIdentity.uid)
+    ) {
+      return null;
+    }
+    return current;
+  } catch {
+    return null;
+  }
+}
+
+function relocatedSandboxIdentity(identity, destinationPath) {
+  const name = path.basename(destinationPath);
+  return {
+    ...identity,
+    path: path.resolve(destinationPath),
+    canonicalPath: path.join(identity.parent.canonicalPath, name),
+  };
 }
 
 function markPendingSandboxCleanup(sandboxPath) {

--- a/common/opencode-plugin.js
+++ b/common/opencode-plugin.js
@@ -1,52 +1,70 @@
 import { spawn } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const XCODE_MCP_CACHE_TTL_MS = 30_000;
+const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
 
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
-  const state = {
-    pluginJson: null,
-    infoJson: null,
-    deniedOnce: new Set(),
-    xcodeMcpLikely: undefined,
-    xcodeMcpApprovalStarted: false,
+  return async () => {
+    const state = {
+      pluginJson: null,
+      infoJson: null,
+      config: null,
+      instanceID: randomUUID(),
+      processStartToken: null,
+      deniedOnce: new Set(),
+      xcodeMcpCache: new Map(),
+      xcodeMcpApprovalSessions: new Set(),
+      ownedSandboxes: new Map(),
+      sandboxSweepDone: false,
+    };
+
+    return {
+      config: async (config) => {
+        loadMetadata(pluginRoot, state);
+        registerSkills(config, pluginRoot);
+        registerMcpServers(config, pluginRoot);
+        state.config = config;
+      },
+
+      "experimental.chat.system.transform": async (input, output) => {
+        try {
+          loadMetadata(pluginRoot, state);
+          await appendSystemContext(pluginRoot, state, input, output);
+        } catch {
+          // Fail open. Plugin context should never block a chat request.
+        }
+      },
+
+      "tool.execute.before": async (input, output) => {
+        loadMetadata(pluginRoot, state);
+        applyPreToolUseRules(state, input, output);
+      },
+
+      "shell.env": async (input, output) => {
+        try {
+          loadMetadata(pluginRoot, state);
+          await configureShellEnvironment(pluginRoot, state, input, output);
+        } catch {
+          // Fail open. Shell commands should still run if setup is unavailable.
+        }
+      },
+
+      event: async ({ event }) => {
+        await handlePluginEvent(state, event);
+      },
+
+      dispose: async () => {
+        await removeOwnedSandboxes(state);
+      },
+    };
   };
-
-  return async () => ({
-    config: async (config) => {
-      loadMetadata(pluginRoot, state);
-      registerSkills(config, pluginRoot);
-      registerMcpServers(config, pluginRoot);
-    },
-
-    "experimental.chat.system.transform": async (_input, output) => {
-      try {
-        loadMetadata(pluginRoot, state);
-        await appendSystemContext(pluginRoot, state, output);
-      } catch {
-        // Fail open. Plugin context should never block a chat request.
-      }
-    },
-
-    "tool.execute.before": async (input, output) => {
-      loadMetadata(pluginRoot, state);
-      applyPreToolUseRules(state, input, output);
-    },
-
-    "shell.env": async (input, output) => {
-      try {
-        loadMetadata(pluginRoot, state);
-        configureShellEnvironment(pluginRoot, state, input, output);
-      } catch {
-        // Fail open. Shell commands should still run if setup is unavailable.
-      }
-    },
-  });
 }
 
 function normalizePluginRoot(pluginRootUrl) {
@@ -143,13 +161,14 @@ function copyOptionalFields(source, target, keys) {
   }
 }
 
-async function appendSystemContext(pluginRoot, state, output) {
+async function appendSystemContext(pluginRoot, state, input, output) {
   if (!Array.isArray(output.system)) output.system = [];
 
   const pluginName = state.pluginJson.name ?? path.basename(pluginRoot);
   const welcomeMessage = typeof state.infoJson.welcomeMessage === "string" ? state.infoJson.welcomeMessage : "";
-  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state);
-  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state);
+  const sessionID = safeSessionID(input?.sessionID ?? "global");
+  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state, sessionID);
+  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state, sessionID);
   const sessionStart = renderSessionStart(pluginRoot, xcodeMcpLikely);
 
   let systemMessage = `The ${pluginName} plugin is loaded and ready.`;
@@ -180,31 +199,56 @@ function processConditionalBlocks(content, xcodeMcpLikely) {
     .replace(/<!-- IF_XCODE_MCP -->[\s\S]*?<!-- END_XCODE_MCP -->\n?/g, "");
 }
 
-async function getXcodeMcpLikely(pluginName, state) {
+async function getXcodeMcpLikely(pluginName, state, sessionID) {
   if (pluginName !== "XcodeBuildTools") return false;
-  if (state.xcodeMcpLikely !== undefined) return state.xcodeMcpLikely;
+  if (!hasConfiguredMcpbridge(state.config)) {
+    state.xcodeMcpCache.delete(sessionID);
+    return false;
+  }
+
+  const now = Date.now();
+  const cached = state.xcodeMcpCache.get(sessionID);
+  if (cached && now - cached.checkedAt < XCODE_MCP_CACHE_TTL_MS) return cached.value;
 
   const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
   if (!installed) {
-    state.xcodeMcpLikely = false;
-    return state.xcodeMcpLikely;
+    state.xcodeMcpCache.set(sessionID, { checkedAt: now, value: false });
+    return false;
   }
 
   const xcodeRunning = await commandSucceeds("pgrep", ["-x", "Xcode"], 3000);
   const bridgeRunning = await commandSucceeds("pgrep", ["-f", "mcpbridge"], 3000);
-  state.xcodeMcpLikely = xcodeRunning || bridgeRunning;
-  return state.xcodeMcpLikely;
+  const value = xcodeRunning || bridgeRunning;
+  state.xcodeMcpCache.set(sessionID, { checkedAt: now, value });
+  return value;
 }
 
-function startXcodeMcpApproval(pluginRoot, state) {
-  if (state.xcodeMcpApprovalStarted) return;
-  state.xcodeMcpApprovalStarted = true;
+function hasConfiguredMcpbridge(config) {
+  if (!isObject(config?.mcp)) return false;
+
+  return Object.values(config.mcp).some((server) => {
+    if (!isObject(server) || server.enabled === false || server.type !== "local") return false;
+
+    const command = Array.isArray(server.command) ? server.command : [server.command];
+    return command.some((part) => {
+      if (typeof part !== "string") return false;
+      return part
+        .trim()
+        .split(/\s+/)
+        .some((token) => path.basename(token.replace(/^['"]|['"]$/g, "")) === "mcpbridge");
+    });
+  });
+}
+
+function startXcodeMcpApproval(pluginRoot, state, sessionID) {
+  if (state.xcodeMcpApprovalSessions.has(sessionID)) return;
 
   const runner = path.join(pluginRoot, "hooks", "run-background.sh");
   const target = path.join("hooks", "approve-xcode-mcp.sh");
   if (!fs.existsSync(runner)) return;
 
   try {
+    state.xcodeMcpApprovalSessions.add(sessionID);
     const child = spawn(runner, [target], {
       cwd: pluginRoot,
       detached: true,
@@ -215,9 +259,10 @@ function startXcodeMcpApproval(pluginRoot, state) {
       },
       stdio: "ignore",
     });
-    child.on("error", () => {});
+    child.on("error", () => state.xcodeMcpApprovalSessions.delete(sessionID));
     child.unref();
   } catch {
+    state.xcodeMcpApprovalSessions.delete(sessionID);
     // Auto-approval is best-effort; users can still approve Xcode manually.
   }
 }
@@ -278,7 +323,7 @@ function applyPreToolUseRules(state, input, output) {
   }
 }
 
-function configureShellEnvironment(pluginRoot, state, input, output) {
+async function configureShellEnvironment(pluginRoot, state, input, output) {
   if (!isObject(output.env)) output.env = {};
 
   const binDir = path.join(pluginRoot, "bin");
@@ -289,7 +334,23 @@ function configureShellEnvironment(pluginRoot, state, input, output) {
   if (state.pluginJson.name !== "XcodeBuildTools") return;
 
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
-  const sandboxBase = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox", sessionID);
+  const sandboxRoot = path.join(os.tmpdir(), XCODE_SANDBOX_DIR);
+  // Plugin instances never reuse a sandbox path, so an older instance cannot
+  // delete a replacement instance's active sandbox after an ownership check.
+  const sandboxBase = path.join(sandboxRoot, `${sessionID}-${state.instanceID}`);
+  state.ownedSandboxes.set(sessionID, sandboxBase);
+
+  if (!state.processStartToken) {
+    state.processStartToken = await readProcessStartToken(process.pid);
+  }
+  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+
+  if (!state.sandboxSweepDone) {
+    await sweepStaleSandboxes(sandboxRoot);
+    state.sandboxSweepDone = true;
+  }
+  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+
   const buildDir = path.join(sandboxBase, "build");
   const packagesDir = path.join(sandboxBase, "packages");
 
@@ -297,12 +358,153 @@ function configureShellEnvironment(pluginRoot, state, input, output) {
   fs.mkdirSync(packagesDir, { recursive: true });
   fs.writeFileSync(
     path.join(sandboxBase, "owner.pid"),
-    `${process.pid}\n${process.argv[0] ?? "opencode"}\n`,
+    `${process.pid}\n${process.argv[0] ?? "opencode"}\n${state.processStartToken}\n${state.instanceID}\n`,
     "utf8",
   );
 
   output.env.SANDBOX_DERIVED_DATA = buildDir;
   output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+async function handlePluginEvent(state, event) {
+  if (event?.type !== "session.deleted") return;
+
+  const sessionID = event.properties?.info?.id;
+  if (typeof sessionID !== "string" || !sessionID) return;
+
+  const safeID = safeSessionID(sessionID);
+  state.xcodeMcpCache.delete(safeID);
+  state.xcodeMcpApprovalSessions.delete(safeID);
+  await removeOwnedSandbox(state, safeID);
+}
+
+async function removeOwnedSandbox(state, sessionID) {
+  const sandboxPath = state.ownedSandboxes.get(sessionID);
+  if (!sandboxPath) return;
+
+  state.ownedSandboxes.delete(sessionID);
+  await removeManagedSandbox(sandboxPath, state.instanceID);
+}
+
+async function removeOwnedSandboxes(state) {
+  const sandboxPaths = [...new Set(state.ownedSandboxes.values())];
+  state.ownedSandboxes.clear();
+  state.xcodeMcpCache.clear();
+  state.xcodeMcpApprovalSessions.clear();
+  await Promise.all(sandboxPaths.map((sandboxPath) => removeManagedSandbox(sandboxPath, state.instanceID)));
+}
+
+async function sweepStaleSandboxes(sandboxRoot) {
+  let entries;
+  try {
+    entries = await fs.promises.readdir(sandboxRoot, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.isDirectory() || !SAFE_ID_RE.test(entry.name)) return;
+
+      const sandboxPath = path.join(sandboxRoot, entry.name);
+      const owner = await readSandboxOwner(sandboxPath);
+      if (!owner || (await sandboxOwnerIsActive(owner))) return;
+
+      await removeManagedSandbox(sandboxPath);
+    }),
+  );
+}
+
+async function readSandboxOwner(sandboxPath) {
+  try {
+    const content = await fs.promises.readFile(path.join(sandboxPath, "owner.pid"), "utf8");
+    const lines = content.split(/\r?\n/);
+    const firstLine = lines[0];
+    if (!/^\d+$/.test(firstLine)) return null;
+
+    const pid = Number(firstLine);
+    if (!Number.isSafeInteger(pid) || pid <= 0) return null;
+
+    return {
+      pid,
+      processStartToken: lines[2] ?? "",
+      instanceID: lines[3] ?? "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+async function sandboxOwnerIsActive(owner) {
+  if (!processExists(owner.pid)) return false;
+  if (!owner.processStartToken) return true;
+
+  const currentStartToken = await readProcessStartToken(owner.pid);
+  if (!currentStartToken) return true;
+  return currentStartToken === owner.processStartToken;
+}
+
+function readProcessStartToken(pid) {
+  return new Promise((resolve) => {
+    let settled = false;
+    let stdout = "";
+    let child;
+
+    try {
+      child = spawn("ps", ["-p", String(pid), "-o", "lstart="], {
+        env: {
+          ...process.env,
+          LC_ALL: "C",
+          LANG: "C",
+          TZ: "UTC",
+        },
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+    } catch {
+      resolve("");
+      return;
+    }
+
+    child.stdout?.setEncoding?.("utf8");
+    child.stdout?.on?.("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.on("error", () => finish(""));
+    child.on("close", (code) => finish(code === 0 ? stdout.trim() : ""));
+
+    function finish(value) {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    }
+  });
+}
+
+async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
+  const sandboxRoot = path.resolve(os.tmpdir(), XCODE_SANDBOX_DIR);
+  const candidate = path.resolve(sandboxPath);
+  const relative = path.relative(sandboxRoot, candidate);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return;
+
+  if (expectedInstanceID) {
+    const owner = await readSandboxOwner(candidate);
+    if (!owner || owner.instanceID !== expectedInstanceID) return;
+  }
+
+  try {
+    await fs.promises.rm(candidate, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  } catch {
+    // Best-effort cleanup; the next plugin instance will retry through the stale-owner sweep.
+  }
 }
 
 function prependPath(entry, current) {

--- a/common/opencode-plugin.js
+++ b/common/opencode-plugin.js
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const MCP_PLACEHOLDER_RE = /\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}/g;
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const PROCESS_START_OUTPUT_MAX_CHARS = 256;
 const PROCESS_START_TIMEOUT_MS = 5_000;
@@ -26,7 +27,11 @@ globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] = pendingSandboxCleanups;
 
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
-  return async () => {
+  return async (input = {}) => {
+    const mcpContext = {
+      pluginRoot,
+      projectDir: input?.worktree || input?.directory,
+    };
     const state = {
       pluginJson: null,
       infoJson: null,
@@ -46,7 +51,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       config: async (config) => {
         loadMetadata(pluginRoot, state);
         registerSkills(config, pluginRoot);
-        registerMcpServers(config, pluginRoot);
+        registerMcpServers(config, pluginRoot, mcpContext);
         state.config = config;
       },
 
@@ -114,7 +119,7 @@ function registerSkills(config, pluginRoot) {
   if (!config.skills.paths.includes(skillsDir)) config.skills.paths.push(skillsDir);
 }
 
-function registerMcpServers(config, pluginRoot) {
+function registerMcpServers(config, pluginRoot, context) {
   const mcpConfig = readJsonFile(path.join(pluginRoot, ".mcp.json"));
   const servers = mcpConfig?.mcpServers;
   if (!isObject(servers)) return;
@@ -124,58 +129,117 @@ function registerMcpServers(config, pluginRoot) {
   for (const [name, server] of Object.entries(servers)) {
     if (!isObject(server) || config.mcp[name]) continue;
 
-    const translated = translateMcpServer(server);
+    const translated = translateMcpServer(server, context);
     if (translated) config.mcp[name] = translated;
   }
 }
 
-function translateMcpServer(server) {
+function translateMcpServer(server, context) {
   if (typeof server.url === "string") {
     const translated = {
       type: "remote",
-      url: server.url,
+      url: expandMcpString(server.url, context),
     };
-    copyOptionalFields(server, translated, ["enabled", "headers", "timeout"]);
+    copyOptionalFields(server, translated, ["enabled", "headers", "timeout"], context);
+    const oauth = translateMcpOAuth(server.oauth);
+    if (oauth !== undefined) translated.oauth = oauth;
     return translated;
   }
 
-  const command = normalizeCommand(server.command, server.args);
+  const command = normalizeCommand(server.command, server.args, context);
   if (!command) return null;
 
   const translated = {
     type: "local",
     command,
   };
-  copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"]);
+  copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"], context);
 
   const environment = isObject(server.environment) ? server.environment : server.env;
-  if (isObject(environment)) translated.environment = stringifyRecord(environment);
+  if (isObject(environment)) translated.environment = expandMcpRecord(environment, context);
 
   return translated;
 }
 
-function normalizeCommand(command, args) {
+function translateMcpOAuth(oauth) {
+  if (oauth === false) return false;
+  if (!isObject(oauth)) return undefined;
+
+  const translated = {};
+  for (const key of ["clientId", "clientSecret", "redirectUri"]) {
+    if (typeof oauth[key] === "string") translated[key] = oauth[key];
+  }
+
+  if (
+    Number.isInteger(oauth.callbackPort) &&
+    oauth.callbackPort >= 1 &&
+    oauth.callbackPort <= 65_535
+  ) {
+    translated.callbackPort = oauth.callbackPort;
+  }
+
+  if (typeof oauth.scopes === "string") {
+    translated.scope = oauth.scopes;
+  } else if (typeof oauth.scope === "string") {
+    translated.scope = oauth.scope;
+  }
+
+  return translated;
+}
+
+function normalizeCommand(command, args, context) {
   if (Array.isArray(command) && command.every((item) => typeof item === "string")) {
-    return command;
+    return command.map((item) => expandMcpString(item, context));
   }
 
   if (typeof command !== "string") return null;
 
-  const result = [command];
   if (Array.isArray(args)) {
-    for (const arg of args) {
-      if (typeof arg !== "string") return null;
-      result.push(arg);
-    }
+    if (!args.every((arg) => typeof arg === "string")) return null;
+    return [command, ...args].map((item) => expandMcpString(item, context));
   }
-  return result;
+  return [expandMcpString(command, context)];
 }
 
-function copyOptionalFields(source, target, keys) {
+function copyOptionalFields(source, target, keys, context) {
   for (const key of keys) {
     if (source[key] === undefined) continue;
-    target[key] = key === "headers" && isObject(source[key]) ? stringifyRecord(source[key]) : source[key];
+    if (key === "headers" && isObject(source[key])) {
+      target[key] = expandMcpRecord(source[key], context);
+    } else if (key === "cwd" && typeof source[key] === "string") {
+      target[key] = expandMcpString(source[key], context);
+    } else {
+      target[key] = source[key];
+    }
   }
+}
+
+function expandMcpRecord(value, context) {
+  return Object.fromEntries(
+    Object.entries(stringifyRecord(value)).map(([key, item]) => [
+      key,
+      expandMcpString(item, context),
+    ]),
+  );
+}
+
+function expandMcpString(value, context) {
+  return value.replace(MCP_PLACEHOLDER_RE, (_, name, defaultValue) => {
+    const resolved = mcpVariable(name, context);
+    if (defaultValue !== undefined && (resolved === undefined || resolved === "")) {
+      return defaultValue;
+    }
+    if (resolved === undefined) {
+      throw new Error(`MCP configuration references unset variable: ${name}`);
+    }
+    return resolved;
+  });
+}
+
+function mcpVariable(name, context) {
+  if (name === "CLAUDE_PLUGIN_ROOT") return context.pluginRoot;
+  if (name === "CLAUDE_PROJECT_DIR") return context.projectDir;
+  return process.env[name];
 }
 
 async function appendSystemContext(pluginRoot, state, input, output) {

--- a/common/opencode-plugin.js
+++ b/common/opencode-plugin.js
@@ -1,0 +1,360 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+export function createOpenCodePlugin(pluginRootUrl) {
+  const pluginRoot = normalizePluginRoot(pluginRootUrl);
+  const state = {
+    pluginJson: null,
+    infoJson: null,
+    deniedOnce: new Set(),
+    xcodeMcpLikely: undefined,
+    xcodeMcpApprovalStarted: false,
+  };
+
+  return async () => ({
+    config: async (config) => {
+      loadMetadata(pluginRoot, state);
+      registerSkills(config, pluginRoot);
+      registerMcpServers(config, pluginRoot);
+    },
+
+    "experimental.chat.system.transform": async (_input, output) => {
+      try {
+        loadMetadata(pluginRoot, state);
+        await appendSystemContext(pluginRoot, state, output);
+      } catch {
+        // Fail open. Plugin context should never block a chat request.
+      }
+    },
+
+    "tool.execute.before": async (input, output) => {
+      loadMetadata(pluginRoot, state);
+      applyPreToolUseRules(state, input, output);
+    },
+
+    "shell.env": async (input, output) => {
+      try {
+        loadMetadata(pluginRoot, state);
+        configureShellEnvironment(pluginRoot, state, input, output);
+      } catch {
+        // Fail open. Shell commands should still run if setup is unavailable.
+      }
+    },
+  });
+}
+
+function normalizePluginRoot(pluginRootUrl) {
+  if (pluginRootUrl instanceof URL) {
+    return path.resolve(fileURLToPath(pluginRootUrl));
+  }
+
+  if (typeof pluginRootUrl === "string" && pluginRootUrl.startsWith("file:")) {
+    return path.resolve(fileURLToPath(pluginRootUrl));
+  }
+
+  return path.resolve(String(pluginRootUrl));
+}
+
+function loadMetadata(pluginRoot, state) {
+  if (!state.pluginJson) {
+    state.pluginJson = readJsonFile(path.join(pluginRoot, ".claude-plugin", "plugin.json")) ?? {};
+  }
+  if (!state.infoJson) {
+    state.infoJson = readJsonFile(path.join(pluginRoot, "info.json")) ?? {};
+  }
+}
+
+function registerSkills(config, pluginRoot) {
+  const skillsDir = path.join(pluginRoot, "skills");
+  if (!hasSkillDirectories(skillsDir)) return;
+
+  if (!isObject(config.skills)) config.skills = {};
+  if (!Array.isArray(config.skills.paths)) config.skills.paths = [];
+  if (!config.skills.paths.includes(skillsDir)) config.skills.paths.push(skillsDir);
+}
+
+function registerMcpServers(config, pluginRoot) {
+  const mcpConfig = readJsonFile(path.join(pluginRoot, ".mcp.json"));
+  const servers = mcpConfig?.mcpServers;
+  if (!isObject(servers)) return;
+
+  if (!isObject(config.mcp)) config.mcp = {};
+
+  for (const [name, server] of Object.entries(servers)) {
+    if (!isObject(server) || config.mcp[name]) continue;
+
+    const translated = translateMcpServer(server);
+    if (translated) config.mcp[name] = translated;
+  }
+}
+
+function translateMcpServer(server) {
+  if (typeof server.url === "string") {
+    const translated = {
+      type: "remote",
+      url: server.url,
+    };
+    copyOptionalFields(server, translated, ["enabled", "headers", "timeout"]);
+    return translated;
+  }
+
+  const command = normalizeCommand(server.command, server.args);
+  if (!command) return null;
+
+  const translated = {
+    type: "local",
+    command,
+  };
+  copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"]);
+
+  const environment = isObject(server.environment) ? server.environment : server.env;
+  if (isObject(environment)) translated.environment = stringifyRecord(environment);
+
+  return translated;
+}
+
+function normalizeCommand(command, args) {
+  if (Array.isArray(command) && command.every((item) => typeof item === "string")) {
+    return command;
+  }
+
+  if (typeof command !== "string") return null;
+
+  const result = [command];
+  if (Array.isArray(args)) {
+    for (const arg of args) {
+      if (typeof arg !== "string") return null;
+      result.push(arg);
+    }
+  }
+  return result;
+}
+
+function copyOptionalFields(source, target, keys) {
+  for (const key of keys) {
+    if (source[key] === undefined) continue;
+    target[key] = key === "headers" && isObject(source[key]) ? stringifyRecord(source[key]) : source[key];
+  }
+}
+
+async function appendSystemContext(pluginRoot, state, output) {
+  if (!Array.isArray(output.system)) output.system = [];
+
+  const pluginName = state.pluginJson.name ?? path.basename(pluginRoot);
+  const welcomeMessage = typeof state.infoJson.welcomeMessage === "string" ? state.infoJson.welcomeMessage : "";
+  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state);
+  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state);
+  const sessionStart = renderSessionStart(pluginRoot, xcodeMcpLikely);
+
+  let systemMessage = `The ${pluginName} plugin is loaded and ready.`;
+  if (xcodeMcpLikely) systemMessage += " Xcode MCP server detected.";
+  if (welcomeMessage) systemMessage += ` ${welcomeMessage}`;
+
+  output.system.push([systemMessage, sessionStart].filter(Boolean).join("\n\n"));
+}
+
+function renderSessionStart(pluginRoot, xcodeMcpLikely) {
+  const sessionStartPath = path.join(pluginRoot, "session-start.md");
+  const content = readTextFile(sessionStartPath);
+  if (!content) return "";
+  return processConditionalBlocks(content, xcodeMcpLikely);
+}
+
+function processConditionalBlocks(content, xcodeMcpLikely) {
+  if (xcodeMcpLikely) {
+    return content
+      .replace(/<!-- IF_XCODE_MCP -->\n?/g, "")
+      .replace(/<!-- END_XCODE_MCP -->\n?/g, "")
+      .replace(/<!-- IF_NO_XCODE_MCP -->[\s\S]*?<!-- END_NO_XCODE_MCP -->\n?/g, "");
+  }
+
+  return content
+    .replace(/<!-- IF_NO_XCODE_MCP -->\n?/g, "")
+    .replace(/<!-- END_NO_XCODE_MCP -->\n?/g, "")
+    .replace(/<!-- IF_XCODE_MCP -->[\s\S]*?<!-- END_XCODE_MCP -->\n?/g, "");
+}
+
+async function getXcodeMcpLikely(pluginName, state) {
+  if (pluginName !== "XcodeBuildTools") return false;
+
+  const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
+  if (!installed) {
+    state.xcodeMcpLikely = false;
+    return state.xcodeMcpLikely;
+  }
+
+  const xcodeRunning = await commandSucceeds("pgrep", ["-x", "Xcode"], 3000);
+  const bridgeRunning = await commandSucceeds("pgrep", ["-f", "mcpbridge"], 3000);
+  state.xcodeMcpLikely = xcodeRunning || bridgeRunning;
+  return state.xcodeMcpLikely;
+}
+
+function startXcodeMcpApproval(pluginRoot, state) {
+  if (state.xcodeMcpApprovalStarted) return;
+  state.xcodeMcpApprovalStarted = true;
+
+  const runner = path.join(pluginRoot, "hooks", "run-background.sh");
+  const target = path.join("hooks", "approve-xcode-mcp.sh");
+  if (!fs.existsSync(runner)) return;
+
+  try {
+    const child = spawn(runner, [target], {
+      cwd: pluginRoot,
+      detached: true,
+      env: {
+        ...process.env,
+        CLAUDE_HOOK_OWNER_PID: String(process.pid),
+        CLAUDE_PLUGIN_ROOT: pluginRoot,
+      },
+      stdio: "ignore",
+    });
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+    // Auto-approval is best-effort; users can still approve Xcode manually.
+  }
+}
+
+function commandSucceeds(command, args, timeoutMs) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const child = spawn(command, args, { stdio: "ignore" });
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish(false);
+    }, timeoutMs);
+
+    child.on("error", () => finish(false));
+    child.on("exit", (code) => finish(code === 0));
+
+    function finish(result) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    }
+  });
+}
+
+function applyPreToolUseRules(state, input, output) {
+  const tool = String(input.tool ?? "").toLowerCase();
+  if (tool !== "bash") return;
+
+  const command = output?.args?.command;
+  if (typeof command !== "string" || !command) return;
+
+  const rules = Array.isArray(state.infoJson["pre-tool-use-rules"])
+    ? state.infoJson["pre-tool-use-rules"]
+    : [];
+
+  for (const rule of rules) {
+    if (!isObject(rule)) continue;
+
+    const matchPattern = rule.match;
+    if (typeof matchPattern !== "string" || !regexMatches(matchPattern, command)) continue;
+
+    const notMatchPattern = rule.not_match;
+    if (typeof notMatchPattern === "string" && regexMatches(notMatchPattern, command)) continue;
+
+    const decision = rule.decision ?? "deny";
+    if (decision === "allow") return;
+
+    const message = typeof rule.message === "string" ? rule.message : "Command denied by plugin rule";
+    if (decision === "deny") throw new Error(message);
+
+    const ruleName = typeof rule.name === "string" && rule.name ? rule.name : matchPattern;
+    const key = `${input.sessionID ?? "global"}:${ruleName}`;
+    if (state.deniedOnce.has(key)) continue;
+
+    state.deniedOnce.add(key);
+    throw new Error(message);
+  }
+}
+
+function configureShellEnvironment(pluginRoot, state, input, output) {
+  if (!isObject(output.env)) output.env = {};
+
+  const binDir = path.join(pluginRoot, "bin");
+  if (fs.existsSync(binDir)) {
+    output.env.PATH = prependPath(binDir, output.env.PATH ?? process.env.PATH ?? "");
+  }
+
+  if (state.pluginJson.name !== "XcodeBuildTools") return;
+
+  const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
+  const sandboxBase = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox", sessionID);
+  const buildDir = path.join(sandboxBase, "build");
+  const packagesDir = path.join(sandboxBase, "packages");
+
+  fs.mkdirSync(buildDir, { recursive: true });
+  fs.mkdirSync(packagesDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(sandboxBase, "owner.pid"),
+    `${process.pid}\n${process.argv[0] ?? "opencode"}\n`,
+    "utf8",
+  );
+
+  output.env.SANDBOX_DERIVED_DATA = buildDir;
+  output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+function prependPath(entry, current) {
+  const parts = current.split(path.delimiter).filter(Boolean).filter((part) => part !== entry);
+  return [entry, ...parts].join(path.delimiter);
+}
+
+function safeSessionID(value) {
+  const raw = String(value ?? "");
+  if (SAFE_ID_RE.test(raw)) return raw;
+
+  const hash = createHash("sha256").update(raw || "default").digest("hex").slice(0, 16);
+  return `opencode-${hash}`;
+}
+
+function regexMatches(pattern, value) {
+  try {
+    return new RegExp(pattern).test(value);
+  } catch {
+    return false;
+  }
+}
+
+function hasSkillDirectories(skillsDir) {
+  try {
+    return fs.readdirSync(skillsDir, { withFileTypes: true }).some((entry) => {
+      return entry.isDirectory() && fs.existsSync(path.join(skillsDir, entry.name, "SKILL.md"));
+    });
+  } catch {
+    return false;
+  }
+}
+
+function readJsonFile(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function readTextFile(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function stringifyRecord(value) {
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, String(item)]));
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/common/opencode-plugin.js
+++ b/common/opencode-plugin.js
@@ -6,8 +6,23 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const PROCESS_START_OUTPUT_MAX_CHARS = 256;
+const PROCESS_START_TIMEOUT_MS = 5_000;
 const XCODE_MCP_CACHE_TTL_MS = 30_000;
 const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
+const XCODE_SANDBOX_OWNER_GRACE_MS = 60_000;
+const XCODE_SANDBOX_OWNER_LOCK = ".owner.lock";
+const XCODE_SANDBOX_QUARANTINE_RE =
+  /^\.quarantine-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const XCODE_SANDBOX_PENDING_CLEANUPS_KEY = Symbol.for(
+  "opencode.xcodebuildtools.pending-cleanups",
+);
+const pendingSandboxCleanups =
+  globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] instanceof Set
+    ? globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY]
+    : new Set();
+globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] = pendingSandboxCleanups;
 
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
@@ -22,7 +37,9 @@ export function createOpenCodePlugin(pluginRootUrl) {
       xcodeMcpCache: new Map(),
       xcodeMcpApprovalSessions: new Set(),
       ownedSandboxes: new Map(),
+      deletedSandboxSessions: new Set(),
       sandboxSweepDone: false,
+      disposed: false,
     };
 
     return {
@@ -61,7 +78,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       },
 
       dispose: async () => {
-        await removeOwnedSandboxes(state);
+        await detachOwnedSandboxes(state);
       },
     };
   };
@@ -334,6 +351,7 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   if (state.pluginJson.name !== "XcodeBuildTools") return;
 
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
+  if (state.disposed || state.deletedSandboxSessions.has(sessionID)) return;
   const sandboxRoot = path.join(os.tmpdir(), XCODE_SANDBOX_DIR);
   // Plugin instances never reuse a sandbox path, so an older instance cannot
   // delete a replacement instance's active sandbox after an ownership check.
@@ -343,27 +361,201 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   if (!state.processStartToken) {
     state.processStartToken = await readProcessStartToken(process.pid);
   }
-  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+  if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
 
   if (!state.sandboxSweepDone) {
     await sweepStaleSandboxes(sandboxRoot);
     state.sandboxSweepDone = true;
   }
-  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+  if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
 
   const buildDir = path.join(sandboxBase, "build");
   const packagesDir = path.join(sandboxBase, "packages");
 
   fs.mkdirSync(buildDir, { recursive: true });
   fs.mkdirSync(packagesDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(sandboxBase, "owner.pid"),
-    `${process.pid}\n${process.argv[0] ?? "opencode"}\n${state.processStartToken}\n${state.instanceID}\n`,
-    "utf8",
-  );
+  writeSandboxOwner(sandboxBase, state.processStartToken, state.instanceID);
 
   output.env.SANDBOX_DERIVED_DATA = buildDir;
   output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+function sandboxSetupIsCancelled(state, sessionID, sandboxBase) {
+  return (
+    state.disposed ||
+    state.deletedSandboxSessions.has(sessionID) ||
+    state.ownedSandboxes.get(sessionID) !== sandboxBase
+  );
+}
+
+function writeSandboxOwner(sandboxBase, processStartToken, instanceID) {
+  const ownerPath = path.join(sandboxBase, "owner.pid");
+  const temporaryPath = path.join(sandboxBase, `owner.pid.${instanceID}.tmp`);
+  const content = `${process.pid}\n${process.argv[0] ?? "opencode"}\n${processStartToken}\n${instanceID}\n`;
+  const ownerLock = acquireSandboxOwnerLock(sandboxBase);
+  if (!ownerLock) throw new Error("Sandbox owner is being updated or removed");
+
+  try {
+    fs.writeFileSync(temporaryPath, content, "utf8");
+    if (!sandboxOwnerLockIsHeld(ownerLock)) {
+      throw new Error("Sandbox owner lock changed during update");
+    }
+    fs.renameSync(temporaryPath, ownerPath);
+  } catch (error) {
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch {
+      // The stale-sandbox sweep handles any temporary file left behind.
+    }
+    throw error;
+  } finally {
+    releaseSandboxOwnerLock(ownerLock);
+  }
+}
+
+function markSandboxCleanupPending(sandboxBase, instanceID, ownerLock) {
+  const ownerPath = path.join(sandboxBase, "owner.pid");
+  const temporaryPath = path.join(sandboxBase, `owner.pid.${instanceID}.cleanup.tmp`);
+  const content = `${process.pid}\ncleanup-pending\n\n${instanceID}\ncleanup-pending\n`;
+
+  try {
+    fs.writeFileSync(temporaryPath, content, "utf8");
+    if (!sandboxOwnerLockIsHeld(ownerLock)) return false;
+    fs.renameSync(temporaryPath, ownerPath);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch {
+      // A successful rename removes the temporary path.
+    }
+  }
+}
+
+function acquireSandboxOwnerLock(sandboxBase) {
+  const lockPath = path.join(sandboxBase, XCODE_SANDBOX_OWNER_LOCK);
+  const token = randomUUID();
+  const createdLock = createSandboxOwnerLock(lockPath, token);
+  if (createdLock) return createdLock;
+
+  const observedLock = readSandboxOwnerLock(lockPath);
+  if (!observedLock) return null;
+  if (Date.now() - observedLock.mtimeMs < XCODE_SANDBOX_OWNER_GRACE_MS) return null;
+
+  const claimedPath = `${lockPath}.${token}.stale`;
+  try {
+    fs.renameSync(lockPath, claimedPath);
+  } catch {
+    return null;
+  }
+
+  const claimedLock = readSandboxOwnerLock(claimedPath);
+  if (!sameSandboxOwnerLock(observedLock, claimedLock)) {
+    restoreClaimedSandboxOwnerLock(claimedPath, lockPath);
+    return null;
+  }
+
+  try {
+    fs.unlinkSync(claimedPath);
+  } catch {
+    restoreClaimedSandboxOwnerLock(claimedPath, lockPath);
+    return null;
+  }
+
+  return createSandboxOwnerLock(lockPath, token);
+}
+
+function createSandboxOwnerLock(lockPath, token) {
+  try {
+    fs.writeFileSync(lockPath, `${token}\n`, { encoding: "utf8", flag: "wx" });
+  } catch {
+    return null;
+  }
+
+  const ownerLock = readSandboxOwnerLock(lockPath);
+  if (!ownerLock || ownerLock.token !== token) return null;
+  return ownerLock;
+}
+
+function readSandboxOwnerLock(lockPath) {
+  try {
+    const before = fs.statSync(lockPath);
+    if (!before.isFile()) return null;
+    const beforeToken = fs.readFileSync(lockPath, "utf8").trim();
+    const after = fs.statSync(lockPath);
+    const afterToken = fs.readFileSync(lockPath, "utf8").trim();
+    if (!sameSandboxOwnerLockVersion(before, after) || beforeToken !== afterToken) return null;
+
+    return {
+      path: lockPath,
+      token: afterToken,
+      dev: after.dev,
+      ino: after.ino,
+      mtimeMs: after.mtimeMs,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function sameSandboxOwnerLockVersion(left, right) {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs &&
+    left.ctimeMs === right.ctimeMs
+  );
+}
+
+function sameSandboxOwnerLock(left, right) {
+  return Boolean(
+    left &&
+      right &&
+      left.dev === right.dev &&
+      left.ino === right.ino &&
+      left.token === right.token,
+  );
+}
+
+function sandboxOwnerLockIsHeld(ownerLock) {
+  return sameSandboxOwnerLock(ownerLock, readSandboxOwnerLock(ownerLock.path));
+}
+
+function restoreClaimedSandboxOwnerLock(claimedPath, lockPath) {
+  try {
+    // A hard link restores the claimed inode only when the lock path is still
+    // absent, without overwriting a lock another actor acquired meanwhile.
+    fs.linkSync(claimedPath, lockPath);
+    fs.unlinkSync(claimedPath);
+  } catch {
+    // Leave the uniquely named claim in place if ownership cannot be restored.
+  }
+}
+
+function releaseSandboxOwnerLock(ownerLock) {
+  if (!sandboxOwnerLockIsHeld(ownerLock)) return;
+
+  const claimedPath = `${ownerLock.path}.${randomUUID()}.release`;
+  try {
+    fs.renameSync(ownerLock.path, claimedPath);
+  } catch {
+    return;
+  }
+
+  const claimedLock = readSandboxOwnerLock(claimedPath);
+  if (!sameSandboxOwnerLock(ownerLock, claimedLock)) {
+    restoreClaimedSandboxOwnerLock(claimedPath, ownerLock.path);
+    return;
+  }
+
+  try {
+    fs.unlinkSync(claimedPath);
+  } catch {
+    // The sandbox may already have been removed with the lock inside it.
+  }
 }
 
 async function handlePluginEvent(state, event) {
@@ -373,6 +565,7 @@ async function handlePluginEvent(state, event) {
   if (typeof sessionID !== "string" || !sessionID) return;
 
   const safeID = safeSessionID(sessionID);
+  state.deletedSandboxSessions.add(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
   await removeOwnedSandbox(state, safeID);
@@ -382,16 +575,36 @@ async function removeOwnedSandbox(state, sessionID) {
   const sandboxPath = state.ownedSandboxes.get(sessionID);
   if (!sandboxPath) return;
 
+  markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.delete(sessionID);
-  await removeManagedSandbox(sandboxPath, state.instanceID);
+  const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+  await removeManagedSandbox(
+    quarantinedPath || sandboxPath,
+    quarantinedPath ? "" : state.instanceID,
+  );
 }
 
-async function removeOwnedSandboxes(state) {
+async function detachOwnedSandboxes(state) {
+  state.disposed = true;
   const sandboxPaths = [...new Set(state.ownedSandboxes.values())];
+  for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
-  await Promise.all(sandboxPaths.map((sandboxPath) => removeManagedSandbox(sandboxPath, state.instanceID)));
+  const cleanupTargets = await Promise.all(
+    sandboxPaths.map(async (sandboxPath) => {
+      const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+      return {
+        path: quarantinedPath || sandboxPath,
+        expectedInstanceID: quarantinedPath ? "" : state.instanceID,
+      };
+    }),
+  );
+  await Promise.all(
+    cleanupTargets.map(({ path: sandboxPath, expectedInstanceID }) =>
+      detachManagedSandbox(sandboxPath, expectedInstanceID),
+    ),
+  );
 }
 
 async function sweepStaleSandboxes(sandboxRoot) {
@@ -404,11 +617,43 @@ async function sweepStaleSandboxes(sandboxRoot) {
 
   await Promise.all(
     entries.map(async (entry) => {
-      if (!entry.isDirectory() || !SAFE_ID_RE.test(entry.name)) return;
+      const isQuarantine = XCODE_SANDBOX_QUARANTINE_RE.test(entry.name);
+      if (!entry.isDirectory() || (!SAFE_ID_RE.test(entry.name) && !isQuarantine)) return;
 
       const sandboxPath = path.join(sandboxRoot, entry.name);
       const owner = await readSandboxOwner(sandboxPath);
-      if (!owner || (await sandboxOwnerIsActive(owner))) return;
+      const cleanupPending = owner?.cleanupPending || sandboxCleanupIsPending(sandboxPath);
+      if (!owner || cleanupPending) {
+        if (!cleanupPending && !isQuarantine && !(await sandboxIsPastOwnerGracePeriod(sandboxPath))) {
+          return;
+        }
+
+        const ownerLock = acquireSandboxOwnerLock(sandboxPath);
+        if (!ownerLock) return;
+        let releaseLock = ownerLock;
+        try {
+          // A writer may have published an owner after the initial read or
+          // stale-stat snapshot. Only remove while the publication lock is
+          // held and the marker is still invalid.
+          const currentOwner = await readSandboxOwner(sandboxPath);
+          const currentCleanupPending =
+            currentOwner?.cleanupPending || sandboxCleanupIsPending(sandboxPath);
+          if (
+            (!currentOwner || currentCleanupPending) &&
+            sandboxOwnerLockIsHeld(ownerLock)
+          ) {
+            const quarantined = await quarantineManagedSandbox(sandboxPath, ownerLock);
+            releaseLock = quarantined.ownerLock;
+            if (quarantined.path) {
+              await removeManagedSandbox(quarantined.path);
+            }
+          }
+        } finally {
+          releaseSandboxOwnerLock(releaseLock);
+        }
+        return;
+      }
+      if (await sandboxOwnerIsActive(owner)) return;
 
       await removeManagedSandbox(sandboxPath);
     }),
@@ -425,13 +670,26 @@ async function readSandboxOwner(sandboxPath) {
     const pid = Number(firstLine);
     if (!Number.isSafeInteger(pid) || pid <= 0) return null;
 
+    const instanceID = lines[3] ?? "";
+    if (!UUID_V4_RE.test(instanceID)) return null;
+
     return {
       pid,
       processStartToken: lines[2] ?? "",
-      instanceID: lines[3] ?? "",
+      instanceID,
+      cleanupPending: lines[4] === "cleanup-pending",
     };
   } catch {
     return null;
+  }
+}
+
+async function sandboxIsPastOwnerGracePeriod(sandboxPath) {
+  try {
+    const stat = await fs.promises.stat(sandboxPath);
+    return Date.now() - stat.mtimeMs >= XCODE_SANDBOX_OWNER_GRACE_MS;
+  } catch {
+    return false;
   }
 }
 
@@ -458,9 +716,10 @@ function readProcessStartToken(pid) {
     let settled = false;
     let stdout = "";
     let child;
+    let timer;
 
     try {
-      child = spawn("ps", ["-p", String(pid), "-o", "lstart="], {
+      child = spawn("/bin/ps", ["-p", String(pid), "-o", "lstart="], {
         env: {
           ...process.env,
           LC_ALL: "C",
@@ -476,24 +735,156 @@ function readProcessStartToken(pid) {
 
     child.stdout?.setEncoding?.("utf8");
     child.stdout?.on?.("data", (chunk) => {
-      stdout += chunk;
+      const remaining = PROCESS_START_OUTPUT_MAX_CHARS - stdout.length;
+      if (remaining > 0) stdout += String(chunk).slice(0, remaining);
     });
     child.on("error", () => finish(""));
-    child.on("close", (code) => finish(code === 0 ? stdout.trim() : ""));
+    child.on("close", (code) => {
+      const firstLine = stdout.trim().split(/\r?\n/, 1)[0] ?? "";
+      finish(code === 0 ? firstLine : "");
+    });
+    timer = setTimeout(() => {
+      try {
+        child.kill?.("SIGTERM");
+      } catch {
+        // Resolving the hook is more important than terminating a broken ps shim.
+      }
+      finish("");
+    }, PROCESS_START_TIMEOUT_MS);
 
     function finish(value) {
       if (settled) return;
       settled = true;
+      clearTimeout(timer);
       resolve(value);
     }
   });
 }
 
 async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
-  const sandboxRoot = path.resolve(os.tmpdir(), XCODE_SANDBOX_DIR);
-  const candidate = path.resolve(sandboxPath);
-  const relative = path.relative(sandboxRoot, candidate);
-  if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return;
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate) return false;
+
+  if (expectedInstanceID) {
+    const owner = await readSandboxOwner(candidate);
+    if (!owner || owner.instanceID !== expectedInstanceID) return false;
+  }
+
+  try {
+    await fs.promises.rm(candidate, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    clearPendingSandboxCleanup(candidate);
+    return true;
+  } catch {
+    // Best-effort cleanup; the next plugin instance will retry through the stale-owner sweep.
+    return false;
+  }
+}
+
+async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate) return "";
+
+  const ownerLock = acquireSandboxOwnerLock(candidate);
+  if (!ownerLock) return "";
+  let releaseLock = ownerLock;
+
+  try {
+    const currentOwner = await readSandboxOwner(candidate);
+    if (!currentOwner || currentOwner.instanceID !== expectedInstanceID) return "";
+    if (!markSandboxCleanupPending(candidate, expectedInstanceID, ownerLock)) return "";
+
+    const quarantinePath = path.join(path.dirname(candidate), `.quarantine-${randomUUID()}`);
+    if (!managedSandboxCandidate(quarantinePath)) return "";
+
+    try {
+      fs.renameSync(candidate, quarantinePath);
+      movePendingSandboxCleanup(candidate, quarantinePath);
+    } catch {
+      return "";
+    }
+
+    releaseLock = {
+      ...ownerLock,
+      path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+    };
+    const relocatedOwner = await readSandboxOwner(quarantinePath);
+    if (
+      !sandboxOwnerLockIsHeld(releaseLock) ||
+      !relocatedOwner ||
+      relocatedOwner.instanceID !== expectedInstanceID ||
+      !relocatedOwner.cleanupPending
+    ) {
+      if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+        movePendingSandboxCleanup(quarantinePath, candidate);
+        releaseLock = { ...releaseLock, path: ownerLock.path };
+      }
+      return "";
+    }
+
+    const ownerPath = path.join(quarantinePath, "owner.pid");
+    const retiredOwnerPath = path.join(quarantinePath, `owner.pid.retired-${randomUUID()}`);
+    try {
+      fs.renameSync(ownerPath, retiredOwnerPath);
+    } catch (error) {
+      if (error?.code !== "ENOENT") return quarantinePath;
+    }
+
+    return quarantinePath;
+  } finally {
+    releaseSandboxOwnerLock(releaseLock);
+  }
+}
+
+async function quarantineManagedSandbox(sandboxPath, ownerLock) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate || !sandboxOwnerLockIsHeld(ownerLock)) {
+    return { path: "", ownerLock };
+  }
+
+  const quarantinePath = path.join(path.dirname(candidate), `.quarantine-${randomUUID()}`);
+  if (!managedSandboxCandidate(quarantinePath)) return { path: "", ownerLock };
+
+  try {
+    fs.renameSync(candidate, quarantinePath);
+    movePendingSandboxCleanup(candidate, quarantinePath);
+  } catch {
+    return { path: "", ownerLock };
+  }
+
+  const relocatedLock = {
+    ...ownerLock,
+    path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+  };
+  const publishedOwner = await readSandboxOwner(quarantinePath);
+  const cleanupPending =
+    publishedOwner?.cleanupPending || sandboxCleanupIsPending(quarantinePath);
+  if (
+    !sandboxOwnerLockIsHeld(relocatedLock) ||
+    (publishedOwner && !cleanupPending)
+  ) {
+    if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+      movePendingSandboxCleanup(quarantinePath, candidate);
+      return { path: "", ownerLock };
+    }
+    // Preserve the quarantine when the original path has already been reused.
+    return { path: "", ownerLock: relocatedLock };
+  }
+
+  return { path: quarantinePath, ownerLock: relocatedLock };
+}
+
+function restoreQuarantinedSandbox(quarantinePath, originalPath) {
+  try {
+    fs.renameSync(quarantinePath, originalPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function detachManagedSandbox(sandboxPath, expectedInstanceID = "") {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate) return;
 
   if (expectedInstanceID) {
     const owner = await readSandboxOwner(candidate);
@@ -501,10 +892,48 @@ async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
   }
 
   try {
-    await fs.promises.rm(candidate, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    const child = spawn("/bin/rm", ["-rf", candidate], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.on("error", () => {});
+    child.on("exit", (code) => {
+      if (code === 0) clearPendingSandboxCleanup(candidate);
+    });
+    child.unref();
   } catch {
     // Best-effort cleanup; the next plugin instance will retry through the stale-owner sweep.
   }
+}
+
+function managedSandboxCandidate(sandboxPath) {
+  const sandboxRoot = path.resolve(os.tmpdir(), XCODE_SANDBOX_DIR);
+  const candidate = path.resolve(sandboxPath);
+  const relative = path.relative(sandboxRoot, candidate);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return "";
+  return candidate;
+}
+
+function markPendingSandboxCleanup(sandboxPath) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (candidate) pendingSandboxCleanups.add(candidate);
+}
+
+function clearPendingSandboxCleanup(sandboxPath) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (candidate) pendingSandboxCleanups.delete(candidate);
+}
+
+function movePendingSandboxCleanup(sourcePath, destinationPath) {
+  const source = managedSandboxCandidate(sourcePath);
+  const destination = managedSandboxCandidate(destinationPath);
+  if (!source || !destination || !pendingSandboxCleanups.delete(source)) return;
+  pendingSandboxCleanups.add(destination);
+}
+
+function sandboxCleanupIsPending(sandboxPath) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  return Boolean(candidate && pendingSandboxCleanups.has(candidate));
 }
 
 function prependPath(entry, current) {

--- a/common/opencode-plugin.js
+++ b/common/opencode-plugin.js
@@ -28,13 +28,10 @@ globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] = pendingSandboxCleanups;
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
   return async (input = {}) => {
-    const mcpContext = {
-      pluginRoot,
-      projectDir: input?.worktree || input?.directory,
-    };
     const state = {
       pluginJson: null,
       infoJson: null,
+      pluginData: null,
       config: null,
       instanceID: randomUUID(),
       processStartToken: null,
@@ -45,6 +42,11 @@ export function createOpenCodePlugin(pluginRootUrl) {
       deletedSandboxSessions: new Set(),
       sandboxSweepDone: false,
       disposed: false,
+    };
+    const mcpContext = {
+      pluginRoot,
+      pluginData: () => pluginDataDirectory(pluginRoot, state),
+      projectDir: input?.worktree || input?.directory,
     };
 
     return {
@@ -110,6 +112,19 @@ function loadMetadata(pluginRoot, state) {
   }
 }
 
+function pluginDataDirectory(pluginRoot, state) {
+  if (state.pluginData) return state.pluginData;
+
+  loadMetadata(pluginRoot, state);
+  const pluginName = state.pluginJson.name || path.basename(pluginRoot) || "plugin";
+  const pluginID = String(pluginName).replace(/[^A-Za-z0-9_-]/g, "-");
+  const dataHome = process.env.XDG_DATA_HOME || path.join(os.homedir(), ".local", "share");
+  const pluginData = path.resolve(dataHome, "opencode", "plugin-data", pluginID);
+  fs.mkdirSync(pluginData, { recursive: true });
+  state.pluginData = pluginData;
+  return pluginData;
+}
+
 function registerSkills(config, pluginRoot) {
   const skillsDir = path.join(pluginRoot, "skills");
   if (!hasSkillDirectories(skillsDir)) return;
@@ -156,7 +171,17 @@ function translateMcpServer(server, context) {
   copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"], context);
 
   const environment = isObject(server.environment) ? server.environment : server.env;
-  if (isObject(environment)) translated.environment = expandMcpRecord(environment, context);
+  translated.environment = {
+    ...(isObject(environment) ? expandMcpRecord(environment, context) : {}),
+    ...expandMcpRecord(
+      {
+        CLAUDE_PLUGIN_ROOT: "${CLAUDE_PLUGIN_ROOT}",
+        CLAUDE_PLUGIN_DATA: "${CLAUDE_PLUGIN_DATA}",
+        CLAUDE_PROJECT_DIR: "${CLAUDE_PROJECT_DIR}",
+      },
+      context,
+    ),
+  };
 
   return translated;
 }
@@ -238,6 +263,7 @@ function expandMcpString(value, context) {
 
 function mcpVariable(name, context) {
   if (name === "CLAUDE_PLUGIN_ROOT") return context.pluginRoot;
+  if (name === "CLAUDE_PLUGIN_DATA") return context.pluginData();
   if (name === "CLAUDE_PROJECT_DIR") return context.projectDir;
   return process.env[name];
 }

--- a/common/opencode-plugin.js
+++ b/common/opencode-plugin.js
@@ -16,6 +16,9 @@ const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9
 const PROCESS_START_OUTPUT_MAX_CHARS = 256;
 const PROCESS_START_TIMEOUT_MS = 5_000;
 const PROCESS_TERMINATION_GRACE_MS = 250;
+const SYSTEM_EXECUTABLE_PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+const SYSTEM_PGREP = "/usr/bin/pgrep";
+const SYSTEM_XCRUN = "/usr/bin/xcrun";
 const XCODE_MCP_CACHE_TTL_MS = 30_000;
 const XCRUN_OPTIONS_WITH_VALUE = new Set([
   "--sdk",
@@ -74,6 +77,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       deniedOnce: new Set(),
       xcodeMcpCache: new Map(),
       xcodeMcpApprovalSessions: new Set(),
+      xcodeMcpApprovalHelpers: new Map(),
       sandboxRoot: null,
       ownedSandboxes: new Map(),
       ownedSandboxIdentities: new Map(),
@@ -126,6 +130,8 @@ export function createOpenCodePlugin(pluginRootUrl) {
       },
 
       dispose: async () => {
+        state.disposed = true;
+        await stopAllXcodeMcpApprovals(state);
         await detachOwnedSandboxes(state);
       },
     };
@@ -352,8 +358,11 @@ async function appendSystemContext(pluginRoot, state, input, output) {
   const pluginName = state.pluginJson.name ?? path.basename(pluginRoot);
   const welcomeMessage = typeof state.infoJson.welcomeMessage === "string" ? state.infoJson.welcomeMessage : "";
   const sessionID = safeSessionID(input?.sessionID ?? "global");
-  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state, sessionID);
-  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state, sessionID);
+  let xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state, sessionID);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) xcodeMcpLikely = false;
+  if (xcodeMcpLikely && !xcodeMcpLifecycleCancelled(state, sessionID)) {
+    startXcodeMcpApproval(pluginRoot, state, sessionID);
+  }
   const sessionStart = renderSessionStart(pluginRoot, xcodeMcpLikely);
 
   let systemMessage = `The ${pluginName} plugin is loaded and ready.`;
@@ -385,6 +394,7 @@ function processConditionalBlocks(content, xcodeMcpLikely) {
 }
 
 async function getXcodeMcpLikely(pluginName, state, sessionID) {
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
   if (pluginName !== "XcodeBuildTools") return false;
   if (!hasConfiguredMcpbridge(state.config)) {
     state.xcodeMcpCache.delete(sessionID);
@@ -395,17 +405,26 @@ async function getXcodeMcpLikely(pluginName, state, sessionID) {
   const cached = state.xcodeMcpCache.get(sessionID);
   if (cached && now - cached.checkedAt < XCODE_MCP_CACHE_TTL_MS) return cached.value;
 
-  const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
+  const installed = await commandSucceeds(SYSTEM_XCRUN, ["--find", "mcpbridge"], 5000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
   if (!installed) {
     state.xcodeMcpCache.set(sessionID, { checkedAt: now, value: false });
     return false;
   }
 
-  const xcodeRunning = await commandSucceeds("pgrep", ["-x", "Xcode"], 3000);
-  const bridgeRunning = await commandSucceeds("pgrep", ["-f", "mcpbridge"], 3000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
+  const xcodeRunning = await commandSucceeds(SYSTEM_PGREP, ["-x", "Xcode"], 3000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
+  const bridgeRunning = await commandSucceeds(SYSTEM_PGREP, ["-f", "mcpbridge"], 3000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
   const value = xcodeRunning || bridgeRunning;
   state.xcodeMcpCache.set(sessionID, { checkedAt: now, value });
   return value;
+}
+
+function xcodeMcpLifecycleCancelled(state, sessionID) {
+  return state.disposed || state.deletedSandboxSessions.has(sessionID);
 }
 
 function hasConfiguredMcpbridge(config) {
@@ -452,30 +471,148 @@ function xcrunToolBasename(args) {
 }
 
 function startXcodeMcpApproval(pluginRoot, state, sessionID) {
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return;
   if (state.xcodeMcpApprovalSessions.has(sessionID)) return;
 
-  const runner = path.join(pluginRoot, "hooks", "run-background.sh");
-  const target = path.join("hooks", "approve-xcode-mcp.sh");
-  if (!fs.existsSync(runner)) return;
+  const helper = path.join(pluginRoot, "hooks", "approve-xcode-mcp.sh");
+  if (!fs.existsSync(helper)) return;
 
   try {
+    if (xcodeMcpLifecycleCancelled(state, sessionID)) return;
     state.xcodeMcpApprovalSessions.add(sessionID);
-    const child = spawn(runner, [target], {
+    const child = spawn(helper, [], {
       cwd: pluginRoot,
       detached: true,
       env: {
         ...process.env,
+        PATH: SYSTEM_EXECUTABLE_PATH,
         CLAUDE_HOOK_OWNER_PID: String(process.pid),
         CLAUDE_PLUGIN_ROOT: pluginRoot,
       },
       stdio: "ignore",
     });
-    child.on("error", () => state.xcodeMcpApprovalSessions.delete(sessionID));
+    trackXcodeMcpApprovalHelper(state, sessionID, child);
     child.unref();
   } catch {
     state.xcodeMcpApprovalSessions.delete(sessionID);
     // Auto-approval is best-effort; users can still approve Xcode manually.
   }
+}
+
+function trackXcodeMcpApprovalHelper(state, sessionID, child) {
+  let resolveDone;
+  const record = {
+    child,
+    done: new Promise((resolve) => {
+      resolveDone = resolve;
+    }),
+    pending: true,
+    terminating: false,
+    terminationPromise: null,
+    finish: null,
+    removeFromState: null,
+  };
+
+  const removeFromState = () => {
+    if (state.xcodeMcpApprovalHelpers.get(sessionID) === record) {
+      state.xcodeMcpApprovalHelpers.delete(sessionID);
+    }
+  };
+  const onError = () => finish(true);
+  const onExit = () => finish(false);
+  const finish = (allowRetry) => {
+    if (!record.pending) return;
+    record.pending = false;
+    child.removeListener?.("error", onError);
+    child.removeListener?.("exit", onExit);
+    if (!record.terminating) removeFromState();
+    if (allowRetry) state.xcodeMcpApprovalSessions.delete(sessionID);
+    resolveDone();
+  };
+  record.finish = finish;
+  record.removeFromState = removeFromState;
+
+  state.xcodeMcpApprovalHelpers.set(sessionID, record);
+  child.on("error", onError);
+  child.on("exit", onExit);
+}
+
+function stopXcodeMcpApproval(record) {
+  if (!record) return Promise.resolve();
+  if (!record.terminationPromise) {
+    record.terminating = true;
+    record.terminationPromise = terminateXcodeMcpApproval(record).finally(() => {
+      record.terminating = false;
+      record.removeFromState();
+    });
+  }
+  return record.terminationPromise;
+}
+
+async function terminateXcodeMcpApproval(record) {
+  if (!record.pending) return;
+
+  signalDetachedProcessGroup(record.child, "SIGTERM");
+  let forceKillTimer;
+  await new Promise((resolve) => {
+    let completed = false;
+    const complete = () => {
+      if (completed) return;
+      completed = true;
+      clearTimeout(forceKillTimer);
+      resolve();
+    };
+    const completeIfGroupExited = () => {
+      if (!detachedProcessGroupExists(record.child)) complete();
+    };
+
+    record.done.then(completeIfGroupExited);
+    if (!detachedProcessGroupExists(record.child)) {
+      record.finish(false);
+      complete();
+      return;
+    }
+
+    forceKillTimer = setTimeout(() => {
+      if (detachedProcessGroupExists(record.child)) {
+        signalDetachedProcessGroup(record.child, "SIGKILL");
+      }
+      record.finish(false);
+      complete();
+    }, PROCESS_TERMINATION_GRACE_MS);
+  });
+}
+
+function detachedProcessGroupExists(child) {
+  const pid = Number(child?.pid);
+  if (!Number.isSafeInteger(pid) || pid <= 0) return child != null;
+
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function signalDetachedProcessGroup(child, signal) {
+  const pid = Number(child?.pid);
+  try {
+    if (Number.isSafeInteger(pid) && pid > 0) {
+      process.kill(-pid, signal);
+    } else {
+      child?.kill?.(signal);
+    }
+  } catch {
+    // The helper may have exited between the lifecycle check and the signal.
+  }
+}
+
+async function stopAllXcodeMcpApprovals(state) {
+  const activeHelpers = [...state.xcodeMcpApprovalHelpers.values()];
+  state.xcodeMcpApprovalSessions.clear();
+  await Promise.all(activeHelpers.map((record) => stopXcodeMcpApproval(record)));
+  state.xcodeMcpApprovalHelpers.clear();
 }
 
 function commandSucceeds(command, args, timeoutMs) {
@@ -1001,6 +1138,8 @@ async function handlePluginEvent(state, event) {
   state.deletedSandboxSessions.add(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
+  const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
+  await stopXcodeMcpApproval(activeApproval);
   await removeOwnedSandbox(state, safeID);
 }
 
@@ -1043,6 +1182,7 @@ async function detachOwnedSandboxes(state) {
   state.ownedSandboxIdentities.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
+  state.xcodeMcpApprovalHelpers.clear();
   const cleanupTargets = await Promise.all(
     sandboxes.map(async ({ sandboxPath, sandboxIdentity }) => {
       if (!state.sandboxRoot || !sandboxIdentity) return null;

--- a/docs/superpowers/specs/2026-07-06-opencode-plugin-compatibility-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-06-opencode-plugin-compatibility-fixes-design.md
@@ -1,0 +1,69 @@
+# OpenCode Plugin Compatibility Fixes Design
+
+## Goal
+
+Complete the OpenCode adapter's Claude-compatible MCP environment contract, make the JavaScript runtime checks mandatory, and then perform a second independent code review of the resulting branch.
+
+## Scope
+
+This change addresses three confirmed review findings:
+
+1. Local MCP subprocesses must receive `CLAUDE_PLUGIN_ROOT` and `CLAUDE_PROJECT_DIR` even when the plugin's `.mcp.json` does not declare them explicitly.
+2. `${CLAUDE_PLUGIN_DATA}` must resolve to a stable, writable per-plugin directory and be exported to local MCP subprocesses.
+3. The repository test gate must fail when Node.js is unavailable instead of silently skipping every OpenCode runtime, syntax, and export check.
+
+Generated `*/common/opencode-plugin.js` copies will continue to be produced from `common/opencode-plugin.js` by `scripts/sync-plugin-common.py`; they will not be edited directly.
+
+## Compatibility Context
+
+`createOpenCodePlugin` will construct one MCP compatibility context per plugin instance containing:
+
+- `pluginRoot`: the normalized plugin installation directory.
+- `projectDir`: OpenCode's worktree when present, otherwise its directory.
+- `pluginData`: a stable path derived from the plugin's manifest name.
+
+The data root will be `$XDG_DATA_HOME/opencode/plugin-data` when `XDG_DATA_HOME` is set, otherwise `~/.local/share/opencode/plugin-data`. The plugin identifier will use the manifest name, falling back to the plugin directory name, with characters outside `A-Z`, `a-z`, `0-9`, `_`, and `-` replaced by `-`. This mirrors the compatibility contract's stable, sanitized identifier behavior without writing into the plugin checkout.
+
+The data directory will be created lazily when a configuration references `CLAUDE_PLUGIN_DATA` or when a local MCP server is registered. Remote-only plugins that never use the variable will not create state on disk.
+
+## MCP Translation
+
+Local MCP translation will expand the source server's explicit `env` or `environment` record, then add these host-owned values:
+
+- `CLAUDE_PLUGIN_ROOT`
+- `CLAUDE_PLUGIN_DATA`
+- `CLAUDE_PROJECT_DIR`
+
+The compatibility values take precedence over same-named entries in `.mcp.json`, keeping them authoritative and preventing a plugin configuration from publishing paths inconsistent with the host context. Other explicit environment entries remain unchanged.
+
+`mcpVariable` will resolve all three compatibility placeholders before falling back to `process.env`. Existing required-variable and default-value behavior remains unchanged for ordinary environment variables.
+
+If the data directory cannot be created, MCP registration will fail with the underlying filesystem error. This matches the existing behavior for required placeholders and avoids registering a server with a nonfunctional persistence path.
+
+## Mandatory Node.js Gate
+
+The test suite will contain an explicit repository-integrity check that requires `node` on `PATH`. The existing runtime, syntax, and export tests may retain defensive skips for direct isolated invocation, but the prescribed repository command will fail overall before a missing Node.js runtime can produce a false-green result.
+
+This keeps local failure output clear and avoids coupling the production adapter to a test-only executable lookup helper.
+
+## Test Strategy
+
+Implementation will follow red-green TDD:
+
+1. Add a runtime test proving a local MCP server receives all three compatibility environment variables and that host-owned values override conflicting source entries.
+2. Run that focused test and confirm it fails because the variables are absent.
+3. Add a runtime test proving `${CLAUDE_PLUGIN_DATA}` expands under a temporary `XDG_DATA_HOME`, creates the directory, and remains stable across plugin instances.
+4. Run that focused test and confirm it fails because `CLAUDE_PLUGIN_DATA` is currently unresolved.
+5. Add the mandatory Node.js repository-integrity assertion and reproduce the old false-green behavior with Node removed from `PATH` before changing the gate.
+6. Implement the minimal adapter and test-gate changes, regenerate common helper copies, and rerun focused tests after each fix.
+7. Run `python3 -m unittest discover -s tests -v`, `python3 scripts/sync-plugin-common.py --check`, and `git diff --check 3d176af9d7cf82ab907747a27636b285546a9a07`.
+
+## Second Review
+
+After all tests pass, independent read-only reviews will cover:
+
+- MCP compatibility and path lifecycle behavior.
+- Sandbox and plugin runtime regressions.
+- Packaging, generated-copy integrity, documentation, and test-gate behavior.
+
+Every additional finding must be reproduced or supported by a concrete code path, must have been introduced by this branch, and must receive its own regression test before being fixed. The full verification suite will run again after any follow-up changes.

--- a/iOSSimulator/.claude-plugin/plugin.json
+++ b/iOSSimulator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iOSSimulator",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Control iOS Simulators using native macOS tools - manage simulators, automate UI interactions, take screenshots, and more",
   "author": {
     "name": "Gustavo Ambrozio"

--- a/iOSSimulator/README.md
+++ b/iOSSimulator/README.md
@@ -12,6 +12,8 @@ Control iOS Simulators using native macOS tools. No additional dependencies requ
 
 ## Installation
 
+Claude Code:
+
 ```bash
 # Add the marketplace
 /plugin marketplace add gpambrozio/ClaudeCodePlugins
@@ -19,6 +21,19 @@ Control iOS Simulators using native macOS tools. No additional dependencies requ
 # Install this plugin
 /plugin install iOSSimulator@ClaudeCodePlugins
 ```
+
+OpenCode:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    "/path/to/ClaudeCodePlugins/iOSSimulator/opencode-plugin.js"
+  ]
+}
+```
+
+Restart OpenCode after changing config. The OpenCode entry point registers this plugin's skill, session context, and command guardrails.
 
 ## Prerequisites
 
@@ -100,6 +115,10 @@ Agents with image input can view screenshots. The recommended workflow:
 5. Repeat for complex workflows
 
 ## Changelog
+
+### 0.6.6
+- Added `opencode-plugin.js` for OpenCode users
+- The OpenCode entry point registers the `ios-simulator` skill, session context, and command guardrails
 
 ### 0.6.5
 - Released self-contained common helper copies so the plugin package no longer depends on repository-level symlinks, while keeping hook configuration in `hooks/hooks.json` instead of generated `common/hooks.json` templates

--- a/iOSSimulator/common/opencode-plugin.js
+++ b/iOSSimulator/common/opencode-plugin.js
@@ -271,7 +271,7 @@ function applyPreToolUseRules(state, input, output) {
     if (decision === "deny") throw new Error(message);
 
     const ruleName = typeof rule.name === "string" && rule.name ? rule.name : matchPattern;
-    const key = `${input.sessionID ?? "global"}:${ruleName}`;
+    const key = `${safeSessionID(input.sessionID ?? "global")}:${ruleName}`;
     if (state.deniedOnce.has(key)) continue;
 
     state.deniedOnce.add(key);

--- a/iOSSimulator/common/opencode-plugin.js
+++ b/iOSSimulator/common/opencode-plugin.js
@@ -85,7 +85,10 @@ export function createOpenCodePlugin(pluginRootUrl) {
     const mcpContext = {
       pluginRoot,
       pluginData: () => pluginDataDirectory(pluginRoot, state),
-      projectDir: input?.worktree || input?.directory,
+      projectDir:
+        input?.worktree !== "/" || input?.project?.vcs === "git"
+          ? input?.worktree || input?.directory
+          : input?.directory || input?.worktree,
     };
 
     return {

--- a/iOSSimulator/common/opencode-plugin.js
+++ b/iOSSimulator/common/opencode-plugin.js
@@ -17,6 +17,9 @@ const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9
 const PROCESS_START_OUTPUT_MAX_CHARS = 256;
 const PROCESS_START_TIMEOUT_MS = 5_000;
 const PROCESS_TERMINATION_GRACE_MS = 250;
+const SYSTEM_EXECUTABLE_PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+const SYSTEM_PGREP = "/usr/bin/pgrep";
+const SYSTEM_XCRUN = "/usr/bin/xcrun";
 const XCODE_MCP_CACHE_TTL_MS = 30_000;
 const XCRUN_OPTIONS_WITH_VALUE = new Set([
   "--sdk",
@@ -75,6 +78,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       deniedOnce: new Set(),
       xcodeMcpCache: new Map(),
       xcodeMcpApprovalSessions: new Set(),
+      xcodeMcpApprovalHelpers: new Map(),
       sandboxRoot: null,
       ownedSandboxes: new Map(),
       ownedSandboxIdentities: new Map(),
@@ -127,6 +131,8 @@ export function createOpenCodePlugin(pluginRootUrl) {
       },
 
       dispose: async () => {
+        state.disposed = true;
+        await stopAllXcodeMcpApprovals(state);
         await detachOwnedSandboxes(state);
       },
     };
@@ -353,8 +359,11 @@ async function appendSystemContext(pluginRoot, state, input, output) {
   const pluginName = state.pluginJson.name ?? path.basename(pluginRoot);
   const welcomeMessage = typeof state.infoJson.welcomeMessage === "string" ? state.infoJson.welcomeMessage : "";
   const sessionID = safeSessionID(input?.sessionID ?? "global");
-  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state, sessionID);
-  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state, sessionID);
+  let xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state, sessionID);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) xcodeMcpLikely = false;
+  if (xcodeMcpLikely && !xcodeMcpLifecycleCancelled(state, sessionID)) {
+    startXcodeMcpApproval(pluginRoot, state, sessionID);
+  }
   const sessionStart = renderSessionStart(pluginRoot, xcodeMcpLikely);
 
   let systemMessage = `The ${pluginName} plugin is loaded and ready.`;
@@ -386,6 +395,7 @@ function processConditionalBlocks(content, xcodeMcpLikely) {
 }
 
 async function getXcodeMcpLikely(pluginName, state, sessionID) {
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
   if (pluginName !== "XcodeBuildTools") return false;
   if (!hasConfiguredMcpbridge(state.config)) {
     state.xcodeMcpCache.delete(sessionID);
@@ -396,17 +406,26 @@ async function getXcodeMcpLikely(pluginName, state, sessionID) {
   const cached = state.xcodeMcpCache.get(sessionID);
   if (cached && now - cached.checkedAt < XCODE_MCP_CACHE_TTL_MS) return cached.value;
 
-  const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
+  const installed = await commandSucceeds(SYSTEM_XCRUN, ["--find", "mcpbridge"], 5000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
   if (!installed) {
     state.xcodeMcpCache.set(sessionID, { checkedAt: now, value: false });
     return false;
   }
 
-  const xcodeRunning = await commandSucceeds("pgrep", ["-x", "Xcode"], 3000);
-  const bridgeRunning = await commandSucceeds("pgrep", ["-f", "mcpbridge"], 3000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
+  const xcodeRunning = await commandSucceeds(SYSTEM_PGREP, ["-x", "Xcode"], 3000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
+  const bridgeRunning = await commandSucceeds(SYSTEM_PGREP, ["-f", "mcpbridge"], 3000);
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return false;
   const value = xcodeRunning || bridgeRunning;
   state.xcodeMcpCache.set(sessionID, { checkedAt: now, value });
   return value;
+}
+
+function xcodeMcpLifecycleCancelled(state, sessionID) {
+  return state.disposed || state.deletedSandboxSessions.has(sessionID);
 }
 
 function hasConfiguredMcpbridge(config) {
@@ -453,30 +472,148 @@ function xcrunToolBasename(args) {
 }
 
 function startXcodeMcpApproval(pluginRoot, state, sessionID) {
+  if (xcodeMcpLifecycleCancelled(state, sessionID)) return;
   if (state.xcodeMcpApprovalSessions.has(sessionID)) return;
 
-  const runner = path.join(pluginRoot, "hooks", "run-background.sh");
-  const target = path.join("hooks", "approve-xcode-mcp.sh");
-  if (!fs.existsSync(runner)) return;
+  const helper = path.join(pluginRoot, "hooks", "approve-xcode-mcp.sh");
+  if (!fs.existsSync(helper)) return;
 
   try {
+    if (xcodeMcpLifecycleCancelled(state, sessionID)) return;
     state.xcodeMcpApprovalSessions.add(sessionID);
-    const child = spawn(runner, [target], {
+    const child = spawn(helper, [], {
       cwd: pluginRoot,
       detached: true,
       env: {
         ...process.env,
+        PATH: SYSTEM_EXECUTABLE_PATH,
         CLAUDE_HOOK_OWNER_PID: String(process.pid),
         CLAUDE_PLUGIN_ROOT: pluginRoot,
       },
       stdio: "ignore",
     });
-    child.on("error", () => state.xcodeMcpApprovalSessions.delete(sessionID));
+    trackXcodeMcpApprovalHelper(state, sessionID, child);
     child.unref();
   } catch {
     state.xcodeMcpApprovalSessions.delete(sessionID);
     // Auto-approval is best-effort; users can still approve Xcode manually.
   }
+}
+
+function trackXcodeMcpApprovalHelper(state, sessionID, child) {
+  let resolveDone;
+  const record = {
+    child,
+    done: new Promise((resolve) => {
+      resolveDone = resolve;
+    }),
+    pending: true,
+    terminating: false,
+    terminationPromise: null,
+    finish: null,
+    removeFromState: null,
+  };
+
+  const removeFromState = () => {
+    if (state.xcodeMcpApprovalHelpers.get(sessionID) === record) {
+      state.xcodeMcpApprovalHelpers.delete(sessionID);
+    }
+  };
+  const onError = () => finish(true);
+  const onExit = () => finish(false);
+  const finish = (allowRetry) => {
+    if (!record.pending) return;
+    record.pending = false;
+    child.removeListener?.("error", onError);
+    child.removeListener?.("exit", onExit);
+    if (!record.terminating) removeFromState();
+    if (allowRetry) state.xcodeMcpApprovalSessions.delete(sessionID);
+    resolveDone();
+  };
+  record.finish = finish;
+  record.removeFromState = removeFromState;
+
+  state.xcodeMcpApprovalHelpers.set(sessionID, record);
+  child.on("error", onError);
+  child.on("exit", onExit);
+}
+
+function stopXcodeMcpApproval(record) {
+  if (!record) return Promise.resolve();
+  if (!record.terminationPromise) {
+    record.terminating = true;
+    record.terminationPromise = terminateXcodeMcpApproval(record).finally(() => {
+      record.terminating = false;
+      record.removeFromState();
+    });
+  }
+  return record.terminationPromise;
+}
+
+async function terminateXcodeMcpApproval(record) {
+  if (!record.pending) return;
+
+  signalDetachedProcessGroup(record.child, "SIGTERM");
+  let forceKillTimer;
+  await new Promise((resolve) => {
+    let completed = false;
+    const complete = () => {
+      if (completed) return;
+      completed = true;
+      clearTimeout(forceKillTimer);
+      resolve();
+    };
+    const completeIfGroupExited = () => {
+      if (!detachedProcessGroupExists(record.child)) complete();
+    };
+
+    record.done.then(completeIfGroupExited);
+    if (!detachedProcessGroupExists(record.child)) {
+      record.finish(false);
+      complete();
+      return;
+    }
+
+    forceKillTimer = setTimeout(() => {
+      if (detachedProcessGroupExists(record.child)) {
+        signalDetachedProcessGroup(record.child, "SIGKILL");
+      }
+      record.finish(false);
+      complete();
+    }, PROCESS_TERMINATION_GRACE_MS);
+  });
+}
+
+function detachedProcessGroupExists(child) {
+  const pid = Number(child?.pid);
+  if (!Number.isSafeInteger(pid) || pid <= 0) return child != null;
+
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function signalDetachedProcessGroup(child, signal) {
+  const pid = Number(child?.pid);
+  try {
+    if (Number.isSafeInteger(pid) && pid > 0) {
+      process.kill(-pid, signal);
+    } else {
+      child?.kill?.(signal);
+    }
+  } catch {
+    // The helper may have exited between the lifecycle check and the signal.
+  }
+}
+
+async function stopAllXcodeMcpApprovals(state) {
+  const activeHelpers = [...state.xcodeMcpApprovalHelpers.values()];
+  state.xcodeMcpApprovalSessions.clear();
+  await Promise.all(activeHelpers.map((record) => stopXcodeMcpApproval(record)));
+  state.xcodeMcpApprovalHelpers.clear();
 }
 
 function commandSucceeds(command, args, timeoutMs) {
@@ -1002,6 +1139,8 @@ async function handlePluginEvent(state, event) {
   state.deletedSandboxSessions.add(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
+  const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
+  await stopXcodeMcpApproval(activeApproval);
   await removeOwnedSandbox(state, safeID);
 }
 
@@ -1044,6 +1183,7 @@ async function detachOwnedSandboxes(state) {
   state.ownedSandboxIdentities.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
+  state.xcodeMcpApprovalHelpers.clear();
   const cleanupTargets = await Promise.all(
     sandboxes.map(async ({ sandboxPath, sandboxIdentity }) => {
       if (!state.sandboxRoot || !sandboxIdentity) return null;

--- a/iOSSimulator/common/opencode-plugin.js
+++ b/iOSSimulator/common/opencode-plugin.js
@@ -183,6 +183,7 @@ function processConditionalBlocks(content, xcodeMcpLikely) {
 
 async function getXcodeMcpLikely(pluginName, state) {
   if (pluginName !== "XcodeBuildTools") return false;
+  if (state.xcodeMcpLikely !== undefined) return state.xcodeMcpLikely;
 
   const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
   if (!installed) {

--- a/iOSSimulator/common/opencode-plugin.js
+++ b/iOSSimulator/common/opencode-plugin.js
@@ -1,0 +1,361 @@
+// Generated from common/opencode-plugin.js by scripts/sync-plugin-common.py. Do not edit this copy; edit common/opencode-plugin.js and rerun scripts/sync-plugin-common.py.
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+export function createOpenCodePlugin(pluginRootUrl) {
+  const pluginRoot = normalizePluginRoot(pluginRootUrl);
+  const state = {
+    pluginJson: null,
+    infoJson: null,
+    deniedOnce: new Set(),
+    xcodeMcpLikely: undefined,
+    xcodeMcpApprovalStarted: false,
+  };
+
+  return async () => ({
+    config: async (config) => {
+      loadMetadata(pluginRoot, state);
+      registerSkills(config, pluginRoot);
+      registerMcpServers(config, pluginRoot);
+    },
+
+    "experimental.chat.system.transform": async (_input, output) => {
+      try {
+        loadMetadata(pluginRoot, state);
+        await appendSystemContext(pluginRoot, state, output);
+      } catch {
+        // Fail open. Plugin context should never block a chat request.
+      }
+    },
+
+    "tool.execute.before": async (input, output) => {
+      loadMetadata(pluginRoot, state);
+      applyPreToolUseRules(state, input, output);
+    },
+
+    "shell.env": async (input, output) => {
+      try {
+        loadMetadata(pluginRoot, state);
+        configureShellEnvironment(pluginRoot, state, input, output);
+      } catch {
+        // Fail open. Shell commands should still run if setup is unavailable.
+      }
+    },
+  });
+}
+
+function normalizePluginRoot(pluginRootUrl) {
+  if (pluginRootUrl instanceof URL) {
+    return path.resolve(fileURLToPath(pluginRootUrl));
+  }
+
+  if (typeof pluginRootUrl === "string" && pluginRootUrl.startsWith("file:")) {
+    return path.resolve(fileURLToPath(pluginRootUrl));
+  }
+
+  return path.resolve(String(pluginRootUrl));
+}
+
+function loadMetadata(pluginRoot, state) {
+  if (!state.pluginJson) {
+    state.pluginJson = readJsonFile(path.join(pluginRoot, ".claude-plugin", "plugin.json")) ?? {};
+  }
+  if (!state.infoJson) {
+    state.infoJson = readJsonFile(path.join(pluginRoot, "info.json")) ?? {};
+  }
+}
+
+function registerSkills(config, pluginRoot) {
+  const skillsDir = path.join(pluginRoot, "skills");
+  if (!hasSkillDirectories(skillsDir)) return;
+
+  if (!isObject(config.skills)) config.skills = {};
+  if (!Array.isArray(config.skills.paths)) config.skills.paths = [];
+  if (!config.skills.paths.includes(skillsDir)) config.skills.paths.push(skillsDir);
+}
+
+function registerMcpServers(config, pluginRoot) {
+  const mcpConfig = readJsonFile(path.join(pluginRoot, ".mcp.json"));
+  const servers = mcpConfig?.mcpServers;
+  if (!isObject(servers)) return;
+
+  if (!isObject(config.mcp)) config.mcp = {};
+
+  for (const [name, server] of Object.entries(servers)) {
+    if (!isObject(server) || config.mcp[name]) continue;
+
+    const translated = translateMcpServer(server);
+    if (translated) config.mcp[name] = translated;
+  }
+}
+
+function translateMcpServer(server) {
+  if (typeof server.url === "string") {
+    const translated = {
+      type: "remote",
+      url: server.url,
+    };
+    copyOptionalFields(server, translated, ["enabled", "headers", "timeout"]);
+    return translated;
+  }
+
+  const command = normalizeCommand(server.command, server.args);
+  if (!command) return null;
+
+  const translated = {
+    type: "local",
+    command,
+  };
+  copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"]);
+
+  const environment = isObject(server.environment) ? server.environment : server.env;
+  if (isObject(environment)) translated.environment = stringifyRecord(environment);
+
+  return translated;
+}
+
+function normalizeCommand(command, args) {
+  if (Array.isArray(command) && command.every((item) => typeof item === "string")) {
+    return command;
+  }
+
+  if (typeof command !== "string") return null;
+
+  const result = [command];
+  if (Array.isArray(args)) {
+    for (const arg of args) {
+      if (typeof arg !== "string") return null;
+      result.push(arg);
+    }
+  }
+  return result;
+}
+
+function copyOptionalFields(source, target, keys) {
+  for (const key of keys) {
+    if (source[key] === undefined) continue;
+    target[key] = key === "headers" && isObject(source[key]) ? stringifyRecord(source[key]) : source[key];
+  }
+}
+
+async function appendSystemContext(pluginRoot, state, output) {
+  if (!Array.isArray(output.system)) output.system = [];
+
+  const pluginName = state.pluginJson.name ?? path.basename(pluginRoot);
+  const welcomeMessage = typeof state.infoJson.welcomeMessage === "string" ? state.infoJson.welcomeMessage : "";
+  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state);
+  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state);
+  const sessionStart = renderSessionStart(pluginRoot, xcodeMcpLikely);
+
+  let systemMessage = `The ${pluginName} plugin is loaded and ready.`;
+  if (xcodeMcpLikely) systemMessage += " Xcode MCP server detected.";
+  if (welcomeMessage) systemMessage += ` ${welcomeMessage}`;
+
+  output.system.push([systemMessage, sessionStart].filter(Boolean).join("\n\n"));
+}
+
+function renderSessionStart(pluginRoot, xcodeMcpLikely) {
+  const sessionStartPath = path.join(pluginRoot, "session-start.md");
+  const content = readTextFile(sessionStartPath);
+  if (!content) return "";
+  return processConditionalBlocks(content, xcodeMcpLikely);
+}
+
+function processConditionalBlocks(content, xcodeMcpLikely) {
+  if (xcodeMcpLikely) {
+    return content
+      .replace(/<!-- IF_XCODE_MCP -->\n?/g, "")
+      .replace(/<!-- END_XCODE_MCP -->\n?/g, "")
+      .replace(/<!-- IF_NO_XCODE_MCP -->[\s\S]*?<!-- END_NO_XCODE_MCP -->\n?/g, "");
+  }
+
+  return content
+    .replace(/<!-- IF_NO_XCODE_MCP -->\n?/g, "")
+    .replace(/<!-- END_NO_XCODE_MCP -->\n?/g, "")
+    .replace(/<!-- IF_XCODE_MCP -->[\s\S]*?<!-- END_XCODE_MCP -->\n?/g, "");
+}
+
+async function getXcodeMcpLikely(pluginName, state) {
+  if (pluginName !== "XcodeBuildTools") return false;
+
+  const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
+  if (!installed) {
+    state.xcodeMcpLikely = false;
+    return state.xcodeMcpLikely;
+  }
+
+  const xcodeRunning = await commandSucceeds("pgrep", ["-x", "Xcode"], 3000);
+  const bridgeRunning = await commandSucceeds("pgrep", ["-f", "mcpbridge"], 3000);
+  state.xcodeMcpLikely = xcodeRunning || bridgeRunning;
+  return state.xcodeMcpLikely;
+}
+
+function startXcodeMcpApproval(pluginRoot, state) {
+  if (state.xcodeMcpApprovalStarted) return;
+  state.xcodeMcpApprovalStarted = true;
+
+  const runner = path.join(pluginRoot, "hooks", "run-background.sh");
+  const target = path.join("hooks", "approve-xcode-mcp.sh");
+  if (!fs.existsSync(runner)) return;
+
+  try {
+    const child = spawn(runner, [target], {
+      cwd: pluginRoot,
+      detached: true,
+      env: {
+        ...process.env,
+        CLAUDE_HOOK_OWNER_PID: String(process.pid),
+        CLAUDE_PLUGIN_ROOT: pluginRoot,
+      },
+      stdio: "ignore",
+    });
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+    // Auto-approval is best-effort; users can still approve Xcode manually.
+  }
+}
+
+function commandSucceeds(command, args, timeoutMs) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const child = spawn(command, args, { stdio: "ignore" });
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish(false);
+    }, timeoutMs);
+
+    child.on("error", () => finish(false));
+    child.on("exit", (code) => finish(code === 0));
+
+    function finish(result) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    }
+  });
+}
+
+function applyPreToolUseRules(state, input, output) {
+  const tool = String(input.tool ?? "").toLowerCase();
+  if (tool !== "bash") return;
+
+  const command = output?.args?.command;
+  if (typeof command !== "string" || !command) return;
+
+  const rules = Array.isArray(state.infoJson["pre-tool-use-rules"])
+    ? state.infoJson["pre-tool-use-rules"]
+    : [];
+
+  for (const rule of rules) {
+    if (!isObject(rule)) continue;
+
+    const matchPattern = rule.match;
+    if (typeof matchPattern !== "string" || !regexMatches(matchPattern, command)) continue;
+
+    const notMatchPattern = rule.not_match;
+    if (typeof notMatchPattern === "string" && regexMatches(notMatchPattern, command)) continue;
+
+    const decision = rule.decision ?? "deny";
+    if (decision === "allow") return;
+
+    const message = typeof rule.message === "string" ? rule.message : "Command denied by plugin rule";
+    if (decision === "deny") throw new Error(message);
+
+    const ruleName = typeof rule.name === "string" && rule.name ? rule.name : matchPattern;
+    const key = `${input.sessionID ?? "global"}:${ruleName}`;
+    if (state.deniedOnce.has(key)) continue;
+
+    state.deniedOnce.add(key);
+    throw new Error(message);
+  }
+}
+
+function configureShellEnvironment(pluginRoot, state, input, output) {
+  if (!isObject(output.env)) output.env = {};
+
+  const binDir = path.join(pluginRoot, "bin");
+  if (fs.existsSync(binDir)) {
+    output.env.PATH = prependPath(binDir, output.env.PATH ?? process.env.PATH ?? "");
+  }
+
+  if (state.pluginJson.name !== "XcodeBuildTools") return;
+
+  const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
+  const sandboxBase = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox", sessionID);
+  const buildDir = path.join(sandboxBase, "build");
+  const packagesDir = path.join(sandboxBase, "packages");
+
+  fs.mkdirSync(buildDir, { recursive: true });
+  fs.mkdirSync(packagesDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(sandboxBase, "owner.pid"),
+    `${process.pid}\n${process.argv[0] ?? "opencode"}\n`,
+    "utf8",
+  );
+
+  output.env.SANDBOX_DERIVED_DATA = buildDir;
+  output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+function prependPath(entry, current) {
+  const parts = current.split(path.delimiter).filter(Boolean).filter((part) => part !== entry);
+  return [entry, ...parts].join(path.delimiter);
+}
+
+function safeSessionID(value) {
+  const raw = String(value ?? "");
+  if (SAFE_ID_RE.test(raw)) return raw;
+
+  const hash = createHash("sha256").update(raw || "default").digest("hex").slice(0, 16);
+  return `opencode-${hash}`;
+}
+
+function regexMatches(pattern, value) {
+  try {
+    return new RegExp(pattern).test(value);
+  } catch {
+    return false;
+  }
+}
+
+function hasSkillDirectories(skillsDir) {
+  try {
+    return fs.readdirSync(skillsDir, { withFileTypes: true }).some((entry) => {
+      return entry.isDirectory() && fs.existsSync(path.join(skillsDir, entry.name, "SKILL.md"));
+    });
+  } catch {
+    return false;
+  }
+}
+
+function readJsonFile(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function readTextFile(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function stringifyRecord(value) {
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, String(item)]));
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/iOSSimulator/common/opencode-plugin.js
+++ b/iOSSimulator/common/opencode-plugin.js
@@ -1,53 +1,71 @@
 // Generated from common/opencode-plugin.js by scripts/sync-plugin-common.py. Do not edit this copy; edit common/opencode-plugin.js and rerun scripts/sync-plugin-common.py.
 import { spawn } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const XCODE_MCP_CACHE_TTL_MS = 30_000;
+const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
 
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
-  const state = {
-    pluginJson: null,
-    infoJson: null,
-    deniedOnce: new Set(),
-    xcodeMcpLikely: undefined,
-    xcodeMcpApprovalStarted: false,
+  return async () => {
+    const state = {
+      pluginJson: null,
+      infoJson: null,
+      config: null,
+      instanceID: randomUUID(),
+      processStartToken: null,
+      deniedOnce: new Set(),
+      xcodeMcpCache: new Map(),
+      xcodeMcpApprovalSessions: new Set(),
+      ownedSandboxes: new Map(),
+      sandboxSweepDone: false,
+    };
+
+    return {
+      config: async (config) => {
+        loadMetadata(pluginRoot, state);
+        registerSkills(config, pluginRoot);
+        registerMcpServers(config, pluginRoot);
+        state.config = config;
+      },
+
+      "experimental.chat.system.transform": async (input, output) => {
+        try {
+          loadMetadata(pluginRoot, state);
+          await appendSystemContext(pluginRoot, state, input, output);
+        } catch {
+          // Fail open. Plugin context should never block a chat request.
+        }
+      },
+
+      "tool.execute.before": async (input, output) => {
+        loadMetadata(pluginRoot, state);
+        applyPreToolUseRules(state, input, output);
+      },
+
+      "shell.env": async (input, output) => {
+        try {
+          loadMetadata(pluginRoot, state);
+          await configureShellEnvironment(pluginRoot, state, input, output);
+        } catch {
+          // Fail open. Shell commands should still run if setup is unavailable.
+        }
+      },
+
+      event: async ({ event }) => {
+        await handlePluginEvent(state, event);
+      },
+
+      dispose: async () => {
+        await removeOwnedSandboxes(state);
+      },
+    };
   };
-
-  return async () => ({
-    config: async (config) => {
-      loadMetadata(pluginRoot, state);
-      registerSkills(config, pluginRoot);
-      registerMcpServers(config, pluginRoot);
-    },
-
-    "experimental.chat.system.transform": async (_input, output) => {
-      try {
-        loadMetadata(pluginRoot, state);
-        await appendSystemContext(pluginRoot, state, output);
-      } catch {
-        // Fail open. Plugin context should never block a chat request.
-      }
-    },
-
-    "tool.execute.before": async (input, output) => {
-      loadMetadata(pluginRoot, state);
-      applyPreToolUseRules(state, input, output);
-    },
-
-    "shell.env": async (input, output) => {
-      try {
-        loadMetadata(pluginRoot, state);
-        configureShellEnvironment(pluginRoot, state, input, output);
-      } catch {
-        // Fail open. Shell commands should still run if setup is unavailable.
-      }
-    },
-  });
 }
 
 function normalizePluginRoot(pluginRootUrl) {
@@ -144,13 +162,14 @@ function copyOptionalFields(source, target, keys) {
   }
 }
 
-async function appendSystemContext(pluginRoot, state, output) {
+async function appendSystemContext(pluginRoot, state, input, output) {
   if (!Array.isArray(output.system)) output.system = [];
 
   const pluginName = state.pluginJson.name ?? path.basename(pluginRoot);
   const welcomeMessage = typeof state.infoJson.welcomeMessage === "string" ? state.infoJson.welcomeMessage : "";
-  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state);
-  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state);
+  const sessionID = safeSessionID(input?.sessionID ?? "global");
+  const xcodeMcpLikely = await getXcodeMcpLikely(pluginName, state, sessionID);
+  if (xcodeMcpLikely) startXcodeMcpApproval(pluginRoot, state, sessionID);
   const sessionStart = renderSessionStart(pluginRoot, xcodeMcpLikely);
 
   let systemMessage = `The ${pluginName} plugin is loaded and ready.`;
@@ -181,31 +200,56 @@ function processConditionalBlocks(content, xcodeMcpLikely) {
     .replace(/<!-- IF_XCODE_MCP -->[\s\S]*?<!-- END_XCODE_MCP -->\n?/g, "");
 }
 
-async function getXcodeMcpLikely(pluginName, state) {
+async function getXcodeMcpLikely(pluginName, state, sessionID) {
   if (pluginName !== "XcodeBuildTools") return false;
-  if (state.xcodeMcpLikely !== undefined) return state.xcodeMcpLikely;
+  if (!hasConfiguredMcpbridge(state.config)) {
+    state.xcodeMcpCache.delete(sessionID);
+    return false;
+  }
+
+  const now = Date.now();
+  const cached = state.xcodeMcpCache.get(sessionID);
+  if (cached && now - cached.checkedAt < XCODE_MCP_CACHE_TTL_MS) return cached.value;
 
   const installed = await commandSucceeds("xcrun", ["--find", "mcpbridge"], 5000);
   if (!installed) {
-    state.xcodeMcpLikely = false;
-    return state.xcodeMcpLikely;
+    state.xcodeMcpCache.set(sessionID, { checkedAt: now, value: false });
+    return false;
   }
 
   const xcodeRunning = await commandSucceeds("pgrep", ["-x", "Xcode"], 3000);
   const bridgeRunning = await commandSucceeds("pgrep", ["-f", "mcpbridge"], 3000);
-  state.xcodeMcpLikely = xcodeRunning || bridgeRunning;
-  return state.xcodeMcpLikely;
+  const value = xcodeRunning || bridgeRunning;
+  state.xcodeMcpCache.set(sessionID, { checkedAt: now, value });
+  return value;
 }
 
-function startXcodeMcpApproval(pluginRoot, state) {
-  if (state.xcodeMcpApprovalStarted) return;
-  state.xcodeMcpApprovalStarted = true;
+function hasConfiguredMcpbridge(config) {
+  if (!isObject(config?.mcp)) return false;
+
+  return Object.values(config.mcp).some((server) => {
+    if (!isObject(server) || server.enabled === false || server.type !== "local") return false;
+
+    const command = Array.isArray(server.command) ? server.command : [server.command];
+    return command.some((part) => {
+      if (typeof part !== "string") return false;
+      return part
+        .trim()
+        .split(/\s+/)
+        .some((token) => path.basename(token.replace(/^['"]|['"]$/g, "")) === "mcpbridge");
+    });
+  });
+}
+
+function startXcodeMcpApproval(pluginRoot, state, sessionID) {
+  if (state.xcodeMcpApprovalSessions.has(sessionID)) return;
 
   const runner = path.join(pluginRoot, "hooks", "run-background.sh");
   const target = path.join("hooks", "approve-xcode-mcp.sh");
   if (!fs.existsSync(runner)) return;
 
   try {
+    state.xcodeMcpApprovalSessions.add(sessionID);
     const child = spawn(runner, [target], {
       cwd: pluginRoot,
       detached: true,
@@ -216,9 +260,10 @@ function startXcodeMcpApproval(pluginRoot, state) {
       },
       stdio: "ignore",
     });
-    child.on("error", () => {});
+    child.on("error", () => state.xcodeMcpApprovalSessions.delete(sessionID));
     child.unref();
   } catch {
+    state.xcodeMcpApprovalSessions.delete(sessionID);
     // Auto-approval is best-effort; users can still approve Xcode manually.
   }
 }
@@ -279,7 +324,7 @@ function applyPreToolUseRules(state, input, output) {
   }
 }
 
-function configureShellEnvironment(pluginRoot, state, input, output) {
+async function configureShellEnvironment(pluginRoot, state, input, output) {
   if (!isObject(output.env)) output.env = {};
 
   const binDir = path.join(pluginRoot, "bin");
@@ -290,7 +335,23 @@ function configureShellEnvironment(pluginRoot, state, input, output) {
   if (state.pluginJson.name !== "XcodeBuildTools") return;
 
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
-  const sandboxBase = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox", sessionID);
+  const sandboxRoot = path.join(os.tmpdir(), XCODE_SANDBOX_DIR);
+  // Plugin instances never reuse a sandbox path, so an older instance cannot
+  // delete a replacement instance's active sandbox after an ownership check.
+  const sandboxBase = path.join(sandboxRoot, `${sessionID}-${state.instanceID}`);
+  state.ownedSandboxes.set(sessionID, sandboxBase);
+
+  if (!state.processStartToken) {
+    state.processStartToken = await readProcessStartToken(process.pid);
+  }
+  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+
+  if (!state.sandboxSweepDone) {
+    await sweepStaleSandboxes(sandboxRoot);
+    state.sandboxSweepDone = true;
+  }
+  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+
   const buildDir = path.join(sandboxBase, "build");
   const packagesDir = path.join(sandboxBase, "packages");
 
@@ -298,12 +359,153 @@ function configureShellEnvironment(pluginRoot, state, input, output) {
   fs.mkdirSync(packagesDir, { recursive: true });
   fs.writeFileSync(
     path.join(sandboxBase, "owner.pid"),
-    `${process.pid}\n${process.argv[0] ?? "opencode"}\n`,
+    `${process.pid}\n${process.argv[0] ?? "opencode"}\n${state.processStartToken}\n${state.instanceID}\n`,
     "utf8",
   );
 
   output.env.SANDBOX_DERIVED_DATA = buildDir;
   output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+async function handlePluginEvent(state, event) {
+  if (event?.type !== "session.deleted") return;
+
+  const sessionID = event.properties?.info?.id;
+  if (typeof sessionID !== "string" || !sessionID) return;
+
+  const safeID = safeSessionID(sessionID);
+  state.xcodeMcpCache.delete(safeID);
+  state.xcodeMcpApprovalSessions.delete(safeID);
+  await removeOwnedSandbox(state, safeID);
+}
+
+async function removeOwnedSandbox(state, sessionID) {
+  const sandboxPath = state.ownedSandboxes.get(sessionID);
+  if (!sandboxPath) return;
+
+  state.ownedSandboxes.delete(sessionID);
+  await removeManagedSandbox(sandboxPath, state.instanceID);
+}
+
+async function removeOwnedSandboxes(state) {
+  const sandboxPaths = [...new Set(state.ownedSandboxes.values())];
+  state.ownedSandboxes.clear();
+  state.xcodeMcpCache.clear();
+  state.xcodeMcpApprovalSessions.clear();
+  await Promise.all(sandboxPaths.map((sandboxPath) => removeManagedSandbox(sandboxPath, state.instanceID)));
+}
+
+async function sweepStaleSandboxes(sandboxRoot) {
+  let entries;
+  try {
+    entries = await fs.promises.readdir(sandboxRoot, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.isDirectory() || !SAFE_ID_RE.test(entry.name)) return;
+
+      const sandboxPath = path.join(sandboxRoot, entry.name);
+      const owner = await readSandboxOwner(sandboxPath);
+      if (!owner || (await sandboxOwnerIsActive(owner))) return;
+
+      await removeManagedSandbox(sandboxPath);
+    }),
+  );
+}
+
+async function readSandboxOwner(sandboxPath) {
+  try {
+    const content = await fs.promises.readFile(path.join(sandboxPath, "owner.pid"), "utf8");
+    const lines = content.split(/\r?\n/);
+    const firstLine = lines[0];
+    if (!/^\d+$/.test(firstLine)) return null;
+
+    const pid = Number(firstLine);
+    if (!Number.isSafeInteger(pid) || pid <= 0) return null;
+
+    return {
+      pid,
+      processStartToken: lines[2] ?? "",
+      instanceID: lines[3] ?? "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+async function sandboxOwnerIsActive(owner) {
+  if (!processExists(owner.pid)) return false;
+  if (!owner.processStartToken) return true;
+
+  const currentStartToken = await readProcessStartToken(owner.pid);
+  if (!currentStartToken) return true;
+  return currentStartToken === owner.processStartToken;
+}
+
+function readProcessStartToken(pid) {
+  return new Promise((resolve) => {
+    let settled = false;
+    let stdout = "";
+    let child;
+
+    try {
+      child = spawn("ps", ["-p", String(pid), "-o", "lstart="], {
+        env: {
+          ...process.env,
+          LC_ALL: "C",
+          LANG: "C",
+          TZ: "UTC",
+        },
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+    } catch {
+      resolve("");
+      return;
+    }
+
+    child.stdout?.setEncoding?.("utf8");
+    child.stdout?.on?.("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.on("error", () => finish(""));
+    child.on("close", (code) => finish(code === 0 ? stdout.trim() : ""));
+
+    function finish(value) {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    }
+  });
+}
+
+async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
+  const sandboxRoot = path.resolve(os.tmpdir(), XCODE_SANDBOX_DIR);
+  const candidate = path.resolve(sandboxPath);
+  const relative = path.relative(sandboxRoot, candidate);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return;
+
+  if (expectedInstanceID) {
+    const owner = await readSandboxOwner(candidate);
+    if (!owner || owner.instanceID !== expectedInstanceID) return;
+  }
+
+  try {
+    await fs.promises.rm(candidate, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  } catch {
+    // Best-effort cleanup; the next plugin instance will retry through the stale-owner sweep.
+  }
 }
 
 function prependPath(entry, current) {

--- a/iOSSimulator/common/opencode-plugin.js
+++ b/iOSSimulator/common/opencode-plugin.js
@@ -7,8 +7,23 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const PROCESS_START_OUTPUT_MAX_CHARS = 256;
+const PROCESS_START_TIMEOUT_MS = 5_000;
 const XCODE_MCP_CACHE_TTL_MS = 30_000;
 const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
+const XCODE_SANDBOX_OWNER_GRACE_MS = 60_000;
+const XCODE_SANDBOX_OWNER_LOCK = ".owner.lock";
+const XCODE_SANDBOX_QUARANTINE_RE =
+  /^\.quarantine-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const XCODE_SANDBOX_PENDING_CLEANUPS_KEY = Symbol.for(
+  "opencode.xcodebuildtools.pending-cleanups",
+);
+const pendingSandboxCleanups =
+  globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] instanceof Set
+    ? globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY]
+    : new Set();
+globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] = pendingSandboxCleanups;
 
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
@@ -23,7 +38,9 @@ export function createOpenCodePlugin(pluginRootUrl) {
       xcodeMcpCache: new Map(),
       xcodeMcpApprovalSessions: new Set(),
       ownedSandboxes: new Map(),
+      deletedSandboxSessions: new Set(),
       sandboxSweepDone: false,
+      disposed: false,
     };
 
     return {
@@ -62,7 +79,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       },
 
       dispose: async () => {
-        await removeOwnedSandboxes(state);
+        await detachOwnedSandboxes(state);
       },
     };
   };
@@ -335,6 +352,7 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   if (state.pluginJson.name !== "XcodeBuildTools") return;
 
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
+  if (state.disposed || state.deletedSandboxSessions.has(sessionID)) return;
   const sandboxRoot = path.join(os.tmpdir(), XCODE_SANDBOX_DIR);
   // Plugin instances never reuse a sandbox path, so an older instance cannot
   // delete a replacement instance's active sandbox after an ownership check.
@@ -344,27 +362,201 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   if (!state.processStartToken) {
     state.processStartToken = await readProcessStartToken(process.pid);
   }
-  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+  if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
 
   if (!state.sandboxSweepDone) {
     await sweepStaleSandboxes(sandboxRoot);
     state.sandboxSweepDone = true;
   }
-  if (state.ownedSandboxes.get(sessionID) !== sandboxBase) return;
+  if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
 
   const buildDir = path.join(sandboxBase, "build");
   const packagesDir = path.join(sandboxBase, "packages");
 
   fs.mkdirSync(buildDir, { recursive: true });
   fs.mkdirSync(packagesDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(sandboxBase, "owner.pid"),
-    `${process.pid}\n${process.argv[0] ?? "opencode"}\n${state.processStartToken}\n${state.instanceID}\n`,
-    "utf8",
-  );
+  writeSandboxOwner(sandboxBase, state.processStartToken, state.instanceID);
 
   output.env.SANDBOX_DERIVED_DATA = buildDir;
   output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+function sandboxSetupIsCancelled(state, sessionID, sandboxBase) {
+  return (
+    state.disposed ||
+    state.deletedSandboxSessions.has(sessionID) ||
+    state.ownedSandboxes.get(sessionID) !== sandboxBase
+  );
+}
+
+function writeSandboxOwner(sandboxBase, processStartToken, instanceID) {
+  const ownerPath = path.join(sandboxBase, "owner.pid");
+  const temporaryPath = path.join(sandboxBase, `owner.pid.${instanceID}.tmp`);
+  const content = `${process.pid}\n${process.argv[0] ?? "opencode"}\n${processStartToken}\n${instanceID}\n`;
+  const ownerLock = acquireSandboxOwnerLock(sandboxBase);
+  if (!ownerLock) throw new Error("Sandbox owner is being updated or removed");
+
+  try {
+    fs.writeFileSync(temporaryPath, content, "utf8");
+    if (!sandboxOwnerLockIsHeld(ownerLock)) {
+      throw new Error("Sandbox owner lock changed during update");
+    }
+    fs.renameSync(temporaryPath, ownerPath);
+  } catch (error) {
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch {
+      // The stale-sandbox sweep handles any temporary file left behind.
+    }
+    throw error;
+  } finally {
+    releaseSandboxOwnerLock(ownerLock);
+  }
+}
+
+function markSandboxCleanupPending(sandboxBase, instanceID, ownerLock) {
+  const ownerPath = path.join(sandboxBase, "owner.pid");
+  const temporaryPath = path.join(sandboxBase, `owner.pid.${instanceID}.cleanup.tmp`);
+  const content = `${process.pid}\ncleanup-pending\n\n${instanceID}\ncleanup-pending\n`;
+
+  try {
+    fs.writeFileSync(temporaryPath, content, "utf8");
+    if (!sandboxOwnerLockIsHeld(ownerLock)) return false;
+    fs.renameSync(temporaryPath, ownerPath);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch {
+      // A successful rename removes the temporary path.
+    }
+  }
+}
+
+function acquireSandboxOwnerLock(sandboxBase) {
+  const lockPath = path.join(sandboxBase, XCODE_SANDBOX_OWNER_LOCK);
+  const token = randomUUID();
+  const createdLock = createSandboxOwnerLock(lockPath, token);
+  if (createdLock) return createdLock;
+
+  const observedLock = readSandboxOwnerLock(lockPath);
+  if (!observedLock) return null;
+  if (Date.now() - observedLock.mtimeMs < XCODE_SANDBOX_OWNER_GRACE_MS) return null;
+
+  const claimedPath = `${lockPath}.${token}.stale`;
+  try {
+    fs.renameSync(lockPath, claimedPath);
+  } catch {
+    return null;
+  }
+
+  const claimedLock = readSandboxOwnerLock(claimedPath);
+  if (!sameSandboxOwnerLock(observedLock, claimedLock)) {
+    restoreClaimedSandboxOwnerLock(claimedPath, lockPath);
+    return null;
+  }
+
+  try {
+    fs.unlinkSync(claimedPath);
+  } catch {
+    restoreClaimedSandboxOwnerLock(claimedPath, lockPath);
+    return null;
+  }
+
+  return createSandboxOwnerLock(lockPath, token);
+}
+
+function createSandboxOwnerLock(lockPath, token) {
+  try {
+    fs.writeFileSync(lockPath, `${token}\n`, { encoding: "utf8", flag: "wx" });
+  } catch {
+    return null;
+  }
+
+  const ownerLock = readSandboxOwnerLock(lockPath);
+  if (!ownerLock || ownerLock.token !== token) return null;
+  return ownerLock;
+}
+
+function readSandboxOwnerLock(lockPath) {
+  try {
+    const before = fs.statSync(lockPath);
+    if (!before.isFile()) return null;
+    const beforeToken = fs.readFileSync(lockPath, "utf8").trim();
+    const after = fs.statSync(lockPath);
+    const afterToken = fs.readFileSync(lockPath, "utf8").trim();
+    if (!sameSandboxOwnerLockVersion(before, after) || beforeToken !== afterToken) return null;
+
+    return {
+      path: lockPath,
+      token: afterToken,
+      dev: after.dev,
+      ino: after.ino,
+      mtimeMs: after.mtimeMs,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function sameSandboxOwnerLockVersion(left, right) {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs &&
+    left.ctimeMs === right.ctimeMs
+  );
+}
+
+function sameSandboxOwnerLock(left, right) {
+  return Boolean(
+    left &&
+      right &&
+      left.dev === right.dev &&
+      left.ino === right.ino &&
+      left.token === right.token,
+  );
+}
+
+function sandboxOwnerLockIsHeld(ownerLock) {
+  return sameSandboxOwnerLock(ownerLock, readSandboxOwnerLock(ownerLock.path));
+}
+
+function restoreClaimedSandboxOwnerLock(claimedPath, lockPath) {
+  try {
+    // A hard link restores the claimed inode only when the lock path is still
+    // absent, without overwriting a lock another actor acquired meanwhile.
+    fs.linkSync(claimedPath, lockPath);
+    fs.unlinkSync(claimedPath);
+  } catch {
+    // Leave the uniquely named claim in place if ownership cannot be restored.
+  }
+}
+
+function releaseSandboxOwnerLock(ownerLock) {
+  if (!sandboxOwnerLockIsHeld(ownerLock)) return;
+
+  const claimedPath = `${ownerLock.path}.${randomUUID()}.release`;
+  try {
+    fs.renameSync(ownerLock.path, claimedPath);
+  } catch {
+    return;
+  }
+
+  const claimedLock = readSandboxOwnerLock(claimedPath);
+  if (!sameSandboxOwnerLock(ownerLock, claimedLock)) {
+    restoreClaimedSandboxOwnerLock(claimedPath, ownerLock.path);
+    return;
+  }
+
+  try {
+    fs.unlinkSync(claimedPath);
+  } catch {
+    // The sandbox may already have been removed with the lock inside it.
+  }
 }
 
 async function handlePluginEvent(state, event) {
@@ -374,6 +566,7 @@ async function handlePluginEvent(state, event) {
   if (typeof sessionID !== "string" || !sessionID) return;
 
   const safeID = safeSessionID(sessionID);
+  state.deletedSandboxSessions.add(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
   await removeOwnedSandbox(state, safeID);
@@ -383,16 +576,36 @@ async function removeOwnedSandbox(state, sessionID) {
   const sandboxPath = state.ownedSandboxes.get(sessionID);
   if (!sandboxPath) return;
 
+  markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.delete(sessionID);
-  await removeManagedSandbox(sandboxPath, state.instanceID);
+  const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+  await removeManagedSandbox(
+    quarantinedPath || sandboxPath,
+    quarantinedPath ? "" : state.instanceID,
+  );
 }
 
-async function removeOwnedSandboxes(state) {
+async function detachOwnedSandboxes(state) {
+  state.disposed = true;
   const sandboxPaths = [...new Set(state.ownedSandboxes.values())];
+  for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
-  await Promise.all(sandboxPaths.map((sandboxPath) => removeManagedSandbox(sandboxPath, state.instanceID)));
+  const cleanupTargets = await Promise.all(
+    sandboxPaths.map(async (sandboxPath) => {
+      const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+      return {
+        path: quarantinedPath || sandboxPath,
+        expectedInstanceID: quarantinedPath ? "" : state.instanceID,
+      };
+    }),
+  );
+  await Promise.all(
+    cleanupTargets.map(({ path: sandboxPath, expectedInstanceID }) =>
+      detachManagedSandbox(sandboxPath, expectedInstanceID),
+    ),
+  );
 }
 
 async function sweepStaleSandboxes(sandboxRoot) {
@@ -405,11 +618,43 @@ async function sweepStaleSandboxes(sandboxRoot) {
 
   await Promise.all(
     entries.map(async (entry) => {
-      if (!entry.isDirectory() || !SAFE_ID_RE.test(entry.name)) return;
+      const isQuarantine = XCODE_SANDBOX_QUARANTINE_RE.test(entry.name);
+      if (!entry.isDirectory() || (!SAFE_ID_RE.test(entry.name) && !isQuarantine)) return;
 
       const sandboxPath = path.join(sandboxRoot, entry.name);
       const owner = await readSandboxOwner(sandboxPath);
-      if (!owner || (await sandboxOwnerIsActive(owner))) return;
+      const cleanupPending = owner?.cleanupPending || sandboxCleanupIsPending(sandboxPath);
+      if (!owner || cleanupPending) {
+        if (!cleanupPending && !isQuarantine && !(await sandboxIsPastOwnerGracePeriod(sandboxPath))) {
+          return;
+        }
+
+        const ownerLock = acquireSandboxOwnerLock(sandboxPath);
+        if (!ownerLock) return;
+        let releaseLock = ownerLock;
+        try {
+          // A writer may have published an owner after the initial read or
+          // stale-stat snapshot. Only remove while the publication lock is
+          // held and the marker is still invalid.
+          const currentOwner = await readSandboxOwner(sandboxPath);
+          const currentCleanupPending =
+            currentOwner?.cleanupPending || sandboxCleanupIsPending(sandboxPath);
+          if (
+            (!currentOwner || currentCleanupPending) &&
+            sandboxOwnerLockIsHeld(ownerLock)
+          ) {
+            const quarantined = await quarantineManagedSandbox(sandboxPath, ownerLock);
+            releaseLock = quarantined.ownerLock;
+            if (quarantined.path) {
+              await removeManagedSandbox(quarantined.path);
+            }
+          }
+        } finally {
+          releaseSandboxOwnerLock(releaseLock);
+        }
+        return;
+      }
+      if (await sandboxOwnerIsActive(owner)) return;
 
       await removeManagedSandbox(sandboxPath);
     }),
@@ -426,13 +671,26 @@ async function readSandboxOwner(sandboxPath) {
     const pid = Number(firstLine);
     if (!Number.isSafeInteger(pid) || pid <= 0) return null;
 
+    const instanceID = lines[3] ?? "";
+    if (!UUID_V4_RE.test(instanceID)) return null;
+
     return {
       pid,
       processStartToken: lines[2] ?? "",
-      instanceID: lines[3] ?? "",
+      instanceID,
+      cleanupPending: lines[4] === "cleanup-pending",
     };
   } catch {
     return null;
+  }
+}
+
+async function sandboxIsPastOwnerGracePeriod(sandboxPath) {
+  try {
+    const stat = await fs.promises.stat(sandboxPath);
+    return Date.now() - stat.mtimeMs >= XCODE_SANDBOX_OWNER_GRACE_MS;
+  } catch {
+    return false;
   }
 }
 
@@ -459,9 +717,10 @@ function readProcessStartToken(pid) {
     let settled = false;
     let stdout = "";
     let child;
+    let timer;
 
     try {
-      child = spawn("ps", ["-p", String(pid), "-o", "lstart="], {
+      child = spawn("/bin/ps", ["-p", String(pid), "-o", "lstart="], {
         env: {
           ...process.env,
           LC_ALL: "C",
@@ -477,24 +736,156 @@ function readProcessStartToken(pid) {
 
     child.stdout?.setEncoding?.("utf8");
     child.stdout?.on?.("data", (chunk) => {
-      stdout += chunk;
+      const remaining = PROCESS_START_OUTPUT_MAX_CHARS - stdout.length;
+      if (remaining > 0) stdout += String(chunk).slice(0, remaining);
     });
     child.on("error", () => finish(""));
-    child.on("close", (code) => finish(code === 0 ? stdout.trim() : ""));
+    child.on("close", (code) => {
+      const firstLine = stdout.trim().split(/\r?\n/, 1)[0] ?? "";
+      finish(code === 0 ? firstLine : "");
+    });
+    timer = setTimeout(() => {
+      try {
+        child.kill?.("SIGTERM");
+      } catch {
+        // Resolving the hook is more important than terminating a broken ps shim.
+      }
+      finish("");
+    }, PROCESS_START_TIMEOUT_MS);
 
     function finish(value) {
       if (settled) return;
       settled = true;
+      clearTimeout(timer);
       resolve(value);
     }
   });
 }
 
 async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
-  const sandboxRoot = path.resolve(os.tmpdir(), XCODE_SANDBOX_DIR);
-  const candidate = path.resolve(sandboxPath);
-  const relative = path.relative(sandboxRoot, candidate);
-  if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return;
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate) return false;
+
+  if (expectedInstanceID) {
+    const owner = await readSandboxOwner(candidate);
+    if (!owner || owner.instanceID !== expectedInstanceID) return false;
+  }
+
+  try {
+    await fs.promises.rm(candidate, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    clearPendingSandboxCleanup(candidate);
+    return true;
+  } catch {
+    // Best-effort cleanup; the next plugin instance will retry through the stale-owner sweep.
+    return false;
+  }
+}
+
+async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate) return "";
+
+  const ownerLock = acquireSandboxOwnerLock(candidate);
+  if (!ownerLock) return "";
+  let releaseLock = ownerLock;
+
+  try {
+    const currentOwner = await readSandboxOwner(candidate);
+    if (!currentOwner || currentOwner.instanceID !== expectedInstanceID) return "";
+    if (!markSandboxCleanupPending(candidate, expectedInstanceID, ownerLock)) return "";
+
+    const quarantinePath = path.join(path.dirname(candidate), `.quarantine-${randomUUID()}`);
+    if (!managedSandboxCandidate(quarantinePath)) return "";
+
+    try {
+      fs.renameSync(candidate, quarantinePath);
+      movePendingSandboxCleanup(candidate, quarantinePath);
+    } catch {
+      return "";
+    }
+
+    releaseLock = {
+      ...ownerLock,
+      path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+    };
+    const relocatedOwner = await readSandboxOwner(quarantinePath);
+    if (
+      !sandboxOwnerLockIsHeld(releaseLock) ||
+      !relocatedOwner ||
+      relocatedOwner.instanceID !== expectedInstanceID ||
+      !relocatedOwner.cleanupPending
+    ) {
+      if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+        movePendingSandboxCleanup(quarantinePath, candidate);
+        releaseLock = { ...releaseLock, path: ownerLock.path };
+      }
+      return "";
+    }
+
+    const ownerPath = path.join(quarantinePath, "owner.pid");
+    const retiredOwnerPath = path.join(quarantinePath, `owner.pid.retired-${randomUUID()}`);
+    try {
+      fs.renameSync(ownerPath, retiredOwnerPath);
+    } catch (error) {
+      if (error?.code !== "ENOENT") return quarantinePath;
+    }
+
+    return quarantinePath;
+  } finally {
+    releaseSandboxOwnerLock(releaseLock);
+  }
+}
+
+async function quarantineManagedSandbox(sandboxPath, ownerLock) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate || !sandboxOwnerLockIsHeld(ownerLock)) {
+    return { path: "", ownerLock };
+  }
+
+  const quarantinePath = path.join(path.dirname(candidate), `.quarantine-${randomUUID()}`);
+  if (!managedSandboxCandidate(quarantinePath)) return { path: "", ownerLock };
+
+  try {
+    fs.renameSync(candidate, quarantinePath);
+    movePendingSandboxCleanup(candidate, quarantinePath);
+  } catch {
+    return { path: "", ownerLock };
+  }
+
+  const relocatedLock = {
+    ...ownerLock,
+    path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+  };
+  const publishedOwner = await readSandboxOwner(quarantinePath);
+  const cleanupPending =
+    publishedOwner?.cleanupPending || sandboxCleanupIsPending(quarantinePath);
+  if (
+    !sandboxOwnerLockIsHeld(relocatedLock) ||
+    (publishedOwner && !cleanupPending)
+  ) {
+    if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+      movePendingSandboxCleanup(quarantinePath, candidate);
+      return { path: "", ownerLock };
+    }
+    // Preserve the quarantine when the original path has already been reused.
+    return { path: "", ownerLock: relocatedLock };
+  }
+
+  return { path: quarantinePath, ownerLock: relocatedLock };
+}
+
+function restoreQuarantinedSandbox(quarantinePath, originalPath) {
+  try {
+    fs.renameSync(quarantinePath, originalPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function detachManagedSandbox(sandboxPath, expectedInstanceID = "") {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (!candidate) return;
 
   if (expectedInstanceID) {
     const owner = await readSandboxOwner(candidate);
@@ -502,10 +893,48 @@ async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
   }
 
   try {
-    await fs.promises.rm(candidate, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    const child = spawn("/bin/rm", ["-rf", candidate], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.on("error", () => {});
+    child.on("exit", (code) => {
+      if (code === 0) clearPendingSandboxCleanup(candidate);
+    });
+    child.unref();
   } catch {
     // Best-effort cleanup; the next plugin instance will retry through the stale-owner sweep.
   }
+}
+
+function managedSandboxCandidate(sandboxPath) {
+  const sandboxRoot = path.resolve(os.tmpdir(), XCODE_SANDBOX_DIR);
+  const candidate = path.resolve(sandboxPath);
+  const relative = path.relative(sandboxRoot, candidate);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return "";
+  return candidate;
+}
+
+function markPendingSandboxCleanup(sandboxPath) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (candidate) pendingSandboxCleanups.add(candidate);
+}
+
+function clearPendingSandboxCleanup(sandboxPath) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  if (candidate) pendingSandboxCleanups.delete(candidate);
+}
+
+function movePendingSandboxCleanup(sourcePath, destinationPath) {
+  const source = managedSandboxCandidate(sourcePath);
+  const destination = managedSandboxCandidate(destinationPath);
+  if (!source || !destination || !pendingSandboxCleanups.delete(source)) return;
+  pendingSandboxCleanups.add(destination);
+}
+
+function sandboxCleanupIsPending(sandboxPath) {
+  const candidate = managedSandboxCandidate(sandboxPath);
+  return Boolean(candidate && pendingSandboxCleanups.has(candidate));
 }
 
 function prependPath(entry, current) {

--- a/iOSSimulator/common/opencode-plugin.js
+++ b/iOSSimulator/common/opencode-plugin.js
@@ -7,6 +7,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const MCP_PLACEHOLDER_RE = /\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}/g;
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const PROCESS_START_OUTPUT_MAX_CHARS = 256;
 const PROCESS_START_TIMEOUT_MS = 5_000;
@@ -27,7 +28,11 @@ globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] = pendingSandboxCleanups;
 
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
-  return async () => {
+  return async (input = {}) => {
+    const mcpContext = {
+      pluginRoot,
+      projectDir: input?.worktree || input?.directory,
+    };
     const state = {
       pluginJson: null,
       infoJson: null,
@@ -47,7 +52,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       config: async (config) => {
         loadMetadata(pluginRoot, state);
         registerSkills(config, pluginRoot);
-        registerMcpServers(config, pluginRoot);
+        registerMcpServers(config, pluginRoot, mcpContext);
         state.config = config;
       },
 
@@ -115,7 +120,7 @@ function registerSkills(config, pluginRoot) {
   if (!config.skills.paths.includes(skillsDir)) config.skills.paths.push(skillsDir);
 }
 
-function registerMcpServers(config, pluginRoot) {
+function registerMcpServers(config, pluginRoot, context) {
   const mcpConfig = readJsonFile(path.join(pluginRoot, ".mcp.json"));
   const servers = mcpConfig?.mcpServers;
   if (!isObject(servers)) return;
@@ -125,58 +130,117 @@ function registerMcpServers(config, pluginRoot) {
   for (const [name, server] of Object.entries(servers)) {
     if (!isObject(server) || config.mcp[name]) continue;
 
-    const translated = translateMcpServer(server);
+    const translated = translateMcpServer(server, context);
     if (translated) config.mcp[name] = translated;
   }
 }
 
-function translateMcpServer(server) {
+function translateMcpServer(server, context) {
   if (typeof server.url === "string") {
     const translated = {
       type: "remote",
-      url: server.url,
+      url: expandMcpString(server.url, context),
     };
-    copyOptionalFields(server, translated, ["enabled", "headers", "timeout"]);
+    copyOptionalFields(server, translated, ["enabled", "headers", "timeout"], context);
+    const oauth = translateMcpOAuth(server.oauth);
+    if (oauth !== undefined) translated.oauth = oauth;
     return translated;
   }
 
-  const command = normalizeCommand(server.command, server.args);
+  const command = normalizeCommand(server.command, server.args, context);
   if (!command) return null;
 
   const translated = {
     type: "local",
     command,
   };
-  copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"]);
+  copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"], context);
 
   const environment = isObject(server.environment) ? server.environment : server.env;
-  if (isObject(environment)) translated.environment = stringifyRecord(environment);
+  if (isObject(environment)) translated.environment = expandMcpRecord(environment, context);
 
   return translated;
 }
 
-function normalizeCommand(command, args) {
+function translateMcpOAuth(oauth) {
+  if (oauth === false) return false;
+  if (!isObject(oauth)) return undefined;
+
+  const translated = {};
+  for (const key of ["clientId", "clientSecret", "redirectUri"]) {
+    if (typeof oauth[key] === "string") translated[key] = oauth[key];
+  }
+
+  if (
+    Number.isInteger(oauth.callbackPort) &&
+    oauth.callbackPort >= 1 &&
+    oauth.callbackPort <= 65_535
+  ) {
+    translated.callbackPort = oauth.callbackPort;
+  }
+
+  if (typeof oauth.scopes === "string") {
+    translated.scope = oauth.scopes;
+  } else if (typeof oauth.scope === "string") {
+    translated.scope = oauth.scope;
+  }
+
+  return translated;
+}
+
+function normalizeCommand(command, args, context) {
   if (Array.isArray(command) && command.every((item) => typeof item === "string")) {
-    return command;
+    return command.map((item) => expandMcpString(item, context));
   }
 
   if (typeof command !== "string") return null;
 
-  const result = [command];
   if (Array.isArray(args)) {
-    for (const arg of args) {
-      if (typeof arg !== "string") return null;
-      result.push(arg);
-    }
+    if (!args.every((arg) => typeof arg === "string")) return null;
+    return [command, ...args].map((item) => expandMcpString(item, context));
   }
-  return result;
+  return [expandMcpString(command, context)];
 }
 
-function copyOptionalFields(source, target, keys) {
+function copyOptionalFields(source, target, keys, context) {
   for (const key of keys) {
     if (source[key] === undefined) continue;
-    target[key] = key === "headers" && isObject(source[key]) ? stringifyRecord(source[key]) : source[key];
+    if (key === "headers" && isObject(source[key])) {
+      target[key] = expandMcpRecord(source[key], context);
+    } else if (key === "cwd" && typeof source[key] === "string") {
+      target[key] = expandMcpString(source[key], context);
+    } else {
+      target[key] = source[key];
+    }
   }
+}
+
+function expandMcpRecord(value, context) {
+  return Object.fromEntries(
+    Object.entries(stringifyRecord(value)).map(([key, item]) => [
+      key,
+      expandMcpString(item, context),
+    ]),
+  );
+}
+
+function expandMcpString(value, context) {
+  return value.replace(MCP_PLACEHOLDER_RE, (_, name, defaultValue) => {
+    const resolved = mcpVariable(name, context);
+    if (defaultValue !== undefined && (resolved === undefined || resolved === "")) {
+      return defaultValue;
+    }
+    if (resolved === undefined) {
+      throw new Error(`MCP configuration references unset variable: ${name}`);
+    }
+    return resolved;
+  });
+}
+
+function mcpVariable(name, context) {
+  if (name === "CLAUDE_PLUGIN_ROOT") return context.pluginRoot;
+  if (name === "CLAUDE_PROJECT_DIR") return context.projectDir;
+  return process.env[name];
 }
 
 async function appendSystemContext(pluginRoot, state, input, output) {

--- a/iOSSimulator/common/opencode-plugin.js
+++ b/iOSSimulator/common/opencode-plugin.js
@@ -29,13 +29,10 @@ globalThis[XCODE_SANDBOX_PENDING_CLEANUPS_KEY] = pendingSandboxCleanups;
 export function createOpenCodePlugin(pluginRootUrl) {
   const pluginRoot = normalizePluginRoot(pluginRootUrl);
   return async (input = {}) => {
-    const mcpContext = {
-      pluginRoot,
-      projectDir: input?.worktree || input?.directory,
-    };
     const state = {
       pluginJson: null,
       infoJson: null,
+      pluginData: null,
       config: null,
       instanceID: randomUUID(),
       processStartToken: null,
@@ -46,6 +43,11 @@ export function createOpenCodePlugin(pluginRootUrl) {
       deletedSandboxSessions: new Set(),
       sandboxSweepDone: false,
       disposed: false,
+    };
+    const mcpContext = {
+      pluginRoot,
+      pluginData: () => pluginDataDirectory(pluginRoot, state),
+      projectDir: input?.worktree || input?.directory,
     };
 
     return {
@@ -111,6 +113,19 @@ function loadMetadata(pluginRoot, state) {
   }
 }
 
+function pluginDataDirectory(pluginRoot, state) {
+  if (state.pluginData) return state.pluginData;
+
+  loadMetadata(pluginRoot, state);
+  const pluginName = state.pluginJson.name || path.basename(pluginRoot) || "plugin";
+  const pluginID = String(pluginName).replace(/[^A-Za-z0-9_-]/g, "-");
+  const dataHome = process.env.XDG_DATA_HOME || path.join(os.homedir(), ".local", "share");
+  const pluginData = path.resolve(dataHome, "opencode", "plugin-data", pluginID);
+  fs.mkdirSync(pluginData, { recursive: true });
+  state.pluginData = pluginData;
+  return pluginData;
+}
+
 function registerSkills(config, pluginRoot) {
   const skillsDir = path.join(pluginRoot, "skills");
   if (!hasSkillDirectories(skillsDir)) return;
@@ -157,7 +172,17 @@ function translateMcpServer(server, context) {
   copyOptionalFields(server, translated, ["cwd", "enabled", "timeout"], context);
 
   const environment = isObject(server.environment) ? server.environment : server.env;
-  if (isObject(environment)) translated.environment = expandMcpRecord(environment, context);
+  translated.environment = {
+    ...(isObject(environment) ? expandMcpRecord(environment, context) : {}),
+    ...expandMcpRecord(
+      {
+        CLAUDE_PLUGIN_ROOT: "${CLAUDE_PLUGIN_ROOT}",
+        CLAUDE_PLUGIN_DATA: "${CLAUDE_PLUGIN_DATA}",
+        CLAUDE_PROJECT_DIR: "${CLAUDE_PROJECT_DIR}",
+      },
+      context,
+    ),
+  };
 
   return translated;
 }
@@ -239,6 +264,7 @@ function expandMcpString(value, context) {
 
 function mcpVariable(name, context) {
   if (name === "CLAUDE_PLUGIN_ROOT") return context.pluginRoot;
+  if (name === "CLAUDE_PLUGIN_DATA") return context.pluginData();
   if (name === "CLAUDE_PROJECT_DIR") return context.projectDir;
   return process.env[name];
 }

--- a/iOSSimulator/common/opencode-plugin.js
+++ b/iOSSimulator/common/opencode-plugin.js
@@ -8,11 +8,47 @@ import { fileURLToPath } from "node:url";
 
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
 const MCP_PLACEHOLDER_RE = /\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}/g;
+const MCP_COMPATIBILITY_ENVIRONMENT_KEYS = new Set([
+  "CLAUDE_PLUGIN_ROOT",
+  "CLAUDE_PLUGIN_DATA",
+  "CLAUDE_PROJECT_DIR",
+]);
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const PROCESS_START_OUTPUT_MAX_CHARS = 256;
 const PROCESS_START_TIMEOUT_MS = 5_000;
+const PROCESS_TERMINATION_GRACE_MS = 250;
 const XCODE_MCP_CACHE_TTL_MS = 30_000;
+const XCRUN_OPTIONS_WITH_VALUE = new Set([
+  "--sdk",
+  "-sdk",
+  "--toolchain",
+  "-toolchain",
+]);
+const XCRUN_OPTIONS_WITHOUT_VALUE = new Set([
+  "-h",
+  "--help",
+  "--version",
+  "-v",
+  "--verbose",
+  "-l",
+  "--log",
+  "-f",
+  "--find",
+  "-r",
+  "--run",
+  "-n",
+  "--no-cache",
+  "-k",
+  "--kill-cache",
+  "--show-sdk-path",
+  "--show-sdk-version",
+  "--show-sdk-build-version",
+  "--show-sdk-platform-path",
+  "--show-sdk-platform-version",
+  "--show-toolchain-path",
+]);
 const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
+const XCODE_SANDBOX_MODE = 0o700;
 const XCODE_SANDBOX_OWNER_GRACE_MS = 60_000;
 const XCODE_SANDBOX_OWNER_LOCK = ".owner.lock";
 const XCODE_SANDBOX_QUARANTINE_RE =
@@ -39,7 +75,9 @@ export function createOpenCodePlugin(pluginRootUrl) {
       deniedOnce: new Set(),
       xcodeMcpCache: new Map(),
       xcodeMcpApprovalSessions: new Set(),
+      sandboxRoot: null,
       ownedSandboxes: new Map(),
+      ownedSandboxIdentities: new Map(),
       deletedSandboxSessions: new Set(),
       sandboxSweepDone: false,
       disposed: false,
@@ -146,8 +184,45 @@ function registerMcpServers(config, pluginRoot, context) {
     if (!isObject(server) || config.mcp[name]) continue;
 
     const translated = translateMcpServer(server, context);
-    if (translated) config.mcp[name] = translated;
+    if (translated && !hasMcpEndpoint(config.mcp, translated)) {
+      config.mcp[name] = translated;
+    }
   }
+}
+
+function hasMcpEndpoint(servers, candidate) {
+  return Object.values(servers).some((server) => {
+    if (!isObject(server) || server.type !== candidate.type) return false;
+    if (candidate.type === "remote") return server.url === candidate.url;
+    if (candidate.type !== "local") return false;
+    if (!Array.isArray(server.command) || !Array.isArray(candidate.command)) return false;
+    return (
+      server.command.length === candidate.command.length &&
+      server.command.every((item, index) => item === candidate.command[index]) &&
+      server.cwd === candidate.cwd &&
+      mcpEnvironmentMatches(server.environment, candidate.environment)
+    );
+  });
+}
+
+function mcpEnvironmentMatches(left, right) {
+  const leftEntries = comparableMcpEnvironment(left);
+  const rightEntries = comparableMcpEnvironment(right);
+  if (!leftEntries || !rightEntries || leftEntries.length !== rightEntries.length) {
+    return false;
+  }
+  return leftEntries.every(([key, value], index) => {
+    const [rightKey, rightValue] = rightEntries[index];
+    return key === rightKey && value === rightValue;
+  });
+}
+
+function comparableMcpEnvironment(environment) {
+  if (environment === undefined) return [];
+  if (!isObject(environment)) return null;
+  return Object.entries(environment)
+    .filter(([key]) => !MCP_COMPATIBILITY_ENVIRONMENT_KEYS.has(key))
+    .sort(([left], [right]) => left.localeCompare(right));
 }
 
 function translateMcpServer(server, context) {
@@ -338,14 +413,40 @@ function hasConfiguredMcpbridge(config) {
     if (!isObject(server) || server.enabled === false || server.type !== "local") return false;
 
     const command = Array.isArray(server.command) ? server.command : [server.command];
-    return command.some((part) => {
-      if (typeof part !== "string") return false;
-      return part
-        .trim()
-        .split(/\s+/)
-        .some((token) => path.basename(token.replace(/^['"]|['"]$/g, "")) === "mcpbridge");
-    });
+    const executable = commandBasename(command[0]);
+    if (executable === "mcpbridge") return true;
+    if (executable !== "xcrun") return false;
+    return xcrunToolBasename(command.slice(1)) === "mcpbridge";
   });
+}
+
+function commandBasename(value) {
+  const commandPart = normalizedCommandPart(value);
+  return commandPart ? path.basename(commandPart) : "";
+}
+
+function normalizedCommandPart(value) {
+  if (typeof value !== "string") return "";
+  return value.trim().replace(/^['"]|['"]$/g, "");
+}
+
+function xcrunToolBasename(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = normalizedCommandPart(args[index]);
+    if (!argument) return "";
+    if (argument === "--") {
+      return commandBasename(args[index + 1]);
+    }
+    if (XCRUN_OPTIONS_WITH_VALUE.has(argument)) {
+      index += 1;
+      continue;
+    }
+    if (/^(?:--?sdk|--?toolchain)=/.test(argument)) continue;
+    if (XCRUN_OPTIONS_WITHOUT_VALUE.has(argument)) continue;
+    if (argument.startsWith("-")) return "";
+    return path.basename(argument);
+  }
+  return "";
 }
 
 function startXcodeMcpApproval(pluginRoot, state, sessionID) {
@@ -378,22 +479,74 @@ function startXcodeMcpApproval(pluginRoot, state, sessionID) {
 function commandSucceeds(command, args, timeoutMs) {
   return new Promise((resolve) => {
     let settled = false;
-    const child = spawn(command, args, { stdio: "ignore" });
-    const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      finish(false);
-    }, timeoutMs);
+    let timedOut = false;
+    let timeoutTimer;
+    let forceKillTimer;
+    let child;
 
-    child.on("error", () => finish(false));
-    child.on("exit", (code) => finish(code === 0));
+    try {
+      child = spawn(command, args, { stdio: "ignore" });
+    } catch {
+      resolve(false);
+      return;
+    }
+
+    const onError = () => finish(false);
+    const onExit = (code) => finish(!timedOut && code === 0);
+    child.on("error", onError);
+    child.on("exit", onExit);
+    timeoutTimer = setTimeout(beginTermination, timeoutMs);
+
+    function beginTermination() {
+      if (settled) return;
+      timedOut = true;
+      forceKillTimer = terminateChildAfterGrace(
+        child,
+        () => !settled,
+        () => finish(false),
+      );
+    }
 
     function finish(result) {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      clearTimeout(timeoutTimer);
+      clearTimeout(forceKillTimer);
+      child.removeListener?.("error", onError);
+      child.removeListener?.("exit", onExit);
       resolve(result);
     }
   });
+}
+
+function terminateChildAfterGrace(child, isPending, onForcedTermination) {
+  try {
+    child.kill("SIGTERM");
+  } catch {
+    // Continue to forced termination so the timed-out child is detached.
+  }
+  if (!isPending()) return undefined;
+
+  return setTimeout(() => {
+    if (!isPending()) return;
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // The process may have exited between the grace timer and this call.
+    }
+    try {
+      child.stdout?.destroy?.();
+      child.stderr?.destroy?.();
+    } catch {
+      // Detaching the child still allows the parent to continue.
+    }
+    try {
+      child.unref();
+    } catch {
+      // Resolving the caller is more important than detaching a broken shim.
+    }
+    onForcedTermination();
+  }, PROCESS_TERMINATION_GRACE_MS);
 }
 
 function applyPreToolUseRules(state, input, output) {
@@ -443,10 +596,10 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
 
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
   if (state.disposed || state.deletedSandboxSessions.has(sessionID)) return;
-  const sandboxRoot = path.join(os.tmpdir(), XCODE_SANDBOX_DIR);
+  const sandboxRoot = secureSandboxRoot(state);
   // Plugin instances never reuse a sandbox path, so an older instance cannot
   // delete a replacement instance's active sandbox after an ownership check.
-  const sandboxBase = path.join(sandboxRoot, `${sessionID}-${state.instanceID}`);
+  const sandboxBase = path.join(sandboxRoot.path, `${sessionID}-${state.instanceID}`);
   state.ownedSandboxes.set(sessionID, sandboxBase);
 
   if (!state.processStartToken) {
@@ -463,12 +616,146 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   const buildDir = path.join(sandboxBase, "build");
   const packagesDir = path.join(sandboxBase, "packages");
 
-  fs.mkdirSync(buildDir, { recursive: true });
-  fs.mkdirSync(packagesDir, { recursive: true });
-  writeSandboxOwner(sandboxBase, state.processStartToken, state.instanceID);
+  const sandboxIdentity = secureSandboxDirectory(sandboxBase, sandboxRoot);
+  state.ownedSandboxIdentities.set(sessionID, sandboxIdentity);
+  if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
+  secureSandboxDirectory(buildDir, sandboxIdentity);
+  secureSandboxDirectory(packagesDir, sandboxIdentity);
+  writeSandboxOwner(
+    sandboxIdentity,
+    state.processStartToken,
+    state.instanceID,
+  );
 
   output.env.SANDBOX_DERIVED_DATA = buildDir;
   output.env.SANDBOX_PACKAGES = packagesDir;
+}
+
+function secureSandboxRoot(state) {
+  if (state.sandboxRoot) {
+    revalidateSandboxDirectory(state.sandboxRoot);
+    return state.sandboxRoot;
+  }
+
+  const temporaryDirectory = path.resolve(os.tmpdir());
+  const canonicalTemporaryDirectory = canonicalPath(temporaryDirectory);
+  const sandboxRoot = path.join(temporaryDirectory, XCODE_SANDBOX_DIR);
+  const expectedCanonicalPath = path.join(
+    canonicalTemporaryDirectory,
+    XCODE_SANDBOX_DIR,
+  );
+
+  createDirectoryNonRecursively(sandboxRoot);
+  const identity = inspectSandboxDirectory(
+    sandboxRoot,
+    expectedCanonicalPath,
+    null,
+  );
+  state.sandboxRoot = identity;
+  return identity;
+}
+
+function secureSandboxDirectory(directoryPath, parentIdentity) {
+  revalidateSandboxDirectory(parentIdentity);
+
+  const candidate = path.resolve(directoryPath);
+  const parentPath = path.resolve(parentIdentity.path);
+  if (path.dirname(candidate) !== parentPath) {
+    throw new Error("Sandbox directory must be a direct child of its trusted parent");
+  }
+
+  const name = path.basename(candidate);
+  if (!SAFE_ID_RE.test(name)) {
+    throw new Error("Sandbox directory has an unsafe name");
+  }
+
+  createDirectoryNonRecursively(candidate);
+  return inspectSandboxDirectory(
+    candidate,
+    path.join(parentIdentity.canonicalPath, name),
+    parentIdentity,
+  );
+}
+
+function createDirectoryNonRecursively(directoryPath) {
+  try {
+    fs.mkdirSync(directoryPath, { mode: XCODE_SANDBOX_MODE });
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+}
+
+function inspectSandboxDirectory(directoryPath, expectedCanonicalPath, parentIdentity) {
+  if (typeof process.getuid !== "function") {
+    throw new Error("Xcode sandbox setup requires POSIX ownership checks");
+  }
+
+  const directoryFlags =
+    fs.constants.O_RDONLY |
+    (fs.constants.O_DIRECTORY ?? 0) |
+    (fs.constants.O_NOFOLLOW ?? 0);
+  const descriptor = fs.openSync(directoryPath, directoryFlags);
+  try {
+    const before = fs.fstatSync(descriptor);
+    if (!before.isDirectory() || before.uid !== process.getuid()) {
+      throw new Error("Sandbox directory is not owned by the current user");
+    }
+
+    fs.fchmodSync(descriptor, XCODE_SANDBOX_MODE);
+    const after = fs.fstatSync(descriptor);
+    const link = fs.lstatSync(directoryPath);
+    if (
+      !after.isDirectory() ||
+      !link.isDirectory() ||
+      link.isSymbolicLink() ||
+      after.uid !== process.getuid() ||
+      link.uid !== process.getuid() ||
+      after.dev !== link.dev ||
+      after.ino !== link.ino ||
+      (after.mode & 0o777) !== XCODE_SANDBOX_MODE
+    ) {
+      throw new Error("Sandbox directory identity changed during validation");
+    }
+
+    const resolved = canonicalPath(directoryPath);
+    if (resolved !== path.resolve(expectedCanonicalPath)) {
+      throw new Error("Sandbox directory escaped its trusted parent");
+    }
+
+    return {
+      path: path.resolve(directoryPath),
+      canonicalPath: resolved,
+      dev: after.dev,
+      ino: after.ino,
+      uid: after.uid,
+      parent: parentIdentity,
+    };
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function revalidateSandboxDirectory(identity) {
+  if (!identity) throw new Error("Sandbox directory identity is unavailable");
+  if (identity.parent) revalidateSandboxDirectory(identity.parent);
+
+  const current = inspectSandboxDirectory(
+    identity.path,
+    identity.canonicalPath,
+    identity.parent,
+  );
+  if (
+    current.dev !== identity.dev ||
+    current.ino !== identity.ino ||
+    current.uid !== identity.uid
+  ) {
+    throw new Error("Sandbox directory was replaced");
+  }
+  return current;
+}
+
+function canonicalPath(filePath) {
+  return fs.realpathSync.native?.(filePath) ?? fs.realpathSync(filePath);
 }
 
 function sandboxSetupIsCancelled(state, sessionID, sandboxBase) {
@@ -479,15 +766,25 @@ function sandboxSetupIsCancelled(state, sessionID, sandboxBase) {
   );
 }
 
-function writeSandboxOwner(sandboxBase, processStartToken, instanceID) {
+function writeSandboxOwner(sandboxIdentity, processStartToken, instanceID) {
+  revalidateSandboxDirectory(sandboxIdentity);
+  const sandboxBase = sandboxIdentity.path;
   const ownerPath = path.join(sandboxBase, "owner.pid");
   const temporaryPath = path.join(sandboxBase, `owner.pid.${instanceID}.tmp`);
   const content = `${process.pid}\n${process.argv[0] ?? "opencode"}\n${processStartToken}\n${instanceID}\n`;
-  const ownerLock = acquireSandboxOwnerLock(sandboxBase);
+  const ownerLock = acquireSandboxOwnerLock(
+    sandboxBase,
+    sandboxIdentity.parent,
+    sandboxIdentity,
+  );
   if (!ownerLock) throw new Error("Sandbox owner is being updated or removed");
 
   try {
-    fs.writeFileSync(temporaryPath, content, "utf8");
+    fs.writeFileSync(temporaryPath, content, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
     if (!sandboxOwnerLockIsHeld(ownerLock)) {
       throw new Error("Sandbox owner lock changed during update");
     }
@@ -510,7 +807,11 @@ function markSandboxCleanupPending(sandboxBase, instanceID, ownerLock) {
   const content = `${process.pid}\ncleanup-pending\n\n${instanceID}\ncleanup-pending\n`;
 
   try {
-    fs.writeFileSync(temporaryPath, content, "utf8");
+    fs.writeFileSync(temporaryPath, content, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
     if (!sandboxOwnerLockIsHeld(ownerLock)) return false;
     fs.renameSync(temporaryPath, ownerPath);
     return true;
@@ -525,11 +826,31 @@ function markSandboxCleanupPending(sandboxBase, instanceID, ownerLock) {
   }
 }
 
-function acquireSandboxOwnerLock(sandboxBase) {
+function acquireSandboxOwnerLock(
+  sandboxBase,
+  sandboxRootIdentity = null,
+  expectedSandboxIdentity = null,
+) {
+  let sandboxIdentity = null;
+  if (sandboxRootIdentity) {
+    sandboxIdentity = secureExistingManagedSandbox(
+      sandboxBase,
+      sandboxRootIdentity,
+      expectedSandboxIdentity,
+    );
+    if (!sandboxIdentity) return null;
+  }
+
   const lockPath = path.join(sandboxBase, XCODE_SANDBOX_OWNER_LOCK);
   const token = randomUUID();
   const createdLock = createSandboxOwnerLock(lockPath, token);
-  if (createdLock) return createdLock;
+  if (createdLock) {
+    return attachSandboxIdentityToLock(
+      createdLock,
+      sandboxRootIdentity,
+      sandboxIdentity,
+    );
+  }
 
   const observedLock = readSandboxOwnerLock(lockPath);
   if (!observedLock) return null;
@@ -555,7 +876,16 @@ function acquireSandboxOwnerLock(sandboxBase) {
     return null;
   }
 
-  return createSandboxOwnerLock(lockPath, token);
+  return attachSandboxIdentityToLock(
+    createSandboxOwnerLock(lockPath, token),
+    sandboxRootIdentity,
+    sandboxIdentity,
+  );
+}
+
+function attachSandboxIdentityToLock(ownerLock, sandboxRootIdentity, sandboxIdentity) {
+  if (!ownerLock || !sandboxRootIdentity || !sandboxIdentity) return ownerLock;
+  return { ...ownerLock, sandboxRootIdentity, sandboxIdentity };
 }
 
 function createSandboxOwnerLock(lockPath, token) {
@@ -612,6 +942,16 @@ function sameSandboxOwnerLock(left, right) {
 }
 
 function sandboxOwnerLockIsHeld(ownerLock) {
+  if (
+    ownerLock?.sandboxRootIdentity &&
+    !secureExistingManagedSandbox(
+      ownerLock.sandboxIdentity.path,
+      ownerLock.sandboxRootIdentity,
+      ownerLock.sandboxIdentity,
+    )
+  ) {
+    return false;
+  }
   return sameSandboxOwnerLock(ownerLock, readSandboxOwnerLock(ownerLock.path));
 }
 
@@ -666,42 +1006,78 @@ async function removeOwnedSandbox(state, sessionID) {
   const sandboxPath = state.ownedSandboxes.get(sessionID);
   if (!sandboxPath) return;
 
+  const sandboxIdentity = state.ownedSandboxIdentities.get(sessionID);
   markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.delete(sessionID);
-  const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+  state.ownedSandboxIdentities.delete(sessionID);
+  if (!state.sandboxRoot || !sandboxIdentity) return;
+
+  const quarantinedPath = await quarantineOwnedSandbox(
+    sandboxPath,
+    state.instanceID,
+    state.sandboxRoot,
+    sandboxIdentity,
+  );
+  const cleanupIdentity = quarantinedPath
+    ? relocatedSandboxIdentity(sandboxIdentity, quarantinedPath)
+    : sandboxIdentity;
   await removeManagedSandbox(
     quarantinedPath || sandboxPath,
     quarantinedPath ? "" : state.instanceID,
+    state.sandboxRoot,
+    cleanupIdentity,
   );
 }
 
 async function detachOwnedSandboxes(state) {
   state.disposed = true;
-  const sandboxPaths = [...new Set(state.ownedSandboxes.values())];
+  const sandboxes = [...state.ownedSandboxes.entries()].map(([sessionID, sandboxPath]) => ({
+    sandboxPath,
+    sandboxIdentity: state.ownedSandboxIdentities.get(sessionID),
+  }));
+  const sandboxPaths = [...new Set(sandboxes.map(({ sandboxPath }) => sandboxPath))];
   for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
+  state.ownedSandboxIdentities.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
   const cleanupTargets = await Promise.all(
-    sandboxPaths.map(async (sandboxPath) => {
-      const quarantinedPath = await quarantineOwnedSandbox(sandboxPath, state.instanceID);
+    sandboxes.map(async ({ sandboxPath, sandboxIdentity }) => {
+      if (!state.sandboxRoot || !sandboxIdentity) return null;
+      const quarantinedPath = await quarantineOwnedSandbox(
+        sandboxPath,
+        state.instanceID,
+        state.sandboxRoot,
+        sandboxIdentity,
+      );
       return {
         path: quarantinedPath || sandboxPath,
         expectedInstanceID: quarantinedPath ? "" : state.instanceID,
+        identity: quarantinedPath
+          ? relocatedSandboxIdentity(sandboxIdentity, quarantinedPath)
+          : sandboxIdentity,
       };
     }),
   );
   await Promise.all(
-    cleanupTargets.map(({ path: sandboxPath, expectedInstanceID }) =>
-      detachManagedSandbox(sandboxPath, expectedInstanceID),
+    cleanupTargets.filter(Boolean).map(({ path: sandboxPath, expectedInstanceID, identity }) =>
+      detachManagedSandbox(
+        sandboxPath,
+        expectedInstanceID,
+        state.sandboxRoot,
+        identity,
+      ),
     ),
   );
 }
 
-async function sweepStaleSandboxes(sandboxRoot) {
+async function sweepStaleSandboxes(sandboxRootIdentity) {
   let entries;
   try {
-    entries = await fs.promises.readdir(sandboxRoot, { withFileTypes: true });
+    revalidateSandboxDirectory(sandboxRootIdentity);
+    entries = await fs.promises.readdir(sandboxRootIdentity.path, {
+      withFileTypes: true,
+    });
   } catch {
     return;
   }
@@ -711,7 +1087,12 @@ async function sweepStaleSandboxes(sandboxRoot) {
       const isQuarantine = XCODE_SANDBOX_QUARANTINE_RE.test(entry.name);
       if (!entry.isDirectory() || (!SAFE_ID_RE.test(entry.name) && !isQuarantine)) return;
 
-      const sandboxPath = path.join(sandboxRoot, entry.name);
+      const sandboxPath = path.join(sandboxRootIdentity.path, entry.name);
+      const sandboxIdentity = secureExistingManagedSandbox(
+        sandboxPath,
+        sandboxRootIdentity,
+      );
+      if (!sandboxIdentity) return;
       const owner = await readSandboxOwner(sandboxPath);
       const cleanupPending = owner?.cleanupPending || sandboxCleanupIsPending(sandboxPath);
       if (!owner || cleanupPending) {
@@ -719,7 +1100,11 @@ async function sweepStaleSandboxes(sandboxRoot) {
           return;
         }
 
-        const ownerLock = acquireSandboxOwnerLock(sandboxPath);
+        const ownerLock = acquireSandboxOwnerLock(
+          sandboxPath,
+          sandboxRootIdentity,
+          sandboxIdentity,
+        );
         if (!ownerLock) return;
         let releaseLock = ownerLock;
         try {
@@ -733,10 +1118,20 @@ async function sweepStaleSandboxes(sandboxRoot) {
             (!currentOwner || currentCleanupPending) &&
             sandboxOwnerLockIsHeld(ownerLock)
           ) {
-            const quarantined = await quarantineManagedSandbox(sandboxPath, ownerLock);
+            const quarantined = await quarantineManagedSandbox(
+              sandboxPath,
+              ownerLock,
+              sandboxRootIdentity,
+              sandboxIdentity,
+            );
             releaseLock = quarantined.ownerLock;
             if (quarantined.path) {
-              await removeManagedSandbox(quarantined.path);
+              await removeManagedSandbox(
+                quarantined.path,
+                "",
+                sandboxRootIdentity,
+                relocatedSandboxIdentity(sandboxIdentity, quarantined.path),
+              );
             }
           }
         } finally {
@@ -746,7 +1141,12 @@ async function sweepStaleSandboxes(sandboxRoot) {
       }
       if (await sandboxOwnerIsActive(owner)) return;
 
-      await removeManagedSandbox(sandboxPath);
+      await removeManagedSandbox(
+        sandboxPath,
+        "",
+        sandboxRootIdentity,
+        sandboxIdentity,
+      );
     }),
   );
 }
@@ -805,9 +1205,11 @@ async function sandboxOwnerIsActive(owner) {
 function readProcessStartToken(pid) {
   return new Promise((resolve) => {
     let settled = false;
+    let timedOut = false;
     let stdout = "";
     let child;
-    let timer;
+    let timeoutTimer;
+    let forceKillTimer;
 
     try {
       child = spawn("/bin/ps", ["-p", String(pid), "-o", "lstart="], {
@@ -824,37 +1226,61 @@ function readProcessStartToken(pid) {
       return;
     }
 
-    child.stdout?.setEncoding?.("utf8");
-    child.stdout?.on?.("data", (chunk) => {
+    const onData = (chunk) => {
       const remaining = PROCESS_START_OUTPUT_MAX_CHARS - stdout.length;
       if (remaining > 0) stdout += String(chunk).slice(0, remaining);
-    });
-    child.on("error", () => finish(""));
-    child.on("close", (code) => {
+    };
+    const onError = () => finish("");
+    const onClose = (code) => {
       const firstLine = stdout.trim().split(/\r?\n/, 1)[0] ?? "";
-      finish(code === 0 ? firstLine : "");
-    });
-    timer = setTimeout(() => {
-      try {
-        child.kill?.("SIGTERM");
-      } catch {
-        // Resolving the hook is more important than terminating a broken ps shim.
-      }
-      finish("");
+      finish(!timedOut && code === 0 ? firstLine : "");
+    };
+
+    child.stdout?.setEncoding?.("utf8");
+    child.stdout?.on?.("data", onData);
+    child.on("error", onError);
+    child.on("close", onClose);
+    timeoutTimer = setTimeout(() => {
+      if (settled) return;
+      timedOut = true;
+      forceKillTimer = terminateChildAfterGrace(
+        child,
+        () => !settled,
+        () => finish(""),
+      );
     }, PROCESS_START_TIMEOUT_MS);
 
     function finish(value) {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      clearTimeout(timeoutTimer);
+      clearTimeout(forceKillTimer);
+      child.stdout?.removeListener?.("data", onData);
+      child.removeListener?.("error", onError);
+      child.removeListener?.("close", onClose);
       resolve(value);
     }
   });
 }
 
-async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
+async function removeManagedSandbox(
+  sandboxPath,
+  expectedInstanceID = "",
+  sandboxRootIdentity = null,
+  expectedSandboxIdentity = null,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
   if (!candidate) return false;
+  if (
+    !sandboxRootIdentity ||
+    !secureExistingManagedSandbox(
+      candidate,
+      sandboxRootIdentity,
+      expectedSandboxIdentity,
+    )
+  ) {
+    return false;
+  }
 
   if (expectedInstanceID) {
     const owner = await readSandboxOwner(candidate);
@@ -871,11 +1297,26 @@ async function removeManagedSandbox(sandboxPath, expectedInstanceID = "") {
   }
 }
 
-async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
+async function quarantineOwnedSandbox(
+  sandboxPath,
+  expectedInstanceID,
+  sandboxRootIdentity,
+  expectedSandboxIdentity,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
   if (!candidate) return "";
+  const sandboxIdentity = secureExistingManagedSandbox(
+    candidate,
+    sandboxRootIdentity,
+    expectedSandboxIdentity,
+  );
+  if (!sandboxIdentity) return "";
 
-  const ownerLock = acquireSandboxOwnerLock(candidate);
+  const ownerLock = acquireSandboxOwnerLock(
+    candidate,
+    sandboxRootIdentity,
+    sandboxIdentity,
+  );
   if (!ownerLock) return "";
   let releaseLock = ownerLock;
 
@@ -897,7 +1338,21 @@ async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
     releaseLock = {
       ...ownerLock,
       path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+      sandboxIdentity: relocatedSandboxIdentity(sandboxIdentity, quarantinePath),
     };
+    if (
+      !secureExistingManagedSandbox(
+        quarantinePath,
+        sandboxRootIdentity,
+        releaseLock.sandboxIdentity,
+      )
+    ) {
+      if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+        movePendingSandboxCleanup(quarantinePath, candidate);
+        releaseLock = ownerLock;
+      }
+      return "";
+    }
     const relocatedOwner = await readSandboxOwner(quarantinePath);
     if (
       !sandboxOwnerLockIsHeld(releaseLock) ||
@@ -907,7 +1362,7 @@ async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
     ) {
       if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
         movePendingSandboxCleanup(quarantinePath, candidate);
-        releaseLock = { ...releaseLock, path: ownerLock.path };
+        releaseLock = ownerLock;
       }
       return "";
     }
@@ -926,9 +1381,21 @@ async function quarantineOwnedSandbox(sandboxPath, expectedInstanceID) {
   }
 }
 
-async function quarantineManagedSandbox(sandboxPath, ownerLock) {
+async function quarantineManagedSandbox(
+  sandboxPath,
+  ownerLock,
+  sandboxRootIdentity,
+  expectedSandboxIdentity,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
-  if (!candidate || !sandboxOwnerLockIsHeld(ownerLock)) {
+  const sandboxIdentity = candidate
+    ? secureExistingManagedSandbox(
+        candidate,
+        sandboxRootIdentity,
+        expectedSandboxIdentity,
+      )
+    : null;
+  if (!candidate || !sandboxIdentity || !sandboxOwnerLockIsHeld(ownerLock)) {
     return { path: "", ownerLock };
   }
 
@@ -945,7 +1412,21 @@ async function quarantineManagedSandbox(sandboxPath, ownerLock) {
   const relocatedLock = {
     ...ownerLock,
     path: path.join(quarantinePath, XCODE_SANDBOX_OWNER_LOCK),
+    sandboxIdentity: relocatedSandboxIdentity(sandboxIdentity, quarantinePath),
   };
+  if (
+    !secureExistingManagedSandbox(
+      quarantinePath,
+      sandboxRootIdentity,
+      relocatedLock.sandboxIdentity,
+    )
+  ) {
+    if (restoreQuarantinedSandbox(quarantinePath, candidate)) {
+      movePendingSandboxCleanup(quarantinePath, candidate);
+      return { path: "", ownerLock };
+    }
+    return { path: "", ownerLock: relocatedLock };
+  }
   const publishedOwner = await readSandboxOwner(quarantinePath);
   const cleanupPending =
     publishedOwner?.cleanupPending || sandboxCleanupIsPending(quarantinePath);
@@ -973,9 +1454,24 @@ function restoreQuarantinedSandbox(quarantinePath, originalPath) {
   }
 }
 
-async function detachManagedSandbox(sandboxPath, expectedInstanceID = "") {
+async function detachManagedSandbox(
+  sandboxPath,
+  expectedInstanceID = "",
+  sandboxRootIdentity = null,
+  expectedSandboxIdentity = null,
+) {
   const candidate = managedSandboxCandidate(sandboxPath);
   if (!candidate) return;
+  if (
+    !sandboxRootIdentity ||
+    !secureExistingManagedSandbox(
+      candidate,
+      sandboxRootIdentity,
+      expectedSandboxIdentity,
+    )
+  ) {
+    return;
+  }
 
   if (expectedInstanceID) {
     const owner = await readSandboxOwner(candidate);
@@ -1003,6 +1499,49 @@ function managedSandboxCandidate(sandboxPath) {
   const relative = path.relative(sandboxRoot, candidate);
   if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) return "";
   return candidate;
+}
+
+function secureExistingManagedSandbox(
+  sandboxPath,
+  sandboxRootIdentity,
+  expectedSandboxIdentity = null,
+) {
+  try {
+    revalidateSandboxDirectory(sandboxRootIdentity);
+    const candidate = managedSandboxCandidate(sandboxPath);
+    if (!candidate || path.dirname(candidate) !== sandboxRootIdentity.path) return null;
+
+    const name = path.basename(candidate);
+    if (!SAFE_ID_RE.test(name) && !XCODE_SANDBOX_QUARANTINE_RE.test(name)) {
+      return null;
+    }
+
+    const current = inspectSandboxDirectory(
+      candidate,
+      path.join(sandboxRootIdentity.canonicalPath, name),
+      sandboxRootIdentity,
+    );
+    if (
+      expectedSandboxIdentity &&
+      (current.dev !== expectedSandboxIdentity.dev ||
+        current.ino !== expectedSandboxIdentity.ino ||
+        current.uid !== expectedSandboxIdentity.uid)
+    ) {
+      return null;
+    }
+    return current;
+  } catch {
+    return null;
+  }
+}
+
+function relocatedSandboxIdentity(identity, destinationPath) {
+  const name = path.basename(destinationPath);
+  return {
+    ...identity,
+    path: path.resolve(destinationPath),
+    canonicalPath: path.join(identity.parent.canonicalPath, name),
+  };
 }
 
 function markPendingSandboxCleanup(sandboxPath) {

--- a/iOSSimulator/info.json
+++ b/iOSSimulator/info.json
@@ -13,6 +13,10 @@
     ],
     "versions": [
         {
+            "version": "0.6.6",
+            "changes": "Added OpenCode support through an opencode-plugin.js entry point that registers skills, session-start context, and pre-tool-use command guardrails."
+        },
+        {
             "version": "0.6.5",
             "changes": "Released self-contained common helper copies so the plugin package no longer depends on repository-level symlinks, while keeping hook configuration in hooks/hooks.json instead of generated common/hooks.json templates."
         },

--- a/iOSSimulator/opencode-plugin.js
+++ b/iOSSimulator/opencode-plugin.js
@@ -1,0 +1,6 @@
+import { createOpenCodePlugin } from "./common/opencode-plugin.js";
+
+export default {
+  id: "iOSSimulator",
+  server: createOpenCodePlugin(new URL(".", import.meta.url)),
+};

--- a/scripts/sync-plugin-common.py
+++ b/scripts/sync-plugin-common.py
@@ -44,7 +44,8 @@ def generated_bytes(source, repo_root):
         ).encode("utf-8") + b"\n"
 
     text = source.read_text(encoding="utf-8")
-    header = f"# {message}\n"
+    comment = "//" if source.suffix in {".js", ".ts"} else "#"
+    header = f"{comment} {message}\n"
     if text.startswith("#!"):
         first_line, separator, remainder = text.partition("\n")
         text = first_line + separator + header + remainder

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -48,9 +48,11 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
             plugin_root = Path(tmpdir) / "plugin"
             worktree = Path(tmpdir) / "worktree"
             directory = Path(tmpdir) / "directory"
+            data_home = Path(tmpdir) / "data-home"
             plugin_root.mkdir()
             worktree.mkdir()
             directory.mkdir()
+            data_home.mkdir()
             (plugin_root / ".mcp.json").write_text(
                 json.dumps(
                     {
@@ -118,6 +120,7 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
                     "TEST_WORKTREE": str(worktree),
                     "TEST_DIRECTORY": str(directory),
                     "OPENCODE_TEST_TOKEN": "runtime-token",
+                    "XDG_DATA_HOME": str(data_home),
                 },
             )
 
@@ -138,6 +141,11 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
                         "PROJECT_PATH": str(worktree),
                         "TOKEN": "runtime-token",
                         "MODE": "source-default",
+                        "CLAUDE_PLUGIN_ROOT": str(plugin_root),
+                        "CLAUDE_PLUGIN_DATA": str(
+                            data_home / "opencode" / "plugin-data" / "plugin"
+                        ),
+                        "CLAUDE_PROJECT_DIR": str(worktree),
                     },
                 },
                 "remote": {
@@ -162,6 +170,138 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
                 "--mode=source-default",
             ],
         )
+
+    def test_local_mcp_receives_plugin_compatibility_environment(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            plugin_root = Path(tmpdir) / "plugin"
+            project_dir = Path(tmpdir) / "project"
+            data_home = Path(tmpdir) / "data-home"
+            (plugin_root / ".claude-plugin").mkdir(parents=True)
+            project_dir.mkdir()
+            data_home.mkdir()
+            (plugin_root / ".claude-plugin" / "plugin.json").write_text(
+                json.dumps({"name": "Example Plugin"}),
+                encoding="utf-8",
+            )
+            (plugin_root / ".mcp.json").write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "local": {
+                                "command": "node",
+                                "environment": {
+                                    "CUSTOM": "kept",
+                                    "CLAUDE_PLUGIN_ROOT": "/wrong/plugin-root",
+                                    "CLAUDE_PLUGIN_DATA": "/wrong/plugin-data",
+                                    "CLAUDE_PROJECT_DIR": "/wrong/project-dir",
+                                },
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.run_node(
+                """
+                import { createOpenCodePlugin } from "./common/opencode-plugin.js?test=mcp-compatibility-environment";
+
+                const server = createOpenCodePlugin(process.env.TEST_PLUGIN_ROOT);
+                const hooks = await server({ directory: process.env.TEST_PROJECT_DIR });
+                const config = {};
+                await hooks.config(config);
+
+                console.log(JSON.stringify(config.mcp.local.environment));
+                """,
+                {
+                    "TEST_PLUGIN_ROOT": str(plugin_root),
+                    "TEST_PROJECT_DIR": str(project_dir),
+                    "XDG_DATA_HOME": str(data_home),
+                },
+            )
+
+            plugin_data = data_home / "opencode" / "plugin-data" / "Example-Plugin"
+            self.assertEqual(
+                result,
+                {
+                    "CUSTOM": "kept",
+                    "CLAUDE_PLUGIN_ROOT": str(plugin_root),
+                    "CLAUDE_PLUGIN_DATA": str(plugin_data),
+                    "CLAUDE_PROJECT_DIR": str(project_dir),
+                },
+            )
+            self.assertTrue(plugin_data.is_dir())
+
+    def test_plugin_data_placeholder_is_stable_across_instances(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            plugin_root = Path(tmpdir) / "plugin"
+            first_project = Path(tmpdir) / "first-project"
+            second_project = Path(tmpdir) / "second-project"
+            data_home = Path(tmpdir) / "data-home"
+            (plugin_root / ".claude-plugin").mkdir(parents=True)
+            first_project.mkdir()
+            second_project.mkdir()
+            data_home.mkdir()
+            (plugin_root / ".claude-plugin" / "plugin.json").write_text(
+                json.dumps({"name": "Example Plugin"}),
+                encoding="utf-8",
+            )
+            (plugin_root / ".mcp.json").write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "local": {
+                                "command": "${CLAUDE_PLUGIN_DATA}/bin/server",
+                                "environment": {
+                                    "PLUGIN_DATA": "${CLAUDE_PLUGIN_DATA}",
+                                },
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.run_node(
+                """
+                import { createOpenCodePlugin } from "./common/opencode-plugin.js?test=stable-plugin-data";
+
+                delete process.env.CLAUDE_PLUGIN_DATA;
+                const server = createOpenCodePlugin(process.env.TEST_PLUGIN_ROOT);
+
+                const firstHooks = await server({ directory: process.env.TEST_FIRST_PROJECT });
+                const firstConfig = {};
+                await firstHooks.config(firstConfig);
+
+                const secondHooks = await server({ directory: process.env.TEST_SECOND_PROJECT });
+                const secondConfig = {};
+                await secondHooks.config(secondConfig);
+
+                console.log(JSON.stringify({
+                  first: firstConfig.mcp.local,
+                  second: secondConfig.mcp.local,
+                }));
+                """,
+                {
+                    "TEST_PLUGIN_ROOT": str(plugin_root),
+                    "TEST_FIRST_PROJECT": str(first_project),
+                    "TEST_SECOND_PROJECT": str(second_project),
+                    "XDG_DATA_HOME": str(data_home),
+                },
+            )
+
+            plugin_data = data_home / "opencode" / "plugin-data" / "Example-Plugin"
+            self.assertEqual(
+                result["first"]["command"],
+                [str(plugin_data / "bin" / "server")],
+            )
+            self.assertEqual(
+                result["second"]["command"],
+                [str(plugin_data / "bin" / "server")],
+            )
+            self.assertEqual(result["first"]["environment"]["PLUGIN_DATA"], str(plugin_data))
+            self.assertEqual(result["second"]["environment"]["PLUGIN_DATA"], str(plugin_data))
+            self.assertTrue(plugin_data.is_dir())
 
     def test_mcp_required_placeholder_reports_unset_variable(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -795,7 +795,7 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
               child.unref = () => {};
 
               let code = 0;
-              if (command === "pgrep" && args[0] === "-f") code = 1;
+              if (command === "/usr/bin/pgrep" && args[0] === "-f") code = 1;
               queueMicrotask(() => child.emit("exit", code));
               return child;
             };
@@ -817,7 +817,7 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
             console.log(JSON.stringify({
               registeredMcp: Object.keys(config.mcp ?? {}),
               detected: output.system[0].includes("Xcode MCP server detected"),
-              approvalLaunched: calls.some(([command]) => command.endsWith("run-background.sh")),
+              approvalLaunched: calls.some(([command]) => command.endsWith("approve-xcode-mcp.sh")),
             }));
             """
         )
@@ -866,7 +866,7 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
             console.log(JSON.stringify({
               detected: output.system[0].includes("Xcode MCP server detected"),
               approvalLaunched: calls.some(
-                ([command]) => command.endsWith("run-background.sh"),
+                ([command]) => command.endsWith("approve-xcode-mcp.sh"),
               ),
             }));
             """
@@ -915,7 +915,7 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
             console.log(JSON.stringify({
               detected: output.system[0].includes("Xcode MCP server detected"),
               approvalLaunched: calls.some(
-                ([command]) => command.endsWith("run-background.sh"),
+                ([command]) => command.endsWith("approve-xcode-mcp.sh"),
               ),
             }));
             """
@@ -966,7 +966,7 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
               results.push({
                 detected: output.system[0].includes("Xcode MCP server detected"),
                 approvalLaunched: calls.slice(callsBefore).some(
-                  ([executable]) => executable.endsWith("run-background.sh"),
+                  ([executable]) => executable.endsWith("approve-xcode-mcp.sh"),
                 ),
               });
             }
@@ -994,8 +994,8 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
               child.unref = () => {};
 
               let code = 0;
-              if (command === "pgrep" && args[0] === "-x") code = xcodeRunning ? 0 : 1;
-              if (command === "pgrep" && args[0] === "-f") code = 1;
+              if (command === "/usr/bin/pgrep" && args[0] === "-x") code = xcodeRunning ? 0 : 1;
+              if (command === "/usr/bin/pgrep" && args[0] === "-f") code = 1;
               queueMicrotask(() => child.emit("exit", code));
               return child;
             };
@@ -1156,7 +1156,7 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
             console.log(JSON.stringify({
               detected: output.system[0].includes("Xcode MCP server detected"),
               approvalLaunched: calls.some(
-                ([command]) => command.endsWith("run-background.sh"),
+                ([command]) => command.endsWith("approve-xcode-mcp.sh"),
               ),
             }));
             """
@@ -1164,6 +1164,492 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
 
         self.assertFalse(result["detected"])
         self.assertFalse(result["approvalLaunched"])
+
+    def test_xcode_mcp_probes_and_approval_use_fixed_system_paths(self):
+        result = self.run_node(
+            """
+            import { EventEmitter } from "node:events";
+            import path from "node:path";
+            import { mock } from "node:test";
+
+            process.env.PATH = "/tmp/untrusted-path";
+            const calls = [];
+            const spawn = (command, args = [], options = {}) => {
+              calls.push({ command, args, options });
+              const child = new EventEmitter();
+              child.pid = 4100 + calls.length;
+              child.kill = () => true;
+              child.unref = () => {};
+
+              if (!command.endsWith("approve-xcode-mcp.sh")) {
+                const code = command === "/usr/bin/pgrep" && args[0] === "-f" ? 1 : 0;
+                queueMicrotask(() => child.emit("exit", code));
+              }
+              return child;
+            };
+            mock.module("node:child_process", { namedExports: { spawn } });
+
+            const plugin = (await import(
+              "./XcodeBuildTools/opencode-plugin.js?test=fixed-system-paths"
+            )).default;
+            const hooks = await plugin.server({});
+            const config = {
+              mcp: {
+                xcode: {
+                  type: "local",
+                  command: ["xcrun", "mcpbridge"],
+                },
+              },
+            };
+            await hooks.config(config);
+            await hooks["experimental.chat.system.transform"](
+              { sessionID: "session-1" },
+              { system: [] },
+            );
+
+            const approval = calls.find(({ command }) =>
+              command.endsWith("approve-xcode-mcp.sh")
+            );
+            console.log(JSON.stringify({
+              probes: calls
+                .filter(({ command }) => !command.endsWith("approve-xcode-mcp.sh"))
+                .map(({ command, args }) => [command, ...args]),
+              approval: approval && {
+                command: approval.command,
+                args: approval.args,
+                cwd: approval.options.cwd,
+                detached: approval.options.detached,
+                path: approval.options.env.PATH,
+                pluginRoot: approval.options.env.CLAUDE_PLUGIN_ROOT,
+                absolute: path.isAbsolute(approval.command),
+                underPluginRoot:
+                  path.relative(approval.options.cwd, approval.command) ===
+                  path.join("hooks", "approve-xcode-mcp.sh"),
+              },
+            }));
+            """
+        )
+
+        self.assertEqual(
+            result["probes"],
+            [
+                ["/usr/bin/xcrun", "--find", "mcpbridge"],
+                ["/usr/bin/pgrep", "-x", "Xcode"],
+                ["/usr/bin/pgrep", "-f", "mcpbridge"],
+            ],
+        )
+        self.assertEqual(result["approval"]["args"], [])
+        self.assertTrue(result["approval"]["absolute"])
+        self.assertTrue(result["approval"]["underPluginRoot"])
+        self.assertTrue(result["approval"]["detached"])
+        self.assertEqual(result["approval"]["path"], "/usr/bin:/bin:/usr/sbin:/sbin")
+        self.assertEqual(result["approval"]["cwd"], result["approval"]["pluginRoot"])
+
+    def test_session_deletion_while_xcode_probe_is_pending_cancels_approval(self):
+        result = self.run_node(
+            """
+            import { EventEmitter } from "node:events";
+            import { mock } from "node:test";
+
+            const calls = [];
+            let releaseProbe;
+            let markProbeStarted;
+            const probeStarted = new Promise((resolve) => {
+              markProbeStarted = resolve;
+            });
+            const spawn = (command, args = []) => {
+              calls.push([command, ...args]);
+              const child = new EventEmitter();
+              child.pid = 4200 + calls.length;
+              child.kill = () => true;
+              child.unref = () => {};
+
+              if (command.endsWith("xcrun")) {
+                releaseProbe = () => child.emit("exit", 0);
+                markProbeStarted();
+              } else {
+                queueMicrotask(() => child.emit("exit", 0));
+              }
+              return child;
+            };
+            mock.module("node:child_process", { namedExports: { spawn } });
+
+            const plugin = (await import(
+              "./XcodeBuildTools/opencode-plugin.js?test=delete-during-xcode-probe"
+            )).default;
+            const hooks = await plugin.server({});
+            await hooks.config({
+              mcp: {
+                xcode: {
+                  type: "local",
+                  command: ["xcrun", "mcpbridge"],
+                },
+              },
+            });
+
+            const firstOutput = { system: [] };
+            const transform = hooks["experimental.chat.system.transform"](
+              { sessionID: "deleted-session" },
+              firstOutput,
+            );
+            await probeStarted;
+            await hooks.event({
+              event: {
+                type: "session.deleted",
+                properties: { info: { id: "deleted-session" } },
+              },
+            });
+            releaseProbe();
+            await transform;
+
+            const callsAfterCompletion = calls.length;
+            const secondOutput = { system: [] };
+            await hooks["experimental.chat.system.transform"](
+              { sessionID: "deleted-session" },
+              secondOutput,
+            );
+
+            console.log(JSON.stringify({
+              calls,
+              callsAfterCompletion,
+              callsAfterRepeat: calls.length,
+              firstDetected: firstOutput.system[0].includes("Xcode MCP server detected"),
+              secondDetected: secondOutput.system[0].includes("Xcode MCP server detected"),
+              approvalLaunches: calls.filter(([command]) =>
+                command.endsWith("approve-xcode-mcp.sh") ||
+                command.endsWith("run-background.sh")
+              ).length,
+            }));
+            """
+        )
+
+        self.assertEqual(result["callsAfterCompletion"], 1)
+        self.assertEqual(result["callsAfterRepeat"], 1)
+        self.assertFalse(result["firstDetected"])
+        self.assertFalse(result["secondDetected"])
+        self.assertEqual(result["approvalLaunches"], 0)
+
+    def test_dispose_while_xcode_probe_is_pending_cancels_approval(self):
+        result = self.run_node(
+            """
+            import { EventEmitter } from "node:events";
+            import { mock } from "node:test";
+
+            const calls = [];
+            let releaseProbe;
+            let markProbeStarted;
+            const probeStarted = new Promise((resolve) => {
+              markProbeStarted = resolve;
+            });
+            const spawn = (command, args = []) => {
+              calls.push([command, ...args]);
+              const child = new EventEmitter();
+              child.pid = 4300 + calls.length;
+              child.kill = () => true;
+              child.unref = () => {};
+
+              if (command.endsWith("xcrun")) {
+                releaseProbe = () => child.emit("exit", 0);
+                markProbeStarted();
+              } else {
+                queueMicrotask(() => child.emit("exit", 0));
+              }
+              return child;
+            };
+            mock.module("node:child_process", { namedExports: { spawn } });
+
+            const plugin = (await import(
+              "./XcodeBuildTools/opencode-plugin.js?test=dispose-during-xcode-probe"
+            )).default;
+            const hooks = await plugin.server({});
+            await hooks.config({
+              mcp: {
+                xcode: {
+                  type: "local",
+                  command: ["xcrun", "mcpbridge"],
+                },
+              },
+            });
+
+            const firstOutput = { system: [] };
+            const transform = hooks["experimental.chat.system.transform"](
+              { sessionID: "disposed-session" },
+              firstOutput,
+            );
+            await probeStarted;
+            await hooks.dispose();
+            releaseProbe();
+            await transform;
+
+            const callsAfterCompletion = calls.length;
+            const secondOutput = { system: [] };
+            await hooks["experimental.chat.system.transform"](
+              { sessionID: "disposed-session" },
+              secondOutput,
+            );
+
+            console.log(JSON.stringify({
+              callsAfterCompletion,
+              callsAfterRepeat: calls.length,
+              firstDetected: firstOutput.system[0].includes("Xcode MCP server detected"),
+              secondDetected: secondOutput.system[0].includes("Xcode MCP server detected"),
+              approvalLaunches: calls.filter(([command]) =>
+                command.endsWith("approve-xcode-mcp.sh") ||
+                command.endsWith("run-background.sh")
+              ).length,
+            }));
+            """
+        )
+
+        self.assertEqual(result["callsAfterCompletion"], 1)
+        self.assertEqual(result["callsAfterRepeat"], 1)
+        self.assertFalse(result["firstDetected"])
+        self.assertFalse(result["secondDetected"])
+        self.assertEqual(result["approvalLaunches"], 0)
+
+    def test_xcode_approval_process_groups_are_bounded_on_delete_and_dispose(self):
+        result = self.run_node(
+            """
+            import { EventEmitter } from "node:events";
+            import { mock } from "node:test";
+
+            const calls = [];
+            const helpers = [];
+            let nextPid = 4400;
+            const spawn = (command, args = [], options = {}) => {
+              calls.push([command, args, options]);
+              const child = new EventEmitter();
+              child.pid = nextPid++;
+              child.kill = () => true;
+              child.unref = () => {};
+
+              if (
+                command.endsWith("approve-xcode-mcp.sh") ||
+                command.endsWith("run-background.sh")
+              ) {
+                helpers.push(child);
+              } else {
+                const code = command.endsWith("pgrep") && args[0] === "-f" ? 1 : 0;
+                queueMicrotask(() => child.emit("exit", code));
+              }
+              return child;
+            };
+            mock.module("node:child_process", { namedExports: { spawn } });
+
+            const groupSignals = [];
+            const graceDelays = [];
+            const pendingGraceTimers = new Set();
+            const originalKill = process.kill;
+            const originalSetTimeout = globalThis.setTimeout;
+            const originalClearTimeout = globalThis.clearTimeout;
+            process.kill = (pid, signal) => {
+              if (signal === 0) return true;
+              groupSignals.push([pid, signal]);
+              if (signal === "SIGTERM") {
+                helpers.find((helper) => helper.pid === -pid)?.emit("exit", 0);
+              }
+              return true;
+            };
+            globalThis.setTimeout = (callback, delay, ...args) => {
+              if (delay !== 250) return originalSetTimeout(callback, delay, ...args);
+              graceDelays.push(delay);
+              const timer = { active: true };
+              pendingGraceTimers.add(timer);
+              queueMicrotask(() => {
+                if (!timer.active) return;
+                timer.active = false;
+                pendingGraceTimers.delete(timer);
+                callback(...args);
+              });
+              return timer;
+            };
+            globalThis.clearTimeout = (timer) => {
+              if (timer && typeof timer === "object" && "active" in timer) {
+                timer.active = false;
+                pendingGraceTimers.delete(timer);
+                return;
+              }
+              originalClearTimeout(timer);
+            };
+
+            try {
+              const plugin = (await import(
+                "./XcodeBuildTools/opencode-plugin.js?test=approval-lifecycle"
+              )).default;
+              const serverConfig = {
+                mcp: {
+                  xcode: {
+                    type: "local",
+                    command: ["xcrun", "mcpbridge"],
+                  },
+                },
+              };
+
+              const deletedHooks = await plugin.server({});
+              await deletedHooks.config(structuredClone(serverConfig));
+              await deletedHooks["experimental.chat.system.transform"](
+                { sessionID: "deleted-session" },
+                { system: [] },
+              );
+              await deletedHooks.event({
+                event: {
+                  type: "session.deleted",
+                  properties: { info: { id: "deleted-session" } },
+                },
+              });
+
+              const disposedHooks = await plugin.server({});
+              await disposedHooks.config(structuredClone(serverConfig));
+              await disposedHooks["experimental.chat.system.transform"](
+                { sessionID: "disposed-session" },
+                { system: [] },
+              );
+              await disposedHooks.dispose();
+            } finally {
+              process.kill = originalKill;
+              globalThis.setTimeout = originalSetTimeout;
+              globalThis.clearTimeout = originalClearTimeout;
+            }
+
+            console.log(JSON.stringify({
+              helperPids: helpers.map(({ pid }) => pid),
+              groupSignals,
+              graceDelays,
+              pendingGraceTimers: pendingGraceTimers.size,
+              listenerCounts: helpers.map((helper) => ({
+                error: helper.listenerCount("error"),
+                exit: helper.listenerCount("exit"),
+              })),
+            }));
+            """
+        )
+
+        self.assertEqual(len(result["helperPids"]), 2)
+        expected_signals = []
+        for pid in result["helperPids"]:
+            expected_signals.extend([[-pid, "SIGTERM"], [-pid, "SIGKILL"]])
+        self.assertEqual(result["groupSignals"], expected_signals)
+        self.assertEqual(result["graceDelays"], [250, 250])
+        self.assertEqual(result["pendingGraceTimers"], 0)
+        self.assertEqual(
+            result["listenerCounts"],
+            [{"error": 0, "exit": 0}, {"error": 0, "exit": 0}],
+        )
+
+    def test_dispose_awaits_session_deletion_approval_group_termination(self):
+        result = self.run_node(
+            """
+            import { EventEmitter } from "node:events";
+            import { mock } from "node:test";
+
+            let helper;
+            let nextPid = 4500;
+            const spawn = (command, args = []) => {
+              const child = new EventEmitter();
+              child.pid = nextPid++;
+              child.kill = () => true;
+              child.unref = () => {};
+
+              if (command.endsWith("approve-xcode-mcp.sh")) {
+                helper = child;
+              } else {
+                const code = command.endsWith("pgrep") && args[0] === "-f" ? 1 : 0;
+                queueMicrotask(() => child.emit("exit", code));
+              }
+              return child;
+            };
+            mock.module("node:child_process", { namedExports: { spawn } });
+
+            const groupSignals = [];
+            const graceTimers = [];
+            const originalKill = process.kill;
+            const originalSetTimeout = globalThis.setTimeout;
+            const originalClearTimeout = globalThis.clearTimeout;
+            process.kill = (pid, signal) => {
+              if (signal === 0) return true;
+              groupSignals.push([pid, signal]);
+              if (signal === "SIGTERM") helper.emit("exit", 0);
+              return true;
+            };
+            globalThis.setTimeout = (callback, delay, ...args) => {
+              if (delay !== 250) return originalSetTimeout(callback, delay, ...args);
+              const timer = { active: true, callback: () => callback(...args) };
+              graceTimers.push(timer);
+              return timer;
+            };
+            globalThis.clearTimeout = (timer) => {
+              if (timer && typeof timer === "object" && "active" in timer) {
+                timer.active = false;
+                return;
+              }
+              originalClearTimeout(timer);
+            };
+
+            let disposeResolved = false;
+            let resolvedBeforeEscalation;
+            try {
+              const plugin = (await import(
+                "./XcodeBuildTools/opencode-plugin.js?test=concurrent-approval-cleanup"
+              )).default;
+              const hooks = await plugin.server({});
+              await hooks.config({
+                mcp: {
+                  xcode: {
+                    type: "local",
+                    command: ["xcrun", "mcpbridge"],
+                  },
+                },
+              });
+              await hooks["experimental.chat.system.transform"](
+                { sessionID: "shared-session" },
+                { system: [] },
+              );
+
+              const deletion = hooks.event({
+                event: {
+                  type: "session.deleted",
+                  properties: { info: { id: "shared-session" } },
+                },
+              });
+              const disposal = hooks.dispose().then(() => {
+                disposeResolved = true;
+              });
+              await new Promise((resolve) => setImmediate(resolve));
+              resolvedBeforeEscalation = disposeResolved;
+
+              for (const timer of graceTimers) {
+                if (!timer.active) continue;
+                timer.active = false;
+                timer.callback();
+              }
+              await Promise.all([deletion, disposal]);
+            } finally {
+              process.kill = originalKill;
+              globalThis.setTimeout = originalSetTimeout;
+              globalThis.clearTimeout = originalClearTimeout;
+            }
+
+            console.log(JSON.stringify({
+              resolvedBeforeEscalation,
+              disposeResolved,
+              groupSignals,
+              graceTimerCount: graceTimers.length,
+              listeners: {
+                error: helper.listenerCount("error"),
+                exit: helper.listenerCount("exit"),
+              },
+            }));
+            """
+        )
+
+        self.assertFalse(result["resolvedBeforeEscalation"])
+        self.assertTrue(result["disposeResolved"])
+        self.assertEqual(result["graceTimerCount"], 1)
+        self.assertEqual(
+            result["groupSignals"],
+            [[-4503, "SIGTERM"], [-4503, "SIGKILL"]],
+        )
+        self.assertEqual(result["listeners"], {"error": 0, "exit": 0})
 
     def test_xcode_mcp_approval_runs_once_per_session(self):
         result = self.run_node(
@@ -1179,7 +1665,7 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
               child.unref = () => {};
 
               let code = 0;
-              if (command === "pgrep" && args[0] === "-f") code = 1;
+              if (command === "/usr/bin/pgrep" && args[0] === "-f") code = 1;
               queueMicrotask(() => child.emit("exit", code));
               return child;
             };
@@ -1207,7 +1693,7 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
             }
 
             console.log(JSON.stringify({
-              approvalLaunches: calls.filter(([command]) => command.endsWith("run-background.sh")).length,
+              approvalLaunches: calls.filter(([command]) => command.endsWith("approve-xcode-mcp.sh")).length,
             }));
             """
         )

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -1,0 +1,610 @@
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class OpenCodePluginRuntimeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.node = shutil.which("node")
+        if not cls.node:
+            raise unittest.SkipTest("node is not available")
+
+    def run_node(self, script, extra_env=None):
+        env = os.environ.copy()
+        env["NODE_NO_WARNINGS"] = "1"
+        if extra_env:
+            env.update(extra_env)
+
+        result = subprocess.run(
+            [
+                self.node,
+                "--experimental-test-module-mocks",
+                "--input-type=module",
+                "-e",
+                textwrap.dedent(script),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return json.loads(result.stdout)
+
+    def test_xcode_mcp_requires_explicit_mcpbridge_configuration(self):
+        result = self.run_node(
+            """
+            import { EventEmitter } from "node:events";
+            import { mock } from "node:test";
+
+            const calls = [];
+            const spawn = (command, args = []) => {
+              calls.push([command, ...args]);
+              const child = new EventEmitter();
+              child.kill = () => true;
+              child.unref = () => {};
+
+              let code = 0;
+              if (command === "pgrep" && args[0] === "-f") code = 1;
+              queueMicrotask(() => child.emit("exit", code));
+              return child;
+            };
+            mock.module("node:child_process", { namedExports: { spawn } });
+
+            const plugin = (await import(
+              "./XcodeBuildTools/opencode-plugin.js?test=requires-config"
+            )).default;
+            const hooks = await plugin.server({});
+            const config = {};
+            await hooks.config(config);
+
+            const output = { system: [] };
+            await hooks["experimental.chat.system.transform"](
+              { sessionID: "session-1" },
+              output,
+            );
+
+            console.log(JSON.stringify({
+              registeredMcp: Object.keys(config.mcp ?? {}),
+              detected: output.system[0].includes("Xcode MCP server detected"),
+              approvalLaunched: calls.some(([command]) => command.endsWith("run-background.sh")),
+            }));
+            """
+        )
+
+        self.assertEqual(result["registeredMcp"], ["sosumi"])
+        self.assertFalse(result["detected"])
+        self.assertFalse(result["approvalLaunched"])
+
+    def test_xcode_mcp_detection_refreshes_after_cache_ttl(self):
+        result = self.run_node(
+            """
+            import { EventEmitter } from "node:events";
+            import { mock } from "node:test";
+
+            let now = 1_000;
+            let xcodeRunning = false;
+            Date.now = () => now;
+
+            const spawn = (command, args = []) => {
+              const child = new EventEmitter();
+              child.kill = () => true;
+              child.unref = () => {};
+
+              let code = 0;
+              if (command === "pgrep" && args[0] === "-x") code = xcodeRunning ? 0 : 1;
+              if (command === "pgrep" && args[0] === "-f") code = 1;
+              queueMicrotask(() => child.emit("exit", code));
+              return child;
+            };
+            mock.module("node:child_process", { namedExports: { spawn } });
+
+            const plugin = (await import(
+              "./XcodeBuildTools/opencode-plugin.js?test=cache-ttl"
+            )).default;
+            const hooks = await plugin.server({});
+            const config = {
+              mcp: {
+                xcode: {
+                  type: "local",
+                  command: ["xcrun", "mcpbridge"],
+                },
+              },
+            };
+            await hooks.config(config);
+
+            const first = { system: [] };
+            await hooks["experimental.chat.system.transform"](
+              { sessionID: "session-1" },
+              first,
+            );
+
+            now += 31_000;
+            xcodeRunning = true;
+
+            const second = { system: [] };
+            await hooks["experimental.chat.system.transform"](
+              { sessionID: "session-1" },
+              second,
+            );
+
+            console.log(JSON.stringify({
+              firstDetected: first.system[0].includes("Xcode MCP server detected"),
+              secondDetected: second.system[0].includes("Xcode MCP server detected"),
+            }));
+            """
+        )
+
+        self.assertFalse(result["firstDetected"])
+        self.assertTrue(result["secondDetected"])
+
+    def test_xcode_mcp_approval_runs_once_per_session(self):
+        result = self.run_node(
+            """
+            import { EventEmitter } from "node:events";
+            import { mock } from "node:test";
+
+            const calls = [];
+            const spawn = (command, args = []) => {
+              calls.push([command, ...args]);
+              const child = new EventEmitter();
+              child.kill = () => true;
+              child.unref = () => {};
+
+              let code = 0;
+              if (command === "pgrep" && args[0] === "-f") code = 1;
+              queueMicrotask(() => child.emit("exit", code));
+              return child;
+            };
+            mock.module("node:child_process", { namedExports: { spawn } });
+
+            const plugin = (await import(
+              "./XcodeBuildTools/opencode-plugin.js?test=approval-per-session"
+            )).default;
+            const hooks = await plugin.server({});
+            const config = {
+              mcp: {
+                xcode: {
+                  type: "local",
+                  command: ["xcrun", "mcpbridge"],
+                },
+              },
+            };
+            await hooks.config(config);
+
+            for (const sessionID of ["session-1", "session-1", "session-2"]) {
+              await hooks["experimental.chat.system.transform"](
+                { sessionID },
+                { system: [] },
+              );
+            }
+
+            console.log(JSON.stringify({
+              approvalLaunches: calls.filter(([command]) => command.endsWith("run-background.sh")).length,
+            }));
+            """
+        )
+
+        self.assertEqual(result["approvalLaunches"], 2)
+
+    def test_shell_env_sweeps_sandboxes_owned_by_dead_processes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import os from "node:os";
+                import path from "node:path";
+
+                const sandboxRoot = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox");
+                const stale = path.join(sandboxRoot, "stale-session");
+                fs.mkdirSync(path.join(stale, "build"), { recursive: true });
+                fs.writeFileSync(path.join(stale, "owner.pid"), "999999999\\nopencode\\n");
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=stale-sweep"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "current-session" },
+                  { env: {} },
+                );
+
+                console.log(JSON.stringify({ staleExists: fs.existsSync(stale) }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertFalse(result["staleExists"])
+
+    def test_process_start_token_uses_canonical_locale_and_timezone(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import { EventEmitter } from "node:events";
+                import { mock } from "node:test";
+
+                const calls = [];
+                const spawn = (command, args = [], options = {}) => {
+                  calls.push({ command, args, options });
+                  const child = new EventEmitter();
+                  child.stdout = new EventEmitter();
+                  child.stdout.setEncoding = () => {};
+                  queueMicrotask(() => {
+                    child.stdout.emit("data", "Mon Jan  1 00:00:00 2024\\n");
+                    child.emit("exit", 0);
+                    child.emit("close", 0);
+                  });
+                  return child;
+                };
+                mock.module("node:child_process", { namedExports: { spawn } });
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=canonical-process-start"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "current-session" },
+                  { env: {} },
+                );
+
+                const psCall = calls.find(({ command }) => command === "ps");
+                console.log(JSON.stringify({
+                  locale: psCall?.options?.env?.LC_ALL,
+                  language: psCall?.options?.env?.LANG,
+                  timezone: psCall?.options?.env?.TZ,
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertEqual(result["locale"], "C")
+        self.assertEqual(result["language"], "C")
+        self.assertEqual(result["timezone"], "UTC")
+
+    def test_process_start_token_waits_for_stdout_to_close(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import { EventEmitter } from "node:events";
+                import fs from "node:fs";
+                import path from "node:path";
+                import { mock } from "node:test";
+
+                const spawn = () => {
+                  const child = new EventEmitter();
+                  child.stdout = new EventEmitter();
+                  child.stdout.setEncoding = () => {};
+                  queueMicrotask(() => {
+                    child.emit("exit", 0);
+                    queueMicrotask(() => {
+                      child.stdout.emit("data", "canonical-start\\n");
+                      child.emit("close", 0);
+                    });
+                  });
+                  return child;
+                };
+                mock.module("node:child_process", { namedExports: { spawn } });
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=wait-for-process-stdout"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                const output = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "current-session" },
+                  output,
+                );
+
+                const sandbox = path.dirname(output.env.SANDBOX_DERIVED_DATA);
+                const owner = fs.readFileSync(path.join(sandbox, "owner.pid"), "utf8");
+                console.log(JSON.stringify({
+                  token: owner.split(/\\r?\\n/)[2],
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertEqual(result["token"], "canonical-start")
+
+    def test_process_start_token_retries_after_a_transient_failure(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import { EventEmitter } from "node:events";
+                import fs from "node:fs";
+                import path from "node:path";
+                import { mock } from "node:test";
+
+                let psCalls = 0;
+                const spawn = (command) => {
+                  const child = new EventEmitter();
+                  child.stdout = new EventEmitter();
+                  child.stdout.setEncoding = () => {};
+                  queueMicrotask(() => {
+                    psCalls += 1;
+                    if (psCalls === 1) {
+                      child.emit("exit", 1);
+                      child.emit("close", 1);
+                      return;
+                    }
+                    child.stdout.emit("data", "canonical-start\\n");
+                    child.emit("exit", 0);
+                    child.emit("close", 0);
+                  });
+                  return child;
+                };
+                mock.module("node:child_process", { namedExports: { spawn } });
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=retry-process-start"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                const output = { env: {} };
+                for (let attempt = 0; attempt < 2; attempt += 1) {
+                  await hooks["shell.env"](
+                    { cwd: process.cwd(), sessionID: "current-session" },
+                    output,
+                  );
+                }
+
+                const sandbox = path.dirname(output.env.SANDBOX_DERIVED_DATA);
+                const owner = fs.readFileSync(path.join(sandbox, "owner.pid"), "utf8");
+                console.log(JSON.stringify({
+                  psCalls,
+                  token: owner.split(/\\r?\\n/)[2],
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertEqual(result["psCalls"], 2)
+        self.assertEqual(result["token"], "canonical-start")
+
+    def test_session_deletion_removes_its_owned_sandbox(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=session-delete"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                const output = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "deleted-session" },
+                  output,
+                );
+                const sandbox = path.dirname(output.env.SANDBOX_DERIVED_DATA);
+                const eventAvailable = typeof hooks.event === "function";
+                if (eventAvailable) {
+                  await hooks.event({
+                    event: {
+                      type: "session.deleted",
+                      properties: { info: { id: "deleted-session" } },
+                    },
+                  });
+                }
+
+                console.log(JSON.stringify({
+                  eventAvailable,
+                  sandboxExists: fs.existsSync(sandbox),
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertTrue(result["eventAvailable"])
+        self.assertFalse(result["sandboxExists"])
+
+    def test_session_deletion_during_shell_setup_does_not_leave_a_sandbox(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import { EventEmitter } from "node:events";
+                import fs from "node:fs";
+                import os from "node:os";
+                import path from "node:path";
+                import { mock } from "node:test";
+
+                let releasePs;
+                let markPsStarted;
+                const psStarted = new Promise((resolve) => {
+                  markPsStarted = resolve;
+                });
+                const spawn = () => {
+                  const child = new EventEmitter();
+                  child.stdout = new EventEmitter();
+                  child.stdout.setEncoding = () => {};
+                  releasePs = () => {
+                    child.stdout.emit("data", "canonical-start\\n");
+                    child.emit("exit", 0);
+                    child.emit("close", 0);
+                  };
+                  markPsStarted();
+                  return child;
+                };
+                mock.module("node:child_process", { namedExports: { spawn } });
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=delete-during-setup"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                const setup = hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "deleted-session" },
+                  { env: {} },
+                );
+                await psStarted;
+                await hooks.event({
+                  event: {
+                    type: "session.deleted",
+                    properties: { info: { id: "deleted-session" } },
+                  },
+                });
+                releasePs();
+                await setup;
+
+                const sandboxRoot = path.join(
+                  os.tmpdir(),
+                  "opencode-xcodebuildtools-sandbox",
+                );
+                const remaining = fs.existsSync(sandboxRoot)
+                  ? fs.readdirSync(sandboxRoot)
+                  : [];
+                console.log(JSON.stringify({ remaining }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertEqual(result["remaining"], [])
+
+    def test_plugin_dispose_removes_all_owned_sandboxes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=dispose"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                const sandboxes = [];
+                for (const sessionID of ["session-1", "session-2"]) {
+                  const output = { env: {} };
+                  await hooks["shell.env"](
+                    { cwd: process.cwd(), sessionID },
+                    output,
+                  );
+                  sandboxes.push(path.dirname(output.env.SANDBOX_DERIVED_DATA));
+                }
+
+                const disposeAvailable = typeof hooks.dispose === "function";
+                if (disposeAvailable) await hooks.dispose();
+
+                console.log(JSON.stringify({
+                  disposeAvailable,
+                  remaining: sandboxes.filter((sandbox) => fs.existsSync(sandbox)),
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertTrue(result["disposeAvailable"])
+        self.assertEqual(result["remaining"], [])
+
+    def test_disposing_replaced_instance_does_not_remove_new_owner_sandbox(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=instance-ownership"
+                )).default;
+                const first = await plugin.server({});
+                const second = await plugin.server({});
+                await first.config({});
+                await second.config({});
+
+                const firstOutput = { env: {} };
+                await first["shell.env"](
+                  { cwd: process.cwd(), sessionID: "shared-session" },
+                  firstOutput,
+                );
+
+                const secondOutput = { env: {} };
+                await second["shell.env"](
+                  { cwd: process.cwd(), sessionID: "shared-session" },
+                  secondOutput,
+                );
+                const firstSandbox = path.dirname(firstOutput.env.SANDBOX_DERIVED_DATA);
+                const sandbox = path.dirname(secondOutput.env.SANDBOX_DERIVED_DATA);
+
+                await first.dispose();
+                const existsAfterFirstDispose = fs.existsSync(sandbox);
+                await second.dispose();
+
+                console.log(JSON.stringify({
+                  distinctSandboxes: firstSandbox !== sandbox,
+                  existsAfterFirstDispose,
+                  existsAfterSecondDispose: fs.existsSync(sandbox),
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertTrue(result["distinctSandboxes"])
+        self.assertTrue(result["existsAfterFirstDispose"])
+        self.assertFalse(result["existsAfterSecondDispose"])
+
+    def test_sweep_removes_sandbox_when_pid_was_reused(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bin_dir = Path(tmpdir) / "bin"
+            bin_dir.mkdir()
+            ps = bin_dir / "ps"
+            ps.write_text("#!/bin/sh\nprintf '%s\\n' current-start-time\n", encoding="utf-8")
+            ps.chmod(0o755)
+
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import os from "node:os";
+                import path from "node:path";
+
+                const sandboxRoot = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox");
+                const stale = path.join(sandboxRoot, "reused-pid-session");
+                fs.mkdirSync(path.join(stale, "build"), { recursive: true });
+                fs.writeFileSync(
+                  path.join(stale, "owner.pid"),
+                  `${process.pid}\\nopencode\\nnot-the-current-start-time\\nstale-instance\\n`,
+                );
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=reused-pid"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "current-session" },
+                  { env: {} },
+                );
+
+                console.log(JSON.stringify({ staleExists: fs.existsSync(stale) }));
+                """,
+                {
+                    "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+                    "TMPDIR": tmpdir,
+                },
+            )
+
+        self.assertFalse(result["staleExists"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -43,6 +43,347 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         return json.loads(result.stdout)
 
+    def test_mcp_placeholders_expand_before_registration(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            plugin_root = Path(tmpdir) / "plugin"
+            worktree = Path(tmpdir) / "worktree"
+            directory = Path(tmpdir) / "directory"
+            plugin_root.mkdir()
+            worktree.mkdir()
+            directory.mkdir()
+            (plugin_root / ".mcp.json").write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "local": {
+                                "command": "${CLAUDE_PLUGIN_ROOT}/bin/server",
+                                "args": [
+                                    "--project=${CLAUDE_PROJECT_DIR}",
+                                    "--token=${OPENCODE_TEST_TOKEN}",
+                                    "--mode=${OPENCODE_TEST_DEFAULT:-source-default}",
+                                ],
+                                "environment": {
+                                    "PLUGIN_PATH": "${CLAUDE_PLUGIN_ROOT}/resources",
+                                    "PROJECT_PATH": "${CLAUDE_PROJECT_DIR}",
+                                    "TOKEN": "${OPENCODE_TEST_TOKEN}",
+                                    "MODE": "${OPENCODE_TEST_DEFAULT:-source-default}",
+                                },
+                                "cwd": "${CLAUDE_PROJECT_DIR}/workspace",
+                            },
+                            "remote": {
+                                "url": (
+                                    "https://${OPENCODE_TEST_HOST:-mcp.example.test}/"
+                                    "${OPENCODE_TEST_TOKEN}?project=${CLAUDE_PROJECT_DIR}"
+                                ),
+                                "headers": {
+                                    "Authorization": "Bearer ${OPENCODE_TEST_TOKEN}",
+                                    "X-Plugin-Root": "${CLAUDE_PLUGIN_ROOT}",
+                                    "X-Mode": "${OPENCODE_TEST_DEFAULT:-source-default}",
+                                },
+                            },
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.run_node(
+                """
+                import { createOpenCodePlugin } from "./common/opencode-plugin.js?test=mcp-placeholders";
+
+                delete process.env.OPENCODE_TEST_DEFAULT;
+                delete process.env.OPENCODE_TEST_HOST;
+
+                const server = createOpenCodePlugin(process.env.TEST_PLUGIN_ROOT);
+                const worktreeHooks = await server({
+                  worktree: process.env.TEST_WORKTREE,
+                  directory: process.env.TEST_DIRECTORY,
+                });
+                const worktreeConfig = {};
+                await worktreeHooks.config(worktreeConfig);
+
+                const directoryHooks = await server({
+                  directory: process.env.TEST_DIRECTORY,
+                });
+                const directoryConfig = {};
+                await directoryHooks.config(directoryConfig);
+
+                console.log(JSON.stringify({
+                  worktree: worktreeConfig.mcp,
+                  directoryCommand: directoryConfig.mcp.local.command,
+                }));
+                """,
+                {
+                    "TEST_PLUGIN_ROOT": str(plugin_root / ".." / "plugin"),
+                    "TEST_WORKTREE": str(worktree),
+                    "TEST_DIRECTORY": str(directory),
+                    "OPENCODE_TEST_TOKEN": "runtime-token",
+                },
+            )
+
+        self.assertEqual(
+            result["worktree"],
+            {
+                "local": {
+                    "type": "local",
+                    "command": [
+                        str(plugin_root / "bin" / "server"),
+                        f"--project={worktree}",
+                        "--token=runtime-token",
+                        "--mode=source-default",
+                    ],
+                    "cwd": str(worktree / "workspace"),
+                    "environment": {
+                        "PLUGIN_PATH": str(plugin_root / "resources"),
+                        "PROJECT_PATH": str(worktree),
+                        "TOKEN": "runtime-token",
+                        "MODE": "source-default",
+                    },
+                },
+                "remote": {
+                    "type": "remote",
+                    "url": (
+                        f"https://mcp.example.test/runtime-token?project={worktree}"
+                    ),
+                    "headers": {
+                        "Authorization": "Bearer runtime-token",
+                        "X-Plugin-Root": str(plugin_root),
+                        "X-Mode": "source-default",
+                    },
+                },
+            },
+        )
+        self.assertEqual(
+            result["directoryCommand"],
+            [
+                str(plugin_root / "bin" / "server"),
+                f"--project={directory}",
+                "--token=runtime-token",
+                "--mode=source-default",
+            ],
+        )
+
+    def test_mcp_required_placeholder_reports_unset_variable(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            plugin_root = Path(tmpdir) / "plugin"
+            plugin_root.mkdir()
+            (plugin_root / ".mcp.json").write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "local": {
+                                "command": "${OPENCODE_TEST_MISSING}/server",
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.run_node(
+                """
+                import { createOpenCodePlugin } from "./common/opencode-plugin.js?test=mcp-required-placeholder";
+
+                delete process.env.OPENCODE_TEST_MISSING;
+                const server = createOpenCodePlugin(process.env.TEST_PLUGIN_ROOT);
+                const hooks = await server({ directory: process.cwd() });
+
+                let message = "";
+                try {
+                  await hooks.config({});
+                } catch (error) {
+                  message = error.message;
+                }
+
+                console.log(JSON.stringify({ message }));
+                """,
+                {"TEST_PLUGIN_ROOT": str(plugin_root)},
+            )
+
+        self.assertIn("OPENCODE_TEST_MISSING", result["message"])
+        self.assertIn("unset", result["message"].lower())
+
+    def test_remote_mcp_oauth_preserves_compatible_configuration(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            plugin_root = Path(tmpdir) / "plugin"
+            plugin_root.mkdir()
+            (plugin_root / ".mcp.json").write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "disabled": {
+                                "url": "https://disabled.example.test/mcp",
+                                "oauth": False,
+                            },
+                            "configured": {
+                                "url": "https://configured.example.test/mcp",
+                                "oauth": {
+                                    "clientId": "client-id",
+                                    "clientSecret": "client-secret",
+                                    "callbackPort": 9876,
+                                    "redirectUri": "http://127.0.0.1:9876/callback",
+                                    "scope": "ignored-singular-scope",
+                                    "scopes": "read write",
+                                    "authorizationUrl": "https://source-only.example.test",
+                                },
+                            },
+                            "singular": {
+                                "url": "https://singular.example.test/mcp",
+                                "oauth": {"scope": "already singular"},
+                            },
+                            "invalidMembers": {
+                                "url": "https://invalid-members.example.test/mcp",
+                                "oauth": {
+                                    "clientId": 123,
+                                    "clientSecret": False,
+                                    "callbackPort": 4321,
+                                    "redirectUri": ["http://invalid.example.test"],
+                                    "scope": {"invalid": True},
+                                    "scopes": 456,
+                                },
+                            },
+                            "fractionalPort": {
+                                "url": "https://fractional-port.example.test/mcp",
+                                "oauth": {
+                                    "clientId": "kept-fractional",
+                                    "callbackPort": 9876.5,
+                                },
+                            },
+                            "stringPort": {
+                                "url": "https://string-port.example.test/mcp",
+                                "oauth": {
+                                    "scope": "kept-string",
+                                    "callbackPort": "9876",
+                                },
+                            },
+                            "lowPort": {
+                                "url": "https://low-port.example.test/mcp",
+                                "oauth": {
+                                    "clientSecret": "kept-low",
+                                    "callbackPort": 0,
+                                },
+                            },
+                            "highPort": {
+                                "url": "https://high-port.example.test/mcp",
+                                "oauth": {
+                                    "redirectUri": "http://kept-high.example.test",
+                                    "callbackPort": 65536,
+                                },
+                            },
+                            "minimumPort": {
+                                "url": "https://minimum-port.example.test/mcp",
+                                "oauth": {"callbackPort": 1},
+                            },
+                            "maximumPort": {
+                                "url": "https://maximum-port.example.test/mcp",
+                                "oauth": {"callbackPort": 65535},
+                            },
+                            "empty": {
+                                "url": "https://empty.example.test/mcp",
+                                "oauth": {},
+                            },
+                            "invalid": {
+                                "url": "https://invalid.example.test/mcp",
+                                "oauth": True,
+                            },
+                            "absent": {
+                                "url": "https://absent.example.test/mcp",
+                            },
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.run_node(
+                """
+                import { createOpenCodePlugin } from "./common/opencode-plugin.js?test=mcp-oauth";
+
+                const server = createOpenCodePlugin(process.env.TEST_PLUGIN_ROOT);
+                const hooks = await server({ directory: process.cwd() });
+                const config = {};
+                await hooks.config(config);
+
+                console.log(JSON.stringify(config.mcp));
+                """,
+                {"TEST_PLUGIN_ROOT": str(plugin_root)},
+            )
+
+        self.assertEqual(
+            result,
+            {
+                "disabled": {
+                    "type": "remote",
+                    "url": "https://disabled.example.test/mcp",
+                    "oauth": False,
+                },
+                "configured": {
+                    "type": "remote",
+                    "url": "https://configured.example.test/mcp",
+                    "oauth": {
+                        "clientId": "client-id",
+                        "clientSecret": "client-secret",
+                        "callbackPort": 9876,
+                        "redirectUri": "http://127.0.0.1:9876/callback",
+                        "scope": "read write",
+                    },
+                },
+                "singular": {
+                    "type": "remote",
+                    "url": "https://singular.example.test/mcp",
+                    "oauth": {"scope": "already singular"},
+                },
+                "invalidMembers": {
+                    "type": "remote",
+                    "url": "https://invalid-members.example.test/mcp",
+                    "oauth": {"callbackPort": 4321},
+                },
+                "fractionalPort": {
+                    "type": "remote",
+                    "url": "https://fractional-port.example.test/mcp",
+                    "oauth": {"clientId": "kept-fractional"},
+                },
+                "stringPort": {
+                    "type": "remote",
+                    "url": "https://string-port.example.test/mcp",
+                    "oauth": {"scope": "kept-string"},
+                },
+                "lowPort": {
+                    "type": "remote",
+                    "url": "https://low-port.example.test/mcp",
+                    "oauth": {"clientSecret": "kept-low"},
+                },
+                "highPort": {
+                    "type": "remote",
+                    "url": "https://high-port.example.test/mcp",
+                    "oauth": {"redirectUri": "http://kept-high.example.test"},
+                },
+                "minimumPort": {
+                    "type": "remote",
+                    "url": "https://minimum-port.example.test/mcp",
+                    "oauth": {"callbackPort": 1},
+                },
+                "maximumPort": {
+                    "type": "remote",
+                    "url": "https://maximum-port.example.test/mcp",
+                    "oauth": {"callbackPort": 65535},
+                },
+                "empty": {
+                    "type": "remote",
+                    "url": "https://empty.example.test/mcp",
+                    "oauth": {},
+                },
+                "invalid": {
+                    "type": "remote",
+                    "url": "https://invalid.example.test/mcp",
+                },
+                "absent": {
+                    "type": "remote",
+                    "url": "https://absent.example.test/mcp",
+                },
+            },
+        )
+
     def test_xcode_mcp_requires_explicit_mcpbridge_configuration(self):
         result = self.run_node(
             """

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -171,6 +171,108 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
             ],
         )
 
+    def test_project_directory_distinguishes_non_git_sentinel_from_git_root(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            plugin_root = Path(tmpdir) / "plugin"
+            data_home = Path(tmpdir) / "data-home"
+            plugin_root.mkdir()
+            data_home.mkdir()
+            (plugin_root / ".mcp.json").write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "local": {
+                                "command": "node",
+                                "args": ["--project=${CLAUDE_PROJECT_DIR}"],
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.run_node(
+                """
+                import { createOpenCodePlugin } from "./common/opencode-plugin.js?test=project-directory-selection";
+
+                const server = createOpenCodePlugin(process.env.TEST_PLUGIN_ROOT);
+
+                async function localMcp(input) {
+                  const hooks = await server(input);
+                  const config = {};
+                  await hooks.config(config);
+                  return config.mcp.local;
+                }
+
+                console.log(JSON.stringify({
+                  nonGit: await localMcp({
+                    worktree: "/",
+                    directory: "/tmp/non-git-project",
+                    project: { vcs: undefined },
+                  }),
+                  gitRoot: await localMcp({
+                    worktree: "/",
+                    directory: "/workspace/subdir",
+                    project: { vcs: "git" },
+                  }),
+                  legacyNonGit: await localMcp({
+                    worktree: "/",
+                    directory: "/tmp/legacy-non-git-project",
+                  }),
+                  git: await localMcp({
+                    worktree: "/tmp/git-worktree",
+                    directory: "/tmp/git-directory",
+                  }),
+                  noWorktree: await localMcp({ directory: "/tmp/directory-only" }),
+                }));
+                """,
+                {
+                    "TEST_PLUGIN_ROOT": str(plugin_root),
+                    "XDG_DATA_HOME": str(data_home),
+                },
+            )
+
+        self.assertEqual(
+            result["nonGit"]["command"],
+            ["node", "--project=/tmp/non-git-project"],
+        )
+        self.assertEqual(
+            result["nonGit"]["environment"]["CLAUDE_PROJECT_DIR"],
+            "/tmp/non-git-project",
+        )
+        self.assertEqual(
+            result["gitRoot"]["command"],
+            ["node", "--project=/"],
+        )
+        self.assertEqual(
+            result["gitRoot"]["environment"]["CLAUDE_PROJECT_DIR"],
+            "/",
+        )
+        self.assertEqual(
+            result["legacyNonGit"]["command"],
+            ["node", "--project=/tmp/legacy-non-git-project"],
+        )
+        self.assertEqual(
+            result["legacyNonGit"]["environment"]["CLAUDE_PROJECT_DIR"],
+            "/tmp/legacy-non-git-project",
+        )
+        self.assertEqual(
+            result["git"]["command"],
+            ["node", "--project=/tmp/git-worktree"],
+        )
+        self.assertEqual(
+            result["git"]["environment"]["CLAUDE_PROJECT_DIR"],
+            "/tmp/git-worktree",
+        )
+        self.assertEqual(
+            result["noWorktree"]["command"],
+            ["node", "--project=/tmp/directory-only"],
+        )
+        self.assertEqual(
+            result["noWorktree"]["environment"]["CLAUDE_PROJECT_DIR"],
+            "/tmp/directory-only",
+        )
+
     def test_local_mcp_receives_plugin_compatibility_environment(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             plugin_root = Path(tmpdir) / "plugin"

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -18,7 +18,7 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
         if not cls.node:
             raise unittest.SkipTest("node is not available")
 
-    def run_node(self, script, extra_env=None):
+    def run_node(self, script, extra_env=None, timeout=None):
         env = os.environ.copy()
         env["NODE_NO_WARNINGS"] = "1"
         if extra_env:
@@ -37,6 +37,7 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
             text=True,
             capture_output=True,
             check=False,
+            timeout=timeout,
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -209,7 +210,10 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
                 const sandboxRoot = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox");
                 const stale = path.join(sandboxRoot, "stale-session");
                 fs.mkdirSync(path.join(stale, "build"), { recursive: true });
-                fs.writeFileSync(path.join(stale, "owner.pid"), "999999999\\nopencode\\n");
+                fs.writeFileSync(
+                  path.join(stale, "owner.pid"),
+                  "999999999\\nopencode\\n\\n00000000-0000-4000-8000-000000000001\\n",
+                );
 
                 const plugin = (await import(
                   "./XcodeBuildTools/opencode-plugin.js?test=stale-sweep"
@@ -227,6 +231,417 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
             )
 
         self.assertFalse(result["staleExists"])
+
+    def test_shell_env_sweeps_old_sandboxes_without_valid_owners(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import os from "node:os";
+                import path from "node:path";
+
+                const sandboxRoot = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox");
+                const stale = path.join(sandboxRoot, "ownerless-stale-session");
+                fs.mkdirSync(path.join(stale, "build"), { recursive: true });
+                const old = new Date(Date.now() - 61_000);
+                fs.utimesSync(stale, old, old);
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=ownerless-stale-sweep"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "current-session" },
+                  { env: {} },
+                );
+
+                console.log(JSON.stringify({ staleExists: fs.existsSync(stale) }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertFalse(result["staleExists"])
+
+    def test_shell_env_keeps_fresh_sandboxes_without_valid_owners(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import os from "node:os";
+                import path from "node:path";
+
+                const sandboxRoot = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox");
+                const fresh = path.join(sandboxRoot, "ownerless-fresh-session");
+                fs.mkdirSync(path.join(fresh, "build"), { recursive: true });
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=ownerless-fresh-sweep"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "current-session" },
+                  { env: {} },
+                );
+
+                console.log(JSON.stringify({ freshExists: fs.existsSync(fresh) }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertTrue(result["freshExists"])
+
+    def test_shell_env_sweeps_old_truncated_owner_with_live_pid(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import os from "node:os";
+                import path from "node:path";
+
+                const sandboxRoot = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox");
+                const stale = path.join(sandboxRoot, "truncated-owner-session");
+                fs.mkdirSync(path.join(stale, "build"), { recursive: true });
+                fs.writeFileSync(path.join(stale, "owner.pid"), `${process.pid}\\nopencode\\n`);
+                const old = new Date(Date.now() - 61_000);
+                fs.utimesSync(stale, old, old);
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=truncated-owner-sweep"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "current-session" },
+                  { env: {} },
+                );
+
+                console.log(JSON.stringify({ staleExists: fs.existsSync(stale) }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertFalse(result["staleExists"])
+
+    def test_shell_env_sweeps_old_partial_instance_id_with_live_pid(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import os from "node:os";
+                import path from "node:path";
+
+                const sandboxRoot = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox");
+                const stale = path.join(sandboxRoot, "partial-instance-session");
+                fs.mkdirSync(path.join(stale, "build"), { recursive: true });
+                fs.writeFileSync(
+                  path.join(stale, "owner.pid"),
+                  `${process.pid}\\nopencode\\n\\na\\n`,
+                );
+                const old = new Date(Date.now() - 61_000);
+                fs.utimesSync(stale, old, old);
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=partial-instance-sweep"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "current-session" },
+                  { env: {} },
+                );
+
+                console.log(JSON.stringify({ staleExists: fs.existsSync(stale) }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertFalse(result["staleExists"])
+
+    def test_shell_env_recovers_an_abandoned_owner_lock(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import os from "node:os";
+                import path from "node:path";
+
+                const sandboxRoot = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox");
+                const stale = path.join(sandboxRoot, "abandoned-lock-session");
+                const lock = path.join(stale, ".owner.lock");
+                fs.mkdirSync(path.join(stale, "build"), { recursive: true });
+                fs.writeFileSync(lock, "00000000-0000-4000-8000-000000000001\\n");
+                const old = new Date(Date.now() - 61_000);
+                fs.utimesSync(lock, old, old);
+                fs.utimesSync(stale, old, old);
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=abandoned-owner-lock"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "current-session" },
+                  { env: {} },
+                );
+
+                console.log(JSON.stringify({ staleExists: fs.existsSync(stale) }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertFalse(result["staleExists"])
+
+    def test_stale_lock_recovery_does_not_steal_a_replacement_lock(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import os from "node:os";
+                import path from "node:path";
+
+                const sandboxRoot = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox");
+                const stale = path.join(sandboxRoot, "replacement-lock-session");
+                const lock = path.join(stale, ".owner.lock");
+                const oldToken = "00000000-0000-4000-8000-000000000001";
+                const replacementToken = "00000000-0000-4000-8000-000000000002";
+                fs.mkdirSync(path.join(stale, "build"), { recursive: true });
+                fs.writeFileSync(lock, `${oldToken}\\n`);
+                const old = new Date(Date.now() - 61_000);
+                fs.utimesSync(lock, old, old);
+                fs.utimesSync(stale, old, old);
+
+                const originalStatSync = fs.statSync;
+                let replacementInstalled = false;
+                fs.statSync = (filePath, ...args) => {
+                  const stat = originalStatSync(filePath, ...args);
+                  if (String(filePath) === lock && !replacementInstalled) {
+                    replacementInstalled = true;
+                    fs.unlinkSync(lock);
+                    fs.writeFileSync(lock, `${replacementToken}\\n`);
+                  }
+                  return stat;
+                };
+
+                try {
+                  const plugin = (await import(
+                    "./XcodeBuildTools/opencode-plugin.js?test=replacement-owner-lock"
+                  )).default;
+                  const hooks = await plugin.server({});
+                  await hooks.config({});
+                  await hooks["shell.env"](
+                    { cwd: process.cwd(), sessionID: "current-session" },
+                    { env: {} },
+                  );
+                } finally {
+                  fs.statSync = originalStatSync;
+                }
+
+                console.log(JSON.stringify({
+                  replacementInstalled,
+                  staleExists: fs.existsSync(stale),
+                  lockToken: fs.existsSync(lock) ? fs.readFileSync(lock, "utf8").trim() : "",
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertTrue(result["replacementInstalled"])
+        self.assertTrue(result["staleExists"])
+        self.assertEqual(
+            result["lockToken"], "00000000-0000-4000-8000-000000000002"
+        )
+
+    def test_stale_sweep_revalidates_owner_published_after_stat(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=owner-publication-race"
+                )).default;
+                const writer = await plugin.server({});
+                await writer.config({});
+
+                const writerInput = { cwd: process.cwd(), sessionID: "writer-session" };
+                const writerOutput = { env: {} };
+                await writer["shell.env"](writerInput, writerOutput);
+
+                const sandbox = path.dirname(writerOutput.env.SANDBOX_DERIVED_DATA);
+                fs.unlinkSync(path.join(sandbox, "owner.pid"));
+                const old = new Date(Date.now() - 61_000);
+                fs.utimesSync(sandbox, old, old);
+
+                const originalStat = fs.promises.stat;
+                let ownerPublished = false;
+                fs.promises.stat = async (filePath) => {
+                  const stat = await originalStat(filePath);
+                  if (String(filePath) === sandbox && !ownerPublished) {
+                    ownerPublished = true;
+                    await writer["shell.env"](writerInput, { env: {} });
+                  }
+                  return stat;
+                };
+
+                try {
+                  const sweeper = await plugin.server({});
+                  await sweeper.config({});
+                  await sweeper["shell.env"](
+                    { cwd: process.cwd(), sessionID: "sweeper-session" },
+                    { env: {} },
+                  );
+                } finally {
+                  fs.promises.stat = originalStat;
+                }
+
+                console.log(JSON.stringify({
+                  ownerPublished,
+                  sandboxExists: fs.existsSync(sandbox),
+                  ownerExists: fs.existsSync(path.join(sandbox, "owner.pid")),
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertTrue(result["ownerPublished"])
+        self.assertTrue(result["sandboxExists"])
+        self.assertTrue(result["ownerExists"])
+
+    def test_stale_sweep_quarantines_before_recursive_removal(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=quarantine-before-remove"
+                )).default;
+                const writer = await plugin.server({});
+                await writer.config({});
+
+                const writerInput = { cwd: process.cwd(), sessionID: "writer-session" };
+                const initialOutput = { env: {} };
+                await writer["shell.env"](writerInput, initialOutput);
+
+                const sandbox = path.dirname(initialOutput.env.SANDBOX_DERIVED_DATA);
+                fs.unlinkSync(path.join(sandbox, "owner.pid"));
+                const old = new Date(Date.now() - 61_000);
+                fs.utimesSync(sandbox, old, old);
+
+                const originalRm = fs.promises.rm;
+                let cleanupPath = "";
+                let writerRepublished = false;
+                fs.promises.rm = async (candidate, options) => {
+                  if (!cleanupPath) {
+                    cleanupPath = String(candidate);
+                    const lock = path.join(cleanupPath, ".owner.lock");
+                    if (fs.existsSync(lock)) fs.unlinkSync(lock);
+
+                    const republishedOutput = { env: {} };
+                    await writer["shell.env"](writerInput, republishedOutput);
+                    writerRepublished = Boolean(republishedOutput.env.SANDBOX_DERIVED_DATA);
+                  }
+                  return originalRm(candidate, options);
+                };
+
+                try {
+                  const sweeper = await plugin.server({});
+                  await sweeper.config({});
+                  await sweeper["shell.env"](
+                    { cwd: process.cwd(), sessionID: "sweeper-session" },
+                    { env: {} },
+                  );
+                } finally {
+                  fs.promises.rm = originalRm;
+                }
+
+                console.log(JSON.stringify({
+                  cleanupPath,
+                  originalSandbox: sandbox,
+                  writerRepublished,
+                  sandboxExists: fs.existsSync(sandbox),
+                  ownerExists: fs.existsSync(path.join(sandbox, "owner.pid")),
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertNotEqual(result["cleanupPath"], result["originalSandbox"])
+        self.assertTrue(result["writerRepublished"])
+        self.assertTrue(result["sandboxExists"])
+        self.assertTrue(result["ownerExists"])
+
+    def test_stale_sweep_restores_owner_published_during_quarantine(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=publish-during-quarantine"
+                )).default;
+                const writer = await plugin.server({});
+                await writer.config({});
+
+                const writerInput = { cwd: process.cwd(), sessionID: "writer-session" };
+                const initialOutput = { env: {} };
+                await writer["shell.env"](writerInput, initialOutput);
+
+                const sandbox = path.dirname(initialOutput.env.SANDBOX_DERIVED_DATA);
+                const ownerPath = path.join(sandbox, "owner.pid");
+                const publishedOwner = fs.readFileSync(ownerPath, "utf8");
+                fs.unlinkSync(ownerPath);
+                const old = new Date(Date.now() - 61_000);
+                fs.utimesSync(sandbox, old, old);
+
+                const originalRenameSync = fs.renameSync;
+                let replacementPublished = false;
+                let quarantinePath = "";
+                fs.renameSync = (source, destination) => {
+                  if (String(source) === sandbox && !replacementPublished) {
+                    quarantinePath = String(destination);
+                    const lock = path.join(sandbox, ".owner.lock");
+                    if (fs.existsSync(lock)) fs.unlinkSync(lock);
+                    fs.writeFileSync(
+                      lock,
+                      "00000000-0000-4000-8000-000000000002\\n",
+                    );
+                    fs.writeFileSync(ownerPath, publishedOwner);
+                    replacementPublished = true;
+                  }
+                  return originalRenameSync(source, destination);
+                };
+
+                try {
+                  const sweeper = await plugin.server({});
+                  await sweeper.config({});
+                  await sweeper["shell.env"](
+                    { cwd: process.cwd(), sessionID: "sweeper-session" },
+                    { env: {} },
+                  );
+                } finally {
+                  fs.renameSync = originalRenameSync;
+                }
+
+                console.log(JSON.stringify({
+                  replacementPublished,
+                  sandboxExists: fs.existsSync(sandbox),
+                  ownerExists: fs.existsSync(path.join(sandbox, "owner.pid")),
+                  quarantineExists: quarantinePath ? fs.existsSync(quarantinePath) : false,
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertTrue(result["replacementPublished"], result)
+        self.assertTrue(result["sandboxExists"])
+        self.assertTrue(result["ownerExists"])
+        self.assertFalse(result["quarantineExists"])
 
     def test_process_start_token_uses_canonical_locale_and_timezone(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -260,8 +675,9 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
                   { env: {} },
                 );
 
-                const psCall = calls.find(({ command }) => command === "ps");
+                const psCall = calls.find(({ command }) => command === "/bin/ps");
                 console.log(JSON.stringify({
+                  command: psCall?.command,
                   locale: psCall?.options?.env?.LC_ALL,
                   language: psCall?.options?.env?.LANG,
                   timezone: psCall?.options?.env?.TZ,
@@ -270,9 +686,118 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
                 {"TMPDIR": tmpdir},
             )
 
+        self.assertEqual(result["command"], "/bin/ps")
         self.assertEqual(result["locale"], "C")
         self.assertEqual(result["language"], "C")
         self.assertEqual(result["timezone"], "UTC")
+
+    def test_process_start_token_times_out_and_continues_shell_setup(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import { EventEmitter } from "node:events";
+                import { mock } from "node:test";
+
+                let commandUsed = "";
+                let killedWith = "";
+                let timeoutMs = 0;
+                const spawn = (command) => {
+                  commandUsed = command;
+                  const child = new EventEmitter();
+                  child.stdout = new EventEmitter();
+                  child.stdout.setEncoding = () => {};
+                  child.kill = (signal) => {
+                    killedWith = signal;
+                    return true;
+                  };
+                  return child;
+                };
+                mock.module("node:child_process", { namedExports: { spawn } });
+
+                const originalSetTimeout = globalThis.setTimeout;
+                const originalClearTimeout = globalThis.clearTimeout;
+                globalThis.setTimeout = (callback, delay) => {
+                  timeoutMs = delay;
+                  queueMicrotask(callback);
+                  return 1;
+                };
+                globalThis.clearTimeout = () => {};
+
+                let output;
+                try {
+                  const plugin = (await import(
+                    "./XcodeBuildTools/opencode-plugin.js?test=process-start-timeout"
+                  )).default;
+                  const hooks = await plugin.server({});
+                  await hooks.config({});
+                  output = { env: {} };
+                  await hooks["shell.env"](
+                    { cwd: process.cwd(), sessionID: "current-session" },
+                    output,
+                  );
+                } finally {
+                  globalThis.setTimeout = originalSetTimeout;
+                  globalThis.clearTimeout = originalClearTimeout;
+                }
+
+                console.log(JSON.stringify({
+                  commandUsed,
+                  killedWith,
+                  timeoutMs,
+                  sandboxConfigured: Boolean(output.env.SANDBOX_DERIVED_DATA),
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+                timeout=2,
+            )
+
+        self.assertEqual(result["commandUsed"], "/bin/ps")
+        self.assertEqual(result["killedWith"], "SIGTERM")
+        self.assertGreater(result["timeoutMs"], 0)
+        self.assertTrue(result["sandboxConfigured"])
+
+    def test_process_start_token_bounds_stdout(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import { EventEmitter } from "node:events";
+                import fs from "node:fs";
+                import path from "node:path";
+                import { mock } from "node:test";
+
+                const spawn = () => {
+                  const child = new EventEmitter();
+                  child.stdout = new EventEmitter();
+                  child.stdout.setEncoding = () => {};
+                  queueMicrotask(() => {
+                    child.stdout.emit("data", "x".repeat(10_000));
+                    child.emit("close", 0);
+                  });
+                  return child;
+                };
+                mock.module("node:child_process", { namedExports: { spawn } });
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=bounded-process-start"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+                const output = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "current-session" },
+                  output,
+                );
+
+                const sandbox = path.dirname(output.env.SANDBOX_DERIVED_DATA);
+                const owner = fs.readFileSync(path.join(sandbox, "owner.pid"), "utf8");
+                console.log(JSON.stringify({
+                  tokenLength: owner.split(/\\r?\\n/)[2].length,
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertLessEqual(result["tokenLength"], 256)
 
     def test_process_start_token_waits_for_stdout_to_close(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -377,6 +902,103 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
         self.assertEqual(result["psCalls"], 2)
         self.assertEqual(result["token"], "canonical-start")
 
+    def test_owner_marker_update_failure_preserves_previous_owner(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=atomic-owner-write"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                const output = { env: {} };
+                const input = { cwd: process.cwd(), sessionID: "current-session" };
+                await hooks["shell.env"](input, output);
+
+                const sandbox = path.dirname(output.env.SANDBOX_DERIVED_DATA);
+                const ownerPath = path.join(sandbox, "owner.pid");
+                const originalOwner = fs.readFileSync(ownerPath, "utf8");
+                const originalWriteFileSync = fs.writeFileSync;
+
+                fs.writeFileSync = (filePath, ...args) => {
+                  if (String(filePath).includes("owner.pid")) {
+                    originalWriteFileSync(filePath, "", "utf8");
+                    throw new Error("simulated interrupted owner write");
+                  }
+                  return originalWriteFileSync(filePath, ...args);
+                };
+                try {
+                  await hooks["shell.env"](input, { env: {} });
+                } finally {
+                  fs.writeFileSync = originalWriteFileSync;
+                }
+
+                const finalOwner = fs.readFileSync(ownerPath, "utf8");
+                console.log(JSON.stringify({ preserved: finalOwner === originalOwner }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertTrue(result["preserved"])
+
+    def test_owner_lock_release_preserves_a_replacement_lock(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import path from "node:path";
+
+                const replacementToken = "00000000-0000-4000-8000-000000000002";
+                const originalRenameSync = fs.renameSync;
+                let replacementInstalled = false;
+                fs.renameSync = (source, destination) => {
+                  if (
+                    String(source).endsWith(".owner.lock") &&
+                    String(destination).includes(".release") &&
+                    !replacementInstalled
+                  ) {
+                    replacementInstalled = true;
+                    fs.unlinkSync(source);
+                    fs.writeFileSync(source, `${replacementToken}\\n`);
+                  }
+                  return originalRenameSync(source, destination);
+                };
+
+                let output;
+                try {
+                  const plugin = (await import(
+                    "./XcodeBuildTools/opencode-plugin.js?test=owner-lock-release"
+                  )).default;
+                  const hooks = await plugin.server({});
+                  await hooks.config({});
+                  output = { env: {} };
+                  await hooks["shell.env"](
+                    { cwd: process.cwd(), sessionID: "current-session" },
+                    output,
+                  );
+                } finally {
+                  fs.renameSync = originalRenameSync;
+                }
+
+                const sandbox = path.dirname(output.env.SANDBOX_DERIVED_DATA);
+                const lock = path.join(sandbox, ".owner.lock");
+                console.log(JSON.stringify({
+                  replacementInstalled,
+                  lockToken: fs.existsSync(lock) ? fs.readFileSync(lock, "utf8").trim() : "",
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertTrue(result["replacementInstalled"])
+        self.assertEqual(
+            result["lockToken"], "00000000-0000-4000-8000-000000000002"
+        )
+
     def test_session_deletion_removes_its_owned_sandbox(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             result = self.run_node(
@@ -416,6 +1038,92 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
 
         self.assertTrue(result["eventAvailable"])
         self.assertFalse(result["sandboxExists"])
+
+    def test_failed_session_deletion_is_reclaimed_by_replacement_instance(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=failed-session-delete"
+                )).default;
+                const first = await plugin.server({});
+                await first.config({});
+
+                const firstOutput = { env: {} };
+                await first["shell.env"](
+                  { cwd: process.cwd(), sessionID: "deleted-session" },
+                  firstOutput,
+                );
+                const firstSandbox = path.dirname(firstOutput.env.SANDBOX_DERIVED_DATA);
+                const sandboxRoot = path.dirname(firstSandbox);
+
+                const originalRm = fs.promises.rm;
+                const originalWriteFileSync = fs.writeFileSync;
+                let cleanupRejected = false;
+                let markerWriteFailed = false;
+                let lateWriterPublished = false;
+                fs.promises.rm = async () => {
+                  cleanupRejected = true;
+                  const lock = path.join(firstSandbox, ".owner.lock");
+                  if (fs.existsSync(lock)) fs.unlinkSync(lock);
+                  const lateOutput = { env: {} };
+                  await first["shell.env"](
+                    { cwd: process.cwd(), sessionID: "deleted-session" },
+                    lateOutput,
+                  );
+                  lateWriterPublished = Boolean(lateOutput.env.SANDBOX_DERIVED_DATA);
+                  throw new Error("simulated cleanup failure");
+                };
+                fs.writeFileSync = (filePath, ...args) => {
+                  if (String(filePath).endsWith(".cleanup.tmp")) {
+                    markerWriteFailed = true;
+                    throw new Error("simulated cleanup marker failure");
+                  }
+                  return originalWriteFileSync(filePath, ...args);
+                };
+                try {
+                  await first.event({
+                    event: {
+                      type: "session.deleted",
+                      properties: { info: { id: "deleted-session" } },
+                    },
+                  });
+                } finally {
+                  fs.promises.rm = originalRm;
+                  fs.writeFileSync = originalWriteFileSync;
+                }
+
+                const replacement = await plugin.server({});
+                await replacement.config({});
+                const replacementOutput = { env: {} };
+                await replacement["shell.env"](
+                  { cwd: process.cwd(), sessionID: "replacement-session" },
+                  replacementOutput,
+                );
+                const replacementSandbox = path.dirname(
+                  replacementOutput.env.SANDBOX_DERIVED_DATA,
+                );
+                const remaining = fs.readdirSync(sandboxRoot).filter(
+                  (entry) => path.join(sandboxRoot, entry) !== replacementSandbox,
+                );
+
+                console.log(JSON.stringify({
+                  cleanupRejected,
+                  lateWriterPublished,
+                  markerWriteFailed,
+                  remaining,
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertTrue(result["cleanupRejected"])
+        self.assertTrue(result["markerWriteFailed"])
+        self.assertFalse(result["lateWriterPublished"])
+        self.assertEqual(result["remaining"], [])
 
     def test_session_deletion_during_shell_setup_does_not_leave_a_sandbox(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -506,6 +1214,11 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
                 const disposeAvailable = typeof hooks.dispose === "function";
                 if (disposeAvailable) await hooks.dispose();
 
+                for (let attempt = 0; attempt < 100; attempt += 1) {
+                  if (!sandboxes.some((sandbox) => fs.existsSync(sandbox))) break;
+                  await new Promise((resolve) => setTimeout(resolve, 5));
+                }
+
                 console.log(JSON.stringify({
                   disposeAvailable,
                   remaining: sandboxes.filter((sandbox) => fs.existsSync(sandbox)),
@@ -516,6 +1229,238 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
 
         self.assertTrue(result["disposeAvailable"])
         self.assertEqual(result["remaining"], [])
+
+    def test_plugin_dispose_allows_parent_exit_while_cleanup_is_active(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import { EventEmitter } from "node:events";
+                import { mock } from "node:test";
+
+                let cleanupStarted = false;
+                let cleanupUnrefed = false;
+                const spawn = (command) => {
+                  const child = new EventEmitter();
+                  child.stdout = new EventEmitter();
+                  child.stdout.setEncoding = () => {};
+                  child.kill = () => true;
+
+                  if (command === "/bin/rm") {
+                    cleanupStarted = true;
+                    const activeCleanup = setTimeout(() => {}, 15_000);
+                    child.unref = () => {
+                      cleanupUnrefed = true;
+                      activeCleanup.unref();
+                    };
+                  } else {
+                    child.unref = () => {};
+                    queueMicrotask(() => {
+                      if (command === "/bin/ps") child.stdout.emit("data", "canonical-start\\n");
+                      child.emit("exit", 0);
+                      child.emit("close", 0);
+                    });
+                  }
+                  return child;
+                };
+                mock.module("node:child_process", { namedExports: { spawn } });
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=parent-exit-dispose"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "current-session" },
+                  { env: {} },
+                );
+
+                await hooks.dispose();
+
+                console.log(JSON.stringify({ cleanupStarted, cleanupUnrefed }));
+                """,
+                {"TMPDIR": tmpdir},
+                timeout=5,
+            )
+
+        self.assertTrue(result["cleanupStarted"])
+        self.assertTrue(result["cleanupUnrefed"])
+
+    def test_plugin_dispose_starts_detached_cleanup_process(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import { EventEmitter } from "node:events";
+                import { mock } from "node:test";
+
+                const calls = [];
+                const spawn = (command, args = [], options = {}) => {
+                  const call = { command, args, options, unrefCalled: false };
+                  calls.push(call);
+                  const child = new EventEmitter();
+                  child.stdout = new EventEmitter();
+                  child.stdout.setEncoding = () => {};
+                  child.kill = () => true;
+                  child.unref = () => { call.unrefCalled = true; };
+                  queueMicrotask(() => {
+                    if (command === "/bin/ps") {
+                      child.stdout.emit("data", "canonical-start\\n");
+                    }
+                    child.emit("exit", 0);
+                    child.emit("close", 0);
+                  });
+                  return child;
+                };
+                mock.module("node:child_process", { namedExports: { spawn } });
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=detached-dispose"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "current-session" },
+                  { env: {} },
+                );
+                await hooks.dispose();
+
+                const removal = calls.find(({ command }) => command === "/bin/rm");
+                console.log(JSON.stringify({
+                  removalStarted: Boolean(removal),
+                  args: removal?.args,
+                  detached: removal?.options?.detached,
+                  stdio: removal?.options?.stdio,
+                  unrefCalled: removal?.unrefCalled,
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertTrue(result["removalStarted"])
+        self.assertEqual(result["args"][0], "-rf")
+        self.assertTrue(result["detached"])
+        self.assertEqual(result["stdio"], "ignore")
+        self.assertTrue(result["unrefCalled"])
+
+    def test_dispose_cleanup_failures_are_reclaimed_by_replacement_instance(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import { EventEmitter } from "node:events";
+                import fs from "node:fs";
+                import path from "node:path";
+                import { mock } from "node:test";
+
+                let activeHooks;
+                let activeSessionID = "";
+                let cleanupMode = "throw";
+                const lateWrites = [];
+                const spawn = (command) => {
+                  if (command === "/bin/rm" && activeHooks) {
+                    const output = { env: {} };
+                    lateWrites.push({
+                      mode: cleanupMode,
+                      output,
+                      promise: activeHooks["shell.env"](
+                        { cwd: process.cwd(), sessionID: activeSessionID },
+                        output,
+                      ),
+                    });
+                  }
+                  if (command === "/bin/rm" && cleanupMode === "throw") {
+                    throw new Error("simulated spawn failure");
+                  }
+
+                  const child = new EventEmitter();
+                  child.stdout = new EventEmitter();
+                  child.stdout.setEncoding = () => {};
+                  child.kill = () => true;
+                  child.unref = () => {};
+                  queueMicrotask(() => {
+                    if (command === "/bin/ps") child.stdout.emit("data", "canonical-start\\n");
+                    const code = command === "/bin/rm" && cleanupMode === "nonzero" ? 1 : 0;
+                    child.emit("exit", code);
+                    child.emit("close", code);
+                  });
+                  return child;
+                };
+                mock.module("node:child_process", { namedExports: { spawn } });
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=failed-dispose-cleanup"
+                )).default;
+                const results = {};
+
+                for (const mode of ["throw", "nonzero"]) {
+                  cleanupMode = mode;
+                  const first = await plugin.server({});
+                  await first.config({});
+                  const firstOutput = { env: {} };
+                  await first["shell.env"](
+                    { cwd: process.cwd(), sessionID: `${mode}-session` },
+                    firstOutput,
+                  );
+                  const firstSandbox = path.dirname(firstOutput.env.SANDBOX_DERIVED_DATA);
+                  activeHooks = first;
+                  activeSessionID = `${mode}-session`;
+
+                  const originalRenameSync = fs.renameSync;
+                  fs.renameSync = (source, destination) => {
+                    if (
+                      String(source) === firstSandbox &&
+                      String(destination).includes(".quarantine-")
+                    ) {
+                      const error = new Error("simulated busy sandbox");
+                      error.code = "EBUSY";
+                      throw error;
+                    }
+                    return originalRenameSync(source, destination);
+                  };
+                  try {
+                    await first.dispose();
+                  } finally {
+                    fs.renameSync = originalRenameSync;
+                  }
+                  await Promise.all(
+                    lateWrites.filter((write) => write.mode === mode).map((write) => write.promise),
+                  );
+                  results[`${mode}LateWriter`] = lateWrites
+                    .filter((write) => write.mode === mode)
+                    .some((write) => Boolean(write.output.env.SANDBOX_DERIVED_DATA));
+                  await new Promise((resolve) => setImmediate(resolve));
+
+                  const replacement = await plugin.server({});
+                  await replacement.config({});
+                  const replacementOutput = { env: {} };
+                  await replacement["shell.env"](
+                    { cwd: process.cwd(), sessionID: `${mode}-replacement` },
+                    replacementOutput,
+                  );
+                  const replacementSandbox = path.dirname(
+                    replacementOutput.env.SANDBOX_DERIVED_DATA,
+                  );
+                  const sandboxRoot = path.dirname(firstSandbox);
+                  results[mode] = fs.readdirSync(sandboxRoot).filter(
+                    (entry) => path.join(sandboxRoot, entry) !== replacementSandbox,
+                  );
+
+                  for (const entry of fs.readdirSync(sandboxRoot)) {
+                    await fs.promises.rm(path.join(sandboxRoot, entry), {
+                      recursive: true,
+                      force: true,
+                    });
+                  }
+                }
+
+                console.log(JSON.stringify(results));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertEqual(result["throw"], [])
+        self.assertEqual(result["nonzero"], [])
+        self.assertFalse(result["throwLateWriter"])
+        self.assertFalse(result["nonzeroLateWriter"])
 
     def test_disposing_replaced_instance_does_not_remove_new_owner_sandbox(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -547,8 +1492,16 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
                 const sandbox = path.dirname(secondOutput.env.SANDBOX_DERIVED_DATA);
 
                 await first.dispose();
+                for (let attempt = 0; attempt < 100; attempt += 1) {
+                  if (!fs.existsSync(firstSandbox)) break;
+                  await new Promise((resolve) => setTimeout(resolve, 5));
+                }
                 const existsAfterFirstDispose = fs.existsSync(sandbox);
                 await second.dispose();
+                for (let attempt = 0; attempt < 100; attempt += 1) {
+                  if (!fs.existsSync(sandbox)) break;
+                  await new Promise((resolve) => setTimeout(resolve, 5));
+                }
 
                 console.log(JSON.stringify({
                   distinctSandboxes: firstSandbox !== sandbox,
@@ -565,24 +1518,32 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
 
     def test_sweep_removes_sandbox_when_pid_was_reused(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            bin_dir = Path(tmpdir) / "bin"
-            bin_dir.mkdir()
-            ps = bin_dir / "ps"
-            ps.write_text("#!/bin/sh\nprintf '%s\\n' current-start-time\n", encoding="utf-8")
-            ps.chmod(0o755)
-
             result = self.run_node(
                 """
+                import { EventEmitter } from "node:events";
                 import fs from "node:fs";
                 import os from "node:os";
                 import path from "node:path";
+                import { mock } from "node:test";
+
+                const spawn = () => {
+                  const child = new EventEmitter();
+                  child.stdout = new EventEmitter();
+                  child.stdout.setEncoding = () => {};
+                  queueMicrotask(() => {
+                    child.stdout.emit("data", "current-start-time\\n");
+                    child.emit("close", 0);
+                  });
+                  return child;
+                };
+                mock.module("node:child_process", { namedExports: { spawn } });
 
                 const sandboxRoot = path.join(os.tmpdir(), "opencode-xcodebuildtools-sandbox");
                 const stale = path.join(sandboxRoot, "reused-pid-session");
                 fs.mkdirSync(path.join(stale, "build"), { recursive: true });
                 fs.writeFileSync(
                   path.join(stale, "owner.pid"),
-                  `${process.pid}\\nopencode\\nnot-the-current-start-time\\nstale-instance\\n`,
+                  `${process.pid}\\nopencode\\nnot-the-current-start-time\\n00000000-0000-4000-8000-000000000001\\n`,
                 );
 
                 const plugin = (await import(
@@ -597,10 +1558,7 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
 
                 console.log(JSON.stringify({ staleExists: fs.existsSync(stale) }));
                 """,
-                {
-                    "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
-                    "TMPDIR": tmpdir,
-                },
+                {"TMPDIR": tmpdir},
             )
 
         self.assertFalse(result["staleExists"])

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -303,6 +303,161 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
             self.assertEqual(result["second"]["environment"]["PLUGIN_DATA"], str(plugin_data))
             self.assertTrue(plugin_data.is_dir())
 
+    def test_mcp_registration_preserves_existing_endpoints_under_other_names(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            plugin_root = Path(tmpdir) / "plugin"
+            data_home = Path(tmpdir) / "data-home"
+            plugin_root.mkdir()
+            data_home.mkdir()
+            (plugin_root / ".mcp.json").write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "pluginRemoteDuplicate": {
+                                "url": "https://shared.example.test/mcp",
+                            },
+                            "pluginLocalDuplicate": {
+                                "command": "node",
+                                "args": ["server.js", "--shared"],
+                                "cwd": "/workspace/shared",
+                                "environment": {
+                                    "MODE": "workflow",
+                                    "WORKFLOW": "workspace",
+                                },
+                            },
+                            "pluginLocalDifferentCwd": {
+                                "command": "node",
+                                "args": ["server.js", "--shared"],
+                                "cwd": "/workspace/other",
+                                "environment": {
+                                    "MODE": "workflow",
+                                    "WORKFLOW": "workspace",
+                                },
+                            },
+                            "pluginLocalDifferentEnvironment": {
+                                "command": "node",
+                                "args": ["server.js", "--shared"],
+                                "cwd": "/workspace/shared",
+                                "environment": {
+                                    "MODE": "server",
+                                    "WORKFLOW": "workspace",
+                                },
+                            },
+                            "pluginRemoteDistinct": {
+                                "url": "https://distinct.example.test/mcp",
+                            },
+                            "pluginLocalDifferentArgs": {
+                                "command": "node",
+                                "args": ["server.js", "--distinct"],
+                                "cwd": "/workspace/shared",
+                                "environment": {
+                                    "MODE": "workflow",
+                                    "WORKFLOW": "workspace",
+                                },
+                            },
+                            "sameName": {
+                                "url": "https://plugin.example.test/mcp",
+                            },
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.run_node(
+                """
+                import { createOpenCodePlugin } from "./common/opencode-plugin.js?test=mcp-endpoint-deduplication";
+
+                const existingRemote = {
+                  type: "remote",
+                  url: "https://shared.example.test/mcp",
+                  headers: { "X-User": "preserved" },
+                };
+                const existingLocal = {
+                  type: "local",
+                  command: ["node", "server.js", "--shared"],
+                  cwd: "/workspace/shared",
+                  environment: {
+                    WORKFLOW: "workspace",
+                    CLAUDE_PROJECT_DIR: "/user/project",
+                    MODE: "workflow",
+                    CLAUDE_PLUGIN_DATA: "/user/plugin-data",
+                    CLAUDE_PLUGIN_ROOT: "/user/plugin-root",
+                  },
+                };
+                const existingLocalBefore = JSON.stringify(existingLocal);
+                const existingSameName = {
+                  type: "remote",
+                  url: "https://user.example.test/mcp",
+                };
+                const config = {
+                  mcp: {
+                    userRemote: existingRemote,
+                    userLocal: existingLocal,
+                    sameName: existingSameName,
+                  },
+                };
+
+                const server = createOpenCodePlugin(process.env.TEST_PLUGIN_ROOT);
+                const hooks = await server({ directory: process.cwd() });
+                await hooks.config(config);
+
+                console.log(JSON.stringify({
+                  keys: Object.keys(config.mcp),
+                  existingRemoteUnchanged:
+                    config.mcp.userRemote === existingRemote &&
+                    JSON.stringify(config.mcp.userRemote) === JSON.stringify({
+                      type: "remote",
+                      url: "https://shared.example.test/mcp",
+                      headers: { "X-User": "preserved" },
+                    }),
+                  existingLocalUnchanged:
+                    config.mcp.userLocal === existingLocal &&
+                    JSON.stringify(config.mcp.userLocal) === existingLocalBefore,
+                  sameNameUnchanged: config.mcp.sameName === existingSameName,
+                  distinctRemote: config.mcp.pluginRemoteDistinct,
+                  differentCwd: config.mcp.pluginLocalDifferentCwd,
+                  differentEnvironment:
+                    config.mcp.pluginLocalDifferentEnvironment,
+                  differentArgs: config.mcp.pluginLocalDifferentArgs,
+                }));
+                """,
+                {
+                    "TEST_PLUGIN_ROOT": str(plugin_root),
+                    "XDG_DATA_HOME": str(data_home),
+                },
+            )
+
+        self.assertEqual(
+            result["keys"],
+            [
+                "userRemote",
+                "userLocal",
+                "sameName",
+                "pluginLocalDifferentCwd",
+                "pluginLocalDifferentEnvironment",
+                "pluginRemoteDistinct",
+                "pluginLocalDifferentArgs",
+            ],
+        )
+        self.assertTrue(result["existingRemoteUnchanged"])
+        self.assertTrue(result["existingLocalUnchanged"])
+        self.assertTrue(result["sameNameUnchanged"])
+        self.assertEqual(
+            result["distinctRemote"],
+            {"type": "remote", "url": "https://distinct.example.test/mcp"},
+        )
+        self.assertEqual(result["differentCwd"]["cwd"], "/workspace/other")
+        self.assertEqual(result["differentCwd"]["environment"]["MODE"], "workflow")
+        self.assertEqual(result["differentEnvironment"]["cwd"], "/workspace/shared")
+        self.assertEqual(
+            result["differentEnvironment"]["environment"]["MODE"], "server"
+        )
+        self.assertEqual(
+            result["differentArgs"]["command"],
+            ["node", "server.js", "--distinct"],
+        )
+
     def test_mcp_required_placeholder_reports_unset_variable(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             plugin_root = Path(tmpdir) / "plugin"
@@ -569,6 +724,158 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
         self.assertFalse(result["detected"])
         self.assertFalse(result["approvalLaunched"])
 
+    def test_xcode_mcp_ignores_mcpbridge_in_an_unrelated_command_argument(self):
+        result = self.run_node(
+            """
+            import { EventEmitter } from "node:events";
+            import { mock } from "node:test";
+
+            const calls = [];
+            const spawn = (command, args = []) => {
+              calls.push([command, ...args]);
+              const child = new EventEmitter();
+              child.kill = () => true;
+              child.unref = () => {};
+              queueMicrotask(() => child.emit("exit", 0));
+              return child;
+            };
+            mock.module("node:child_process", { namedExports: { spawn } });
+
+            const plugin = (await import(
+              "./XcodeBuildTools/opencode-plugin.js?test=ignore-mcpbridge-argument"
+            )).default;
+            const hooks = await plugin.server({});
+            const config = {
+              mcp: {
+                unrelated: {
+                  type: "local",
+                  command: ["/usr/bin/printf", "--label", "mcpbridge"],
+                },
+              },
+            };
+            await hooks.config(config);
+
+            const output = { system: [] };
+            await hooks["experimental.chat.system.transform"](
+              { sessionID: "session-1" },
+              output,
+            );
+
+            console.log(JSON.stringify({
+              detected: output.system[0].includes("Xcode MCP server detected"),
+              approvalLaunched: calls.some(
+                ([command]) => command.endsWith("run-background.sh"),
+              ),
+            }));
+            """
+        )
+
+        self.assertFalse(result["detected"])
+        self.assertFalse(result["approvalLaunched"])
+
+    def test_xcode_mcp_ignores_mcpbridge_after_a_different_xcrun_tool(self):
+        result = self.run_node(
+            """
+            import { EventEmitter } from "node:events";
+            import { mock } from "node:test";
+
+            const calls = [];
+            const spawn = (command, args = []) => {
+              calls.push([command, ...args]);
+              const child = new EventEmitter();
+              child.kill = () => true;
+              child.unref = () => {};
+              queueMicrotask(() => child.emit("exit", 0));
+              return child;
+            };
+            mock.module("node:child_process", { namedExports: { spawn } });
+
+            const plugin = (await import(
+              "./XcodeBuildTools/opencode-plugin.js?test=ignore-late-xcrun-argument"
+            )).default;
+            const hooks = await plugin.server({});
+            const config = {
+              mcp: {
+                unrelated: {
+                  type: "local",
+                  command: ["xcrun", "swift", "--label", "mcpbridge"],
+                },
+              },
+            };
+            await hooks.config(config);
+
+            const output = { system: [] };
+            await hooks["experimental.chat.system.transform"](
+              { sessionID: "session-1" },
+              output,
+            );
+
+            console.log(JSON.stringify({
+              detected: output.system[0].includes("Xcode MCP server detected"),
+              approvalLaunched: calls.some(
+                ([command]) => command.endsWith("run-background.sh"),
+              ),
+            }));
+            """
+        )
+
+        self.assertFalse(result["detected"])
+        self.assertFalse(result["approvalLaunched"])
+
+    def test_xcode_mcp_recognizes_direct_and_option_prefixed_xcrun_tools(self):
+        result = self.run_node(
+            """
+            import { EventEmitter } from "node:events";
+            import { mock } from "node:test";
+
+            const calls = [];
+            const spawn = (command, args = []) => {
+              calls.push([command, ...args]);
+              const child = new EventEmitter();
+              child.kill = () => true;
+              child.unref = () => {};
+              queueMicrotask(() => child.emit("exit", 0));
+              return child;
+            };
+            mock.module("node:child_process", { namedExports: { spawn } });
+
+            const plugin = (await import(
+              "./XcodeBuildTools/opencode-plugin.js?test=xcrun-tool-operands"
+            )).default;
+            const commands = [
+              ["/usr/local/bin/mcpbridge"],
+              ["xcrun", "mcpbridge"],
+              ["xcrun", "--sdk", "macosx", "--toolchain", "swift", "mcpbridge"],
+              ["xcrun", "--sdk=macosx", "--toolchain=swift", "mcpbridge"],
+              ["xcrun", "--find", "--", "mcpbridge"],
+            ];
+            const results = [];
+
+            for (const [index, command] of commands.entries()) {
+              const hooks = await plugin.server({});
+              const config = { mcp: { xcode: { type: "local", command } } };
+              await hooks.config(config);
+              const callsBefore = calls.length;
+              const output = { system: [] };
+              await hooks["experimental.chat.system.transform"](
+                { sessionID: `session-${index}` },
+                output,
+              );
+              results.push({
+                detected: output.system[0].includes("Xcode MCP server detected"),
+                approvalLaunched: calls.slice(callsBefore).some(
+                  ([executable]) => executable.endsWith("run-background.sh"),
+                ),
+              });
+            }
+
+            console.log(JSON.stringify(results));
+            """
+        )
+
+        self.assertTrue(all(item["detected"] for item in result))
+        self.assertTrue(all(item["approvalLaunched"] for item in result))
+
     def test_xcode_mcp_detection_refreshes_after_cache_ttl(self):
         result = self.run_node(
             """
@@ -631,6 +938,131 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
         self.assertFalse(result["firstDetected"])
         self.assertTrue(result["secondDetected"])
 
+    def test_xcode_mcp_detection_force_kills_and_unrefs_a_timed_out_probe(self):
+        result = self.run_node(
+            """
+            import { EventEmitter } from "node:events";
+            import { mock } from "node:test";
+
+            const signals = [];
+            let unrefCalls = 0;
+            const spawn = () => {
+              const child = new EventEmitter();
+              child.kill = (signal) => {
+                signals.push(signal);
+                return true;
+              };
+              child.unref = () => {
+                unrefCalls += 1;
+              };
+              return child;
+            };
+            mock.module("node:child_process", { namedExports: { spawn } });
+
+            const originalSetTimeout = globalThis.setTimeout;
+            const originalClearTimeout = globalThis.clearTimeout;
+            globalThis.setTimeout = (callback) => {
+              queueMicrotask(callback);
+              return 1;
+            };
+            globalThis.clearTimeout = () => {};
+
+            try {
+              const plugin = (await import(
+                "./XcodeBuildTools/opencode-plugin.js?test=force-kill-detection-timeout"
+              )).default;
+              const hooks = await plugin.server({});
+              const config = {
+                mcp: {
+                  xcode: {
+                    type: "local",
+                    command: ["xcrun", "mcpbridge"],
+                  },
+                },
+              };
+              await hooks.config(config);
+              await hooks["experimental.chat.system.transform"](
+                { sessionID: "session-1" },
+                { system: [] },
+              );
+            } finally {
+              globalThis.setTimeout = originalSetTimeout;
+              globalThis.clearTimeout = originalClearTimeout;
+            }
+
+            console.log(JSON.stringify({ signals, unrefCalls }));
+            """
+        )
+
+        self.assertEqual(result["signals"], ["SIGTERM", "SIGKILL"])
+        self.assertEqual(result["unrefCalls"], 1)
+
+    def test_xcode_mcp_detection_rejects_success_reported_after_timeout(self):
+        result = self.run_node(
+            """
+            import { EventEmitter } from "node:events";
+            import { mock } from "node:test";
+
+            const calls = [];
+            const spawn = (command, args = []) => {
+              calls.push([command, ...args]);
+              const child = new EventEmitter();
+              child.kill = (signal) => {
+                if (signal === "SIGTERM") {
+                  queueMicrotask(() => child.emit("exit", 0));
+                }
+                return true;
+              };
+              child.unref = () => {};
+              return child;
+            };
+            mock.module("node:child_process", { namedExports: { spawn } });
+
+            const originalSetTimeout = globalThis.setTimeout;
+            const originalClearTimeout = globalThis.clearTimeout;
+            globalThis.setTimeout = (callback) => {
+              queueMicrotask(callback);
+              return 1;
+            };
+            globalThis.clearTimeout = () => {};
+
+            let output;
+            try {
+              const plugin = (await import(
+                "./XcodeBuildTools/opencode-plugin.js?test=timeout-cannot-succeed"
+              )).default;
+              const hooks = await plugin.server({});
+              const config = {
+                mcp: {
+                  xcode: {
+                    type: "local",
+                    command: ["xcrun", "mcpbridge"],
+                  },
+                },
+              };
+              await hooks.config(config);
+              output = { system: [] };
+              await hooks["experimental.chat.system.transform"](
+                { sessionID: "session-1" },
+                output,
+              );
+            } finally {
+              globalThis.setTimeout = originalSetTimeout;
+              globalThis.clearTimeout = originalClearTimeout;
+            }
+
+            console.log(JSON.stringify({
+              detected: output.system[0].includes("Xcode MCP server detected"),
+              approvalLaunched: calls.some(
+                ([command]) => command.endsWith("run-background.sh"),
+              ),
+            }));
+            """
+        )
+
+        self.assertFalse(result["detected"])
+        self.assertFalse(result["approvalLaunched"])
+
     def test_xcode_mcp_approval_runs_once_per_session(self):
         result = self.run_node(
             """
@@ -679,6 +1111,106 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
         )
 
         self.assertEqual(result["approvalLaunches"], 2)
+
+    def test_shell_env_rejects_a_symlinked_sandbox_root_without_touching_target(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import os from "node:os";
+                import path from "node:path";
+
+                const victim = path.join(os.tmpdir(), "victim");
+                const documents = path.join(victim, "Documents");
+                const keep = path.join(documents, "keep.txt");
+                const sandboxRoot = path.join(
+                  os.tmpdir(),
+                  "opencode-xcodebuildtools-sandbox",
+                );
+                fs.mkdirSync(documents, { recursive: true });
+                fs.writeFileSync(keep, "preserve me\\n", "utf8");
+                const old = new Date(Date.now() - 61_000);
+                fs.utimesSync(documents, old, old);
+                fs.symlinkSync(victim, sandboxRoot, "dir");
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=symlinked-sandbox-root"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+                const output = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "current-session" },
+                  output,
+                );
+
+                console.log(JSON.stringify({
+                  keepExists: fs.existsSync(keep),
+                  victimEntries: fs.readdirSync(victim).sort(),
+                  rootStillSymlink: fs.lstatSync(sandboxRoot).isSymbolicLink(),
+                  derivedDataConfigured: Object.hasOwn(
+                    output.env,
+                    "SANDBOX_DERIVED_DATA",
+                  ),
+                  packagesConfigured: Object.hasOwn(
+                    output.env,
+                    "SANDBOX_PACKAGES",
+                  ),
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertTrue(result["keepExists"])
+        self.assertEqual(result["victimEntries"], ["Documents"])
+        self.assertTrue(result["rootStillSymlink"])
+        self.assertFalse(result["derivedDataConfigured"])
+        self.assertFalse(result["packagesConfigured"])
+
+    def test_shell_env_secures_an_existing_current_user_sandbox_root(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import os from "node:os";
+                import path from "node:path";
+
+                const sandboxRoot = path.join(
+                  os.tmpdir(),
+                  "opencode-xcodebuildtools-sandbox",
+                );
+                fs.mkdirSync(sandboxRoot, { mode: 0o755 });
+                fs.chmodSync(sandboxRoot, 0o755);
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=secure-existing-sandbox-root"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+                const output = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "current-session" },
+                  output,
+                );
+
+                console.log(JSON.stringify({
+                  rootMode: fs.statSync(sandboxRoot).mode & 0o777,
+                  rootIsDirectory: fs.lstatSync(sandboxRoot).isDirectory(),
+                  derivedDataExists: fs.statSync(
+                    output.env.SANDBOX_DERIVED_DATA,
+                  ).isDirectory(),
+                  packagesExist: fs.statSync(
+                    output.env.SANDBOX_PACKAGES,
+                  ).isDirectory(),
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertEqual(result["rootMode"], 0o700)
+        self.assertTrue(result["rootIsDirectory"])
+        self.assertTrue(result["derivedDataExists"])
+        self.assertTrue(result["packagesExist"])
 
     def test_shell_env_sweeps_sandboxes_owned_by_dead_processes(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1177,19 +1709,38 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
             result = self.run_node(
                 """
                 import { EventEmitter } from "node:events";
+                import fs from "node:fs";
+                import path from "node:path";
                 import { mock } from "node:test";
 
                 let commandUsed = "";
-                let killedWith = "";
-                let timeoutMs = 0;
+                const signals = [];
+                const timeoutDelays = [];
+                const clearedTimers = [];
+                let nextTimer = 0;
+                let unrefCalls = 0;
+                let stdoutDestroyCalls = 0;
+                let child;
                 const spawn = (command) => {
                   commandUsed = command;
-                  const child = new EventEmitter();
+                  child = new EventEmitter();
                   child.stdout = new EventEmitter();
                   child.stdout.setEncoding = () => {};
+                  child.stdout.destroy = () => {
+                    stdoutDestroyCalls += 1;
+                  };
                   child.kill = (signal) => {
-                    killedWith = signal;
+                    signals.push(signal);
+                    if (signal === "SIGKILL") {
+                      queueMicrotask(() => {
+                        child.stdout.emit("data", "late-start-token\\n");
+                        child.emit("close", 0);
+                      });
+                    }
                     return true;
+                  };
+                  child.unref = () => {
+                    unrefCalls += 1;
                   };
                   return child;
                 };
@@ -1198,11 +1749,14 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
                 const originalSetTimeout = globalThis.setTimeout;
                 const originalClearTimeout = globalThis.clearTimeout;
                 globalThis.setTimeout = (callback, delay) => {
-                  timeoutMs = delay;
+                  timeoutDelays.push(delay);
                   queueMicrotask(callback);
-                  return 1;
+                  nextTimer += 1;
+                  return nextTimer;
                 };
-                globalThis.clearTimeout = () => {};
+                globalThis.clearTimeout = (timer) => {
+                  clearedTimers.push(timer);
+                };
 
                 let output;
                 try {
@@ -1221,10 +1775,20 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
                   globalThis.clearTimeout = originalClearTimeout;
                 }
 
+                const sandbox = path.dirname(output.env.SANDBOX_DERIVED_DATA);
+                const owner = fs.readFileSync(path.join(sandbox, "owner.pid"), "utf8");
+
                 console.log(JSON.stringify({
                   commandUsed,
-                  killedWith,
-                  timeoutMs,
+                  signals,
+                  timeoutDelays,
+                  clearedTimers,
+                  unrefCalls,
+                  stdoutDestroyCalls,
+                  stdoutDataListeners: child.stdout.listenerCount("data"),
+                  childErrorListeners: child.listenerCount("error"),
+                  childCloseListeners: child.listenerCount("close"),
+                  processStartToken: owner.split(/\\r?\\n/)[2],
                   sandboxConfigured: Boolean(output.env.SANDBOX_DERIVED_DATA),
                 }));
                 """,
@@ -1233,8 +1797,15 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
             )
 
         self.assertEqual(result["commandUsed"], "/bin/ps")
-        self.assertEqual(result["killedWith"], "SIGTERM")
-        self.assertGreater(result["timeoutMs"], 0)
+        self.assertEqual(result["signals"], ["SIGTERM", "SIGKILL"])
+        self.assertEqual(result["timeoutDelays"], [5_000, 250])
+        self.assertEqual(result["clearedTimers"], [1, 2])
+        self.assertEqual(result["unrefCalls"], 1)
+        self.assertEqual(result["stdoutDestroyCalls"], 1)
+        self.assertEqual(result["stdoutDataListeners"], 0)
+        self.assertEqual(result["childErrorListeners"], 0)
+        self.assertEqual(result["childCloseListeners"], 0)
+        self.assertEqual(result["processStartToken"], "")
         self.assertTrue(result["sandboxConfigured"])
 
     def test_process_start_token_bounds_stdout(self):

--- a/tests/test_repository_integrity.py
+++ b/tests/test_repository_integrity.py
@@ -1,6 +1,7 @@
 import json
 import py_compile
 import re
+import shutil
 import shlex
 import subprocess
 import sys
@@ -199,6 +200,71 @@ class RepositoryIntegrityTests(unittest.TestCase):
                         sync_common.generated_bytes(shared_file, REPO_ROOT),
                         plugin_file.read_bytes(),
                     )
+
+    def test_common_js_helpers_use_javascript_comment_headers(self):
+        sync_common = load_sync_common_module()
+        source = REPO_ROOT / "common" / "opencode-plugin.js"
+
+        self.assertTrue(source.exists())
+        self.assertTrue(sync_common.generated_bytes(source, REPO_ROOT).startswith(b"// Generated from"))
+
+    def test_opencode_plugin_entrypoints_exist_for_local_plugins(self):
+        for plugin_dir in plugin_dirs():
+            entrypoint = plugin_dir / "opencode-plugin.js"
+            expected = (
+                'import { createOpenCodePlugin } from "./common/opencode-plugin.js";\n\n'
+                "export default {\n"
+                f'  id: "{plugin_dir.name}",\n'
+                '  server: createOpenCodePlugin(new URL(".", import.meta.url)),\n'
+                "};\n"
+            )
+
+            with self.subTest(plugin=plugin_dir.name):
+                self.assertTrue(entrypoint.exists())
+                self.assertEqual(expected, entrypoint.read_text(encoding="utf-8"))
+
+    def test_opencode_plugin_javascript_syntax(self):
+        node = shutil.which("node")
+        if not node:
+            self.skipTest("node is not available")
+
+        script_paths = [REPO_ROOT / "common" / "opencode-plugin.js"]
+        script_paths.extend(plugin_dir / "opencode-plugin.js" for plugin_dir in plugin_dirs())
+
+        for script_path in script_paths:
+            result = subprocess.run(
+                [node, "--check", str(script_path)],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            with self.subTest(script=str(script_path.relative_to(REPO_ROOT))):
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_opencode_plugin_entrypoints_export_server_plugin_objects(self):
+        node = shutil.which("node")
+        if not node:
+            self.skipTest("node is not available")
+
+        for plugin_dir in plugin_dirs():
+            entrypoint = plugin_dir / "opencode-plugin.js"
+            script = (
+                f'import plugin from "./{entrypoint.relative_to(REPO_ROOT)}";\n'
+                f'if (plugin?.id !== "{plugin_dir.name}") process.exit(1);\n'
+                'if (typeof plugin.server !== "function") process.exit(2);\n'
+            )
+            result = subprocess.run(
+                [node, "--input-type=module", "-e", script],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            with self.subTest(plugin=plugin_dir.name):
+                self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_sync_plugin_common_script_reports_clean_checkout(self):
         result = subprocess.run(

--- a/tests/test_repository_integrity.py
+++ b/tests/test_repository_integrity.py
@@ -12,11 +12,29 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SYNC_COMMON_SCRIPT = REPO_ROOT / "scripts" / "sync-plugin-common.py"
+OPENCODE_GUARDRAIL_REGISTRATION_CLAIM = re.compile(
+    r"\bentry point(?: that)? register(?:s|ed)?\b"
+    r"[^.\n]*\b(?:pre-tool-use\s+)?command\s+guardrails\b",
+    re.IGNORECASE,
+)
 
 
 def load_json(path):
     with path.open(encoding="utf-8") as file:
         return json.load(file)
+
+
+def registered_guardrail_claim_has_rules(info, *current_texts):
+    has_claim = any(
+        isinstance(text, str)
+        and OPENCODE_GUARDRAIL_REGISTRATION_CLAIM.search(text)
+        for text in current_texts
+    )
+    if not has_claim:
+        return True
+
+    rules = info.get("pre-tool-use-rules") if info else None
+    return isinstance(rules, list) and bool(rules)
 
 
 def plugin_dirs():
@@ -91,6 +109,122 @@ class RepositoryIntegrityTests(unittest.TestCase):
 
             with self.subTest(plugin=plugin_dir.name):
                 self.assertIn(f"### {manifest['version']}", readme)
+
+    def test_current_registered_guardrail_claims_have_rules(self):
+        for plugin_dir in plugin_dirs():
+            info_path = plugin_dir / "info.json"
+            readme_path = plugin_dir / "README.md"
+            if not info_path.exists() and not readme_path.exists():
+                continue
+
+            manifest = load_json(plugin_dir / ".claude-plugin" / "plugin.json")
+            current_version = manifest["version"]
+            info = None
+            current_texts = []
+            if info_path.exists():
+                info = load_json(info_path)
+                current_info = next(
+                    (
+                        entry
+                        for entry in info.get("versions", [])
+                        if entry.get("version") == current_version
+                    ),
+                    None,
+                )
+                self.assertIsNotNone(
+                    current_info,
+                    f"{plugin_dir.name} info.json should describe version {current_version}",
+                )
+                current_texts.append(current_info.get("changes", ""))
+
+            if readme_path.exists():
+                readme = readme_path.read_text(encoding="utf-8")
+                current_prose, separator, changelog = readme.partition("\n## Changelog\n")
+                self.assertTrue(
+                    separator,
+                    f"{plugin_dir.name} README should include a Changelog section",
+                )
+                changelog_match = re.search(
+                    rf"(?ms)^###\s+{re.escape(current_version)}\s*$\n"
+                    r"(?P<section>.*?)(?=^###\s+|\Z)",
+                    changelog,
+                )
+                self.assertIsNotNone(
+                    changelog_match,
+                    f"{plugin_dir.name} README should describe version {current_version}",
+                )
+                current_texts.extend(
+                    (current_prose, changelog_match.group("section"))
+                )
+
+            with self.subTest(plugin=plugin_dir.name):
+                self.assertTrue(
+                    registered_guardrail_claim_has_rules(
+                        info,
+                        *current_texts,
+                    ),
+                    "registered command guardrails require nonempty pre-tool-use-rules",
+                )
+
+    def test_only_templated_registration_claim_requires_rules(self):
+        original_claim = (
+            "The OpenCode entry point registers the scaffolding skill, "
+            "session context, and command guardrails."
+        )
+        original_info_claim = (
+            "Added an opencode-plugin.js entry point that registers skills, "
+            "session-start context, and pre-tool-use command guardrails."
+        )
+        current_claim = (
+            "The OpenCode entry point registers the scaffolding skill "
+            "and session context."
+        )
+
+        cases = (
+            ("original", {}, original_claim, False),
+            ("original-info", {}, original_info_claim, False),
+            (
+                "configured",
+                {"pre-tool-use-rules": [{}]},
+                original_claim,
+                True,
+            ),
+            ("current", {}, current_claim, True),
+            ("non-template", {}, "Added command guardrails.", True),
+        )
+
+        for name, info, claim, expected in cases:
+            with self.subTest(name=name):
+                self.assertEqual(
+                    expected,
+                    registered_guardrail_claim_has_rules(
+                        info,
+                        claim,
+                    ),
+                )
+
+    def test_known_registered_guardrail_plugins_have_rules(self):
+        for plugin_name in ("iOSSimulator", "XcodeBuildTools"):
+            plugin_dir = REPO_ROOT / plugin_name
+            manifest = load_json(plugin_dir / ".claude-plugin" / "plugin.json")
+            info = load_json(plugin_dir / "info.json")
+            current_info = next(
+                entry
+                for entry in info["versions"]
+                if entry["version"] == manifest["version"]
+            )
+
+            with self.subTest(plugin=plugin_name):
+                self.assertRegex(
+                    current_info["changes"],
+                    OPENCODE_GUARDRAIL_REGISTRATION_CLAIM,
+                )
+                self.assertTrue(
+                    registered_guardrail_claim_has_rules(
+                        info,
+                        current_info["changes"],
+                    )
+                )
 
     def test_info_skill_list_matches_skill_directories(self):
         for plugin_dir in plugin_dirs():

--- a/tests/test_repository_integrity.py
+++ b/tests/test_repository_integrity.py
@@ -233,8 +233,9 @@ class RepositoryIntegrityTests(unittest.TestCase):
 
         for script_path in script_paths:
             result = subprocess.run(
-                [node, "--check", str(script_path)],
+                [node, "--input-type=module", "--check"],
                 cwd=REPO_ROOT,
+                input=script_path.read_text(encoding="utf-8"),
                 text=True,
                 capture_output=True,
                 check=False,

--- a/tests/test_repository_integrity.py
+++ b/tests/test_repository_integrity.py
@@ -223,6 +223,12 @@ class RepositoryIntegrityTests(unittest.TestCase):
                 self.assertTrue(entrypoint.exists())
                 self.assertEqual(expected, entrypoint.read_text(encoding="utf-8"))
 
+    def test_node_is_available_for_opencode_runtime_checks(self):
+        self.assertIsNotNone(
+            shutil.which("node"),
+            "Node.js is required for OpenCode runtime, syntax, and export checks",
+        )
+
     def test_opencode_plugin_javascript_syntax(self):
         node = shutil.which("node")
         if not node:


### PR DESCRIPTION
## Overview

Adds local OpenCode support to each marketplace plugin without changing the existing Claude Code plugin format. OpenCode users can point their configuration at a plugin's `opencode-plugin.js` entry point, which adapts the package's existing skills, MCP servers, session context, command guardrails, and shell setup to OpenCode hooks.

The implementation also hardens the XcodeBuildTools integration around sandbox containment, stale-session cleanup, bounded process termination, non-Git project paths, and prompt-time executable trust.

## Technical Details

- Adds one canonical `common/opencode-plugin.js` adapter, five synchronized package-local copies, and thin per-plugin entry points.
- Translates Claude-compatible MCP definitions while preserving endpoint precedence and exporting authoritative `CLAUDE_PLUGIN_ROOT`, `CLAUDE_PLUGIN_DATA`, and `CLAUDE_PROJECT_DIR` values.
- Reuses existing session-start content and pre-tool-use rules through OpenCode's system-transform and tool hooks.
- Gives XcodeBuildTools sessions isolated build/package directories with owner, identity, quarantine, and lifecycle checks before cleanup.
- Tracks Xcode MCP detection and approval work per session, uses fixed system executable paths, and shares bounded `SIGTERM` → `SIGKILL` cleanup across session deletion and plugin disposal.
- Makes Node.js a required validation dependency and expands runtime/integrity coverage for the adapter and generated packages.