### PR TITLE
Fix SwiftScaffolding XcodeBuildMCP registration: add missing mcp subcommand

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -56,7 +56,7 @@
     },
     {
       "name": "SwiftScaffolding",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "description": "Swift project scaffolding and code generation tools",
       "source": "./SwiftScaffolding",
       "author": {

--- a/SwiftScaffolding/.claude-plugin/plugin.json
+++ b/SwiftScaffolding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "SwiftScaffolding",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Swift project scaffolding and code generation tools",
   "author": {
     "name": "Gustavo Ambrozio"

--- a/SwiftScaffolding/.mcp.json
+++ b/SwiftScaffolding/.mcp.json
@@ -4,7 +4,8 @@
       "command": "npx",
       "args": [
         "-y",
-        "xcodebuildmcp@latest"
+        "xcodebuildmcp@latest",
+        "mcp"
       ],
       "env": {
         "XCODEBUILDMCP_ENABLED_WORKFLOWS": "project-scaffolding",

--- a/SwiftScaffolding/README.md
+++ b/SwiftScaffolding/README.md
@@ -44,6 +44,9 @@ Use the `scaffolding` skill to scaffold Swift projects.
 
 ## Changelog
 
+### 0.4.5
+- Fixed XcodeBuildMCP registration in `.mcp.json` — added the `"mcp"` subcommand to args so the MCP server starts in stdio mode instead of printing help and exiting
+
 ### 0.4.4
 - Added `opencode-plugin.js` for OpenCode users
 - The OpenCode entry point registers the `scaffolding` skill, XcodeBuildMCP server, and session context

--- a/SwiftScaffolding/info.json
+++ b/SwiftScaffolding/info.json
@@ -5,6 +5,10 @@
     "welcomeMessage": "You can scaffold Swift projects using the scaffolding skill.",
     "versions": [
         {
+            "version": "0.4.5",
+            "changes": "Fixed XcodeBuildMCP registration: added the missing \"mcp\" subcommand in args to prevent connection closure on startup."
+        },
+        {
             "version": "0.4.4",
             "changes": "Added OpenCode support through an opencode-plugin.js entry point that registers skills, MCP servers, and session-start context."
         },


### PR DESCRIPTION
The `.mcp.json` in SwiftScaffolding was missing the `"mcp"` subcommand in the `args` array for the XcodeBuildMCP entry. The `xcodebuildmcp@latest` CLI requires `mcp` to start in MCP stdio mode; without it, the server prints help and exits, causing `-32000: Connection closed` at startup.

This PR adds `"mcp"` to the args array and bumps SwiftScaffolding to v0.4.5.