### PR TITLE
Reuse finished OpenCode subagent sandboxes via lease pool

### DIFF
--- a/MarvinOutputStyle/common/opencode-plugin.js
+++ b/MarvinOutputStyle/common/opencode-plugin.js
@@ -1199,8 +1199,14 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
 
   // Plugin instances never create a sandbox path used by another instance, so
   // an older instance cannot delete a replacement instance's active sandbox
-  // after an ownership check.
-  return path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
+  // after an ownership check. Within this instance the deterministic name can
+  // collide: pooling decouples directory names from sessions, so a sandbox
+  // named after this session may now be leased by a different session. Never
+  // share a live sandbox — fall back to a unique suffix instead.
+  const fresh = path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
+  const leasedPaths = new Set(state.ownedSandboxes.values());
+  if (!leasedPaths.has(fresh)) return fresh;
+  return path.join(sandboxRootIdentity.path, `${sessionID}-${randomUUID()}`);
 }
 
 function recordSessionParent(state, info) {
@@ -1287,6 +1293,8 @@ async function detachOwnedSandboxes(state) {
   for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
   state.ownedSandboxIdentities.clear();
+  // Pooled entries were folded into `sandboxes` above; clear the pool and
+  // session-tracking state so a disposed instance can never lease or release.
   state.freeSandboxes.length = 0;
   state.sessionParents.clear();
   state.lastSessionSandbox.clear();

--- a/MarvinOutputStyle/common/opencode-plugin.js
+++ b/MarvinOutputStyle/common/opencode-plugin.js
@@ -1152,6 +1152,8 @@ async function handlePluginEvent(state, event) {
   if (typeof sessionID !== "string" || !sessionID) return;
 
   const safeID = safeSessionID(sessionID);
+  const parentID =
+    event.properties?.info?.parentID ?? state.sessionParents.get(safeID);
   state.deletedSandboxSessions.add(safeID);
   state.sessionParents.delete(safeID);
   state.lastSessionSandbox.delete(safeID);
@@ -1160,6 +1162,10 @@ async function handlePluginEvent(state, event) {
   const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
   await stopXcodeMcpApproval(activeApproval);
   await removeOwnedSandbox(state, safeID);
+  // A deleted main session drains the free pool: pooled sandboxes existed to
+  // serve its subagents, so reclaim the disk now rather than at dispose.
+  // Sandboxes still leased by live sessions are untouched.
+  if (!parentID) await drainFreeSandboxes(state);
 }
 
 // Leasing order: the sandbox this session already holds, then the sandbox it
@@ -1226,6 +1232,28 @@ async function removeOwnedSandbox(state, sessionID) {
   state.ownedSandboxIdentities.delete(sessionID);
   if (!state.sandboxRoot || !sandboxIdentity) return;
 
+  await quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity);
+}
+
+async function drainFreeSandboxes(state) {
+  const entries = state.freeSandboxes.splice(0, state.freeSandboxes.length);
+  if (entries.length === 0) return;
+
+  const drainedPaths = new Set(entries.map((entry) => entry.path));
+  for (const [sessionID, sandboxPath] of state.lastSessionSandbox) {
+    if (drainedPaths.has(sandboxPath)) state.lastSessionSandbox.delete(sessionID);
+  }
+  if (!state.sandboxRoot) return;
+
+  await Promise.all(
+    entries.map(async ({ path: sandboxPath, identity }) => {
+      markPendingSandboxCleanup(sandboxPath);
+      await quarantineAndRemoveSandbox(state, sandboxPath, identity);
+    }),
+  );
+}
+
+async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
   const quarantinedPath = await quarantineOwnedSandbox(
     sandboxPath,
     state.instanceID,

--- a/MarvinOutputStyle/common/opencode-plugin.js
+++ b/MarvinOutputStyle/common/opencode-plugin.js
@@ -86,6 +86,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       sessionParents: new Map(),
       freeSandboxes: [],
       lastSessionSandbox: new Map(),
+      activeBashCounts: new Map(),
       sandboxSweepDone: false,
       disposed: false,
     };
@@ -118,6 +119,11 @@ export function createOpenCodePlugin(pluginRootUrl) {
       "tool.execute.before": async (input, output) => {
         loadMetadata(pluginRoot, state);
         applyPreToolUseRules(state, input, output);
+        trackBashStart(state, input);
+      },
+
+      "tool.execute.after": async (input) => {
+        trackBashEnd(state, input);
       },
 
       "shell.env": async (input, output) => {
@@ -1132,6 +1138,7 @@ function releaseSandboxOwnerLock(ownerLock) {
 
 async function handlePluginEvent(state, event) {
   if (event?.type === "session.created" || event?.type === "session.updated") {
+    if (state.disposed) return;
     recordSessionParent(state, event.properties?.info);
     return;
   }
@@ -1140,6 +1147,11 @@ async function handlePluginEvent(state, event) {
     const rawSessionID = event.properties?.sessionID;
     if (state.disposed || typeof rawSessionID !== "string" || !rawSessionID) return;
     const safeID = safeSessionID(rawSessionID);
+    // A stale idle — delivered after the session was already re-prompted —
+    // must not pool a sandbox an in-flight bash command is still writing to.
+    // Skipping is safe: the re-prompted turn ends with its own idle, which
+    // performs the release once no command is running.
+    if ((state.activeBashCounts.get(safeID) ?? 0) > 0) return;
     // Only subagent (child) sessions release on idle. A main session going
     // idle is just the end of a turn; it keeps its sandbox for the next one.
     if (state.sessionParents.get(safeID)) releaseSandboxToPool(state, safeID);
@@ -1154,9 +1166,15 @@ async function handlePluginEvent(state, event) {
   const safeID = safeSessionID(sessionID);
   const parentID =
     event.properties?.info?.parentID ?? state.sessionParents.get(safeID);
+  // Only a session this instance actually observed as parentless counts as a
+  // main session. A deletion for a session we never tracked (created before
+  // the plugin loaded) proves nothing about the pool, so it must not drain
+  // warm caches that may belong to a still-live main.
+  const knownMain = !parentID && state.sessionParents.has(safeID);
   state.deletedSandboxSessions.add(safeID);
   state.sessionParents.delete(safeID);
   state.lastSessionSandbox.delete(safeID);
+  state.activeBashCounts.delete(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
   const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
@@ -1165,7 +1183,7 @@ async function handlePluginEvent(state, event) {
   // A deleted main session drains the free pool: pooled sandboxes existed to
   // serve its subagents, so reclaim the disk now rather than at dispose.
   // Sandboxes still leased by live sessions are untouched.
-  if (!parentID) await drainFreeSandboxes(state);
+  if (knownMain) await drainFreeSandboxes(state);
 }
 
 // Leasing order: the sandbox this session already holds, then the sandbox it
@@ -1188,6 +1206,10 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
       return entry.path;
     }
+    // Discarded entries stay marked pending: this instance's sweep already
+    // ran, so without the marker a transient inspect failure would orphan
+    // the directory until another process claims the sandbox root.
+    markPendingSandboxCleanup(entry.path);
   }
 
   while (state.freeSandboxes.length > 0) {
@@ -1195,6 +1217,7 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
       return entry.path;
     }
+    markPendingSandboxCleanup(entry.path);
   }
 
   // Plugin instances never create a sandbox path used by another instance, so
@@ -1212,9 +1235,33 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
 function recordSessionParent(state, info) {
   const id = info?.id;
   if (typeof id !== "string" || !id) return;
+  const safeID = safeSessionID(id);
   const parentID =
     typeof info.parentID === "string" && info.parentID ? info.parentID : null;
-  state.sessionParents.set(safeSessionID(id), parentID);
+  // A payload without parentID normally means "main session", but never let
+  // it downgrade a session we already classified: a partial update would
+  // otherwise stop a known child from releasing on idle and let its
+  // deletion drain the pool.
+  if (parentID === null && state.sessionParents.has(safeID)) return;
+  state.sessionParents.set(safeID, parentID);
+}
+
+// In-flight bash tracking exists solely to gate the idle-release against
+// stale events. Counts only ever prevent a release, so a missed
+// tool.execute.after degrades to "the sandbox stays leased" — the pre-pool
+// behavior, reclaimed on deletion/dispose — never to a premature release.
+function trackBashStart(state, input) {
+  if (String(input?.tool ?? "").toLowerCase() !== "bash") return;
+  const safeID = safeSessionID(input?.sessionID ?? "global");
+  state.activeBashCounts.set(safeID, (state.activeBashCounts.get(safeID) ?? 0) + 1);
+}
+
+function trackBashEnd(state, input) {
+  if (String(input?.tool ?? "").toLowerCase() !== "bash") return;
+  const safeID = safeSessionID(input?.sessionID ?? "global");
+  const count = state.activeBashCounts.get(safeID) ?? 0;
+  if (count <= 1) state.activeBashCounts.delete(safeID);
+  else state.activeBashCounts.set(safeID, count - 1);
 }
 
 function releaseSandboxToPool(state, sessionID) {
@@ -1251,15 +1298,25 @@ async function drainFreeSandboxes(state) {
   }
   if (!state.sandboxRoot) return;
 
+  // Removal is detached (/bin/rm) rather than awaited: draining several
+  // multi-GB trees in-process would stall serialized event delivery — the
+  // very lag that turns a delayed session.idle stale.
   await Promise.all(
     entries.map(async ({ path: sandboxPath, identity }) => {
       markPendingSandboxCleanup(sandboxPath);
-      await quarantineAndRemoveSandbox(state, sandboxPath, identity);
+      await quarantineAndRemoveSandbox(state, sandboxPath, identity, {
+        detach: true,
+      });
     }),
   );
 }
 
-async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
+async function quarantineAndRemoveSandbox(
+  state,
+  sandboxPath,
+  sandboxIdentity,
+  { detach = false } = {},
+) {
   const quarantinedPath = await quarantineOwnedSandbox(
     sandboxPath,
     state.instanceID,
@@ -1269,9 +1326,20 @@ async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
   const cleanupIdentity = quarantinedPath
     ? relocatedSandboxIdentity(sandboxIdentity, quarantinedPath)
     : sandboxIdentity;
+  const removalPath = quarantinedPath || sandboxPath;
+  const expectedInstanceID = quarantinedPath ? "" : state.instanceID;
+  if (detach) {
+    await detachManagedSandbox(
+      removalPath,
+      expectedInstanceID,
+      state.sandboxRoot,
+      cleanupIdentity,
+    );
+    return;
+  }
   await removeManagedSandbox(
-    quarantinedPath || sandboxPath,
-    quarantinedPath ? "" : state.instanceID,
+    removalPath,
+    expectedInstanceID,
     state.sandboxRoot,
     cleanupIdentity,
   );
@@ -1298,6 +1366,7 @@ async function detachOwnedSandboxes(state) {
   state.freeSandboxes.length = 0;
   state.sessionParents.clear();
   state.lastSessionSandbox.clear();
+  state.activeBashCounts.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
   state.xcodeMcpApprovalHelpers.clear();

--- a/MarvinOutputStyle/common/opencode-plugin.js
+++ b/MarvinOutputStyle/common/opencode-plugin.js
@@ -54,6 +54,7 @@ const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
 const XCODE_SANDBOX_MODE = 0o700;
 const XCODE_SANDBOX_OWNER_GRACE_MS = 60_000;
 const XCODE_SANDBOX_OWNER_LOCK = ".owner.lock";
+const XCODE_SANDBOX_CREATION_TOKEN = ".creation-token";
 const XCODE_SANDBOX_QUARANTINE_RE =
   /^\.quarantine-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const XCODE_SANDBOX_PENDING_CLEANUPS_KEY = Symbol.for(
@@ -764,6 +765,7 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   const packagesDir = path.join(sandboxBase, "packages");
 
   const sandboxIdentity = secureSandboxDirectory(sandboxBase, sandboxRoot);
+  sandboxIdentity.creationToken = ensureSandboxCreationToken(sandboxBase);
   state.ownedSandboxIdentities.set(sessionID, sandboxIdentity);
   if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
   secureSandboxDirectory(buildDir, sandboxIdentity);
@@ -829,6 +831,32 @@ function createDirectoryNonRecursively(directoryPath) {
     fs.mkdirSync(directoryPath, { mode: XCODE_SANDBOX_MODE });
   } catch (error) {
     if (error?.code !== "EEXIST") throw error;
+  }
+}
+
+// Written once, the first time a sandbox directory is created, and never
+// rewritten. dev+ino+uid alone can't distinguish "still the sandbox we
+// leased" from "something recreated this exact path" on filesystems that
+// recycle inode numbers quickly (tmpfs, the common $TMPDIR backing on Linux
+// CI runners) — a same-path replacement can't reproduce this token's
+// content by coincidence the way it can reproduce a recycled inode number.
+function ensureSandboxCreationToken(sandboxBase) {
+  const tokenPath = path.join(sandboxBase, XCODE_SANDBOX_CREATION_TOKEN);
+  try {
+    const token = randomUUID();
+    fs.writeFileSync(tokenPath, token, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    return token;
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+  return readSandboxCreationToken(sandboxBase);
+}
+
+function readSandboxCreationToken(sandboxBase) {
+  try {
+    return fs.readFileSync(path.join(sandboxBase, XCODE_SANDBOX_CREATION_TOKEN), "utf8");
+  } catch {
+    return null;
   }
 }
 
@@ -1895,6 +1923,19 @@ function secureExistingManagedSandbox(
     ) {
       return null;
     }
+    // dev+ino+uid alone can't tell "still the sandbox we handed out" from
+    // "something recreated this exact path": tmpfs (the common $TMPDIR
+    // backing on Linux CI runners) can hand a freshly created directory the
+    // same inode a just-removed directory held. The creation token is
+    // content written once when the directory was first made, so a
+    // same-path replacement can't produce a match by coincidence.
+    if (
+      expectedSandboxIdentity?.creationToken &&
+      readSandboxCreationToken(candidate) !== expectedSandboxIdentity.creationToken
+    ) {
+      return null;
+    }
+    current.creationToken = expectedSandboxIdentity?.creationToken;
     return current;
   } catch {
     return null;

--- a/MarvinOutputStyle/common/opencode-plugin.js
+++ b/MarvinOutputStyle/common/opencode-plugin.js
@@ -1136,6 +1136,19 @@ function releaseSandboxOwnerLock(ownerLock) {
   }
 }
 
+// Field-diagnosable pool decisions: when $TMPDIR/xbt-sandbox-debug exists,
+// every lease/release decision (and every refusal, with its reason) is
+// appended to $TMPDIR/xbt-sandbox-debug.log. Inert without the flag file.
+function sandboxDebugLog(message) {
+  try {
+    const flag = path.join(os.tmpdir(), "xbt-sandbox-debug");
+    if (!fs.existsSync(flag)) return;
+    fs.appendFileSync(`${flag}.log`, `${new Date().toISOString()} ${message}\n`);
+  } catch {
+    // Diagnostics must never interfere with sandbox management.
+  }
+}
+
 async function handlePluginEvent(state, event) {
   if (event?.type === "session.created" || event?.type === "session.updated") {
     if (state.disposed) return;
@@ -1151,10 +1164,21 @@ async function handlePluginEvent(state, event) {
     // must not pool a sandbox an in-flight bash command is still writing to.
     // Skipping is safe: the re-prompted turn ends with its own idle, which
     // performs the release once no command is running.
-    if ((state.activeBashCounts.get(safeID) ?? 0) > 0) return;
+    if ((state.activeBashCounts.get(safeID) ?? 0) > 0) {
+      sandboxDebugLog(
+        `idle ${safeID}: release refused, ${state.activeBashCounts.get(safeID)} bash in flight`,
+      );
+      return;
+    }
     // Only subagent (child) sessions release on idle. A main session going
     // idle is just the end of a turn; it keeps its sandbox for the next one.
-    if (state.sessionParents.get(safeID)) releaseSandboxToPool(state, safeID);
+    if (state.sessionParents.get(safeID)) {
+      releaseSandboxToPool(state, safeID);
+    } else {
+      sandboxDebugLog(
+        `idle ${safeID}: release refused, parent=${JSON.stringify(state.sessionParents.get(safeID) ?? null)} known=${state.sessionParents.has(safeID)}`,
+      );
+    }
     return;
   }
 
@@ -1183,6 +1207,9 @@ async function handlePluginEvent(state, event) {
   // A deleted main session drains the free pool: pooled sandboxes existed to
   // serve its subagents, so reclaim the disk now rather than at dispose.
   // Sandboxes still leased by live sessions are untouched.
+  sandboxDebugLog(
+    `deleted ${safeID}: knownMain=${knownMain} drain=${knownMain ? state.freeSandboxes.length : 0} pooled`,
+  );
   if (knownMain) await drainFreeSandboxes(state);
 }
 
@@ -1204,20 +1231,24 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
   if (preferredIndex !== -1) {
     const [entry] = state.freeSandboxes.splice(preferredIndex, 1);
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      sandboxDebugLog(`lease ${sessionID}: reused previous ${path.basename(entry.path)}`);
       return entry.path;
     }
     // Discarded entries stay marked pending: this instance's sweep already
     // ran, so without the marker a transient inspect failure would orphan
     // the directory until another process claims the sandbox root.
     markPendingSandboxCleanup(entry.path);
+    sandboxDebugLog(`lease ${sessionID}: discarded invalid ${path.basename(entry.path)}`);
   }
 
   while (state.freeSandboxes.length > 0) {
     const entry = state.freeSandboxes.pop();
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      sandboxDebugLog(`lease ${sessionID}: reused pooled ${path.basename(entry.path)}`);
       return entry.path;
     }
     markPendingSandboxCleanup(entry.path);
+    sandboxDebugLog(`lease ${sessionID}: discarded invalid ${path.basename(entry.path)}`);
   }
 
   // Plugin instances never create a sandbox path used by another instance, so
@@ -1228,8 +1259,13 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
   // share a live sandbox — fall back to a unique suffix instead.
   const fresh = path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
   const leasedPaths = new Set(state.ownedSandboxes.values());
-  if (!leasedPaths.has(fresh)) return fresh;
-  return path.join(sandboxRootIdentity.path, `${sessionID}-${randomUUID()}`);
+  if (!leasedPaths.has(fresh)) {
+    sandboxDebugLog(`lease ${sessionID}: fresh ${path.basename(fresh)}`);
+    return fresh;
+  }
+  const disambiguated = path.join(sandboxRootIdentity.path, `${sessionID}-${randomUUID()}`);
+  sandboxDebugLog(`lease ${sessionID}: fresh (collision) ${path.basename(disambiguated)}`);
+  return disambiguated;
 }
 
 function recordSessionParent(state, info) {
@@ -1273,6 +1309,7 @@ function releaseSandboxToPool(state, sessionID) {
   state.ownedSandboxIdentities.delete(sessionID);
   state.lastSessionSandbox.set(sessionID, sandboxPath);
   state.freeSandboxes.push({ path: sandboxPath, identity });
+  sandboxDebugLog(`release ${sessionID}: pooled ${path.basename(sandboxPath)}`);
 }
 
 async function removeOwnedSandbox(state, sessionID) {

--- a/MarvinOutputStyle/common/opencode-plugin.js
+++ b/MarvinOutputStyle/common/opencode-plugin.js
@@ -1273,14 +1273,23 @@ async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
 
 async function detachOwnedSandboxes(state) {
   state.disposed = true;
-  const sandboxes = [...state.ownedSandboxes.entries()].map(([sessionID, sandboxPath]) => ({
-    sandboxPath,
-    sandboxIdentity: state.ownedSandboxIdentities.get(sessionID),
-  }));
+  const sandboxes = [
+    ...[...state.ownedSandboxes.entries()].map(([sessionID, sandboxPath]) => ({
+      sandboxPath,
+      sandboxIdentity: state.ownedSandboxIdentities.get(sessionID),
+    })),
+    ...state.freeSandboxes.map((entry) => ({
+      sandboxPath: entry.path,
+      sandboxIdentity: entry.identity,
+    })),
+  ];
   const sandboxPaths = [...new Set(sandboxes.map(({ sandboxPath }) => sandboxPath))];
   for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
   state.ownedSandboxIdentities.clear();
+  state.freeSandboxes.length = 0;
+  state.sessionParents.clear();
+  state.lastSessionSandbox.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
   state.xcodeMcpApprovalHelpers.clear();

--- a/MarvinOutputStyle/common/opencode-plugin.js
+++ b/MarvinOutputStyle/common/opencode-plugin.js
@@ -83,6 +83,9 @@ export function createOpenCodePlugin(pluginRootUrl) {
       ownedSandboxes: new Map(),
       ownedSandboxIdentities: new Map(),
       deletedSandboxSessions: new Set(),
+      sessionParents: new Map(),
+      freeSandboxes: [],
+      lastSessionSandbox: new Map(),
       sandboxSweepDone: false,
       disposed: false,
     };
@@ -737,9 +740,7 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
   if (state.disposed || state.deletedSandboxSessions.has(sessionID)) return;
   const sandboxRoot = secureSandboxRoot(state);
-  // Plugin instances never reuse a sandbox path, so an older instance cannot
-  // delete a replacement instance's active sandbox after an ownership check.
-  const sandboxBase = path.join(sandboxRoot.path, `${sessionID}-${state.instanceID}`);
+  const sandboxBase = leaseSandboxPath(state, sandboxRoot, sessionID);
   state.ownedSandboxes.set(sessionID, sandboxBase);
 
   if (!state.processStartToken) {
@@ -1130,6 +1131,21 @@ function releaseSandboxOwnerLock(ownerLock) {
 }
 
 async function handlePluginEvent(state, event) {
+  if (event?.type === "session.created" || event?.type === "session.updated") {
+    recordSessionParent(state, event.properties?.info);
+    return;
+  }
+
+  if (event?.type === "session.idle") {
+    const rawSessionID = event.properties?.sessionID;
+    if (state.disposed || typeof rawSessionID !== "string" || !rawSessionID) return;
+    const safeID = safeSessionID(rawSessionID);
+    // Only subagent (child) sessions release on idle. A main session going
+    // idle is just the end of a turn; it keeps its sandbox for the next one.
+    if (state.sessionParents.get(safeID)) releaseSandboxToPool(state, safeID);
+    return;
+  }
+
   if (event?.type !== "session.deleted") return;
 
   const sessionID = event.properties?.info?.id;
@@ -1137,11 +1153,67 @@ async function handlePluginEvent(state, event) {
 
   const safeID = safeSessionID(sessionID);
   state.deletedSandboxSessions.add(safeID);
+  state.sessionParents.delete(safeID);
+  state.lastSessionSandbox.delete(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
   const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
   await stopXcodeMcpApproval(activeApproval);
   await removeOwnedSandbox(state, safeID);
+}
+
+// Leasing order: the sandbox this session already holds, then the sandbox it
+// held before releasing (warm caches for a re-prompted subagent), then the
+// most recently freed pool entry, then a fresh directory. Pool entries are
+// revalidated before reuse and dropped if they fail the identity checks.
+// Reused directories keep their original <sessionID>-<instanceID> name and
+// are never renamed — SPM and Xcode state files embed absolute paths.
+function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
+  const existing = state.ownedSandboxes.get(sessionID);
+  if (existing) return existing;
+
+  const preferred = state.lastSessionSandbox.get(sessionID);
+  const preferredIndex =
+    typeof preferred === "string"
+      ? state.freeSandboxes.findIndex((entry) => entry.path === preferred)
+      : -1;
+  if (preferredIndex !== -1) {
+    const [entry] = state.freeSandboxes.splice(preferredIndex, 1);
+    if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      return entry.path;
+    }
+  }
+
+  while (state.freeSandboxes.length > 0) {
+    const entry = state.freeSandboxes.pop();
+    if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      return entry.path;
+    }
+  }
+
+  // Plugin instances never create a sandbox path used by another instance, so
+  // an older instance cannot delete a replacement instance's active sandbox
+  // after an ownership check.
+  return path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
+}
+
+function recordSessionParent(state, info) {
+  const id = info?.id;
+  if (typeof id !== "string" || !id) return;
+  const parentID =
+    typeof info.parentID === "string" && info.parentID ? info.parentID : null;
+  state.sessionParents.set(safeSessionID(id), parentID);
+}
+
+function releaseSandboxToPool(state, sessionID) {
+  const sandboxPath = state.ownedSandboxes.get(sessionID);
+  const identity = state.ownedSandboxIdentities.get(sessionID);
+  if (!sandboxPath || !identity) return;
+
+  state.ownedSandboxes.delete(sessionID);
+  state.ownedSandboxIdentities.delete(sessionID);
+  state.lastSessionSandbox.set(sessionID, sandboxPath);
+  state.freeSandboxes.push({ path: sandboxPath, identity });
 }
 
 async function removeOwnedSandbox(state, sessionID) {

--- a/PluginBase/common/opencode-plugin.js
+++ b/PluginBase/common/opencode-plugin.js
@@ -1199,8 +1199,14 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
 
   // Plugin instances never create a sandbox path used by another instance, so
   // an older instance cannot delete a replacement instance's active sandbox
-  // after an ownership check.
-  return path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
+  // after an ownership check. Within this instance the deterministic name can
+  // collide: pooling decouples directory names from sessions, so a sandbox
+  // named after this session may now be leased by a different session. Never
+  // share a live sandbox — fall back to a unique suffix instead.
+  const fresh = path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
+  const leasedPaths = new Set(state.ownedSandboxes.values());
+  if (!leasedPaths.has(fresh)) return fresh;
+  return path.join(sandboxRootIdentity.path, `${sessionID}-${randomUUID()}`);
 }
 
 function recordSessionParent(state, info) {
@@ -1287,6 +1293,8 @@ async function detachOwnedSandboxes(state) {
   for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
   state.ownedSandboxIdentities.clear();
+  // Pooled entries were folded into `sandboxes` above; clear the pool and
+  // session-tracking state so a disposed instance can never lease or release.
   state.freeSandboxes.length = 0;
   state.sessionParents.clear();
   state.lastSessionSandbox.clear();

--- a/PluginBase/common/opencode-plugin.js
+++ b/PluginBase/common/opencode-plugin.js
@@ -1152,6 +1152,8 @@ async function handlePluginEvent(state, event) {
   if (typeof sessionID !== "string" || !sessionID) return;
 
   const safeID = safeSessionID(sessionID);
+  const parentID =
+    event.properties?.info?.parentID ?? state.sessionParents.get(safeID);
   state.deletedSandboxSessions.add(safeID);
   state.sessionParents.delete(safeID);
   state.lastSessionSandbox.delete(safeID);
@@ -1160,6 +1162,10 @@ async function handlePluginEvent(state, event) {
   const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
   await stopXcodeMcpApproval(activeApproval);
   await removeOwnedSandbox(state, safeID);
+  // A deleted main session drains the free pool: pooled sandboxes existed to
+  // serve its subagents, so reclaim the disk now rather than at dispose.
+  // Sandboxes still leased by live sessions are untouched.
+  if (!parentID) await drainFreeSandboxes(state);
 }
 
 // Leasing order: the sandbox this session already holds, then the sandbox it
@@ -1226,6 +1232,28 @@ async function removeOwnedSandbox(state, sessionID) {
   state.ownedSandboxIdentities.delete(sessionID);
   if (!state.sandboxRoot || !sandboxIdentity) return;
 
+  await quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity);
+}
+
+async function drainFreeSandboxes(state) {
+  const entries = state.freeSandboxes.splice(0, state.freeSandboxes.length);
+  if (entries.length === 0) return;
+
+  const drainedPaths = new Set(entries.map((entry) => entry.path));
+  for (const [sessionID, sandboxPath] of state.lastSessionSandbox) {
+    if (drainedPaths.has(sandboxPath)) state.lastSessionSandbox.delete(sessionID);
+  }
+  if (!state.sandboxRoot) return;
+
+  await Promise.all(
+    entries.map(async ({ path: sandboxPath, identity }) => {
+      markPendingSandboxCleanup(sandboxPath);
+      await quarantineAndRemoveSandbox(state, sandboxPath, identity);
+    }),
+  );
+}
+
+async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
   const quarantinedPath = await quarantineOwnedSandbox(
     sandboxPath,
     state.instanceID,

--- a/PluginBase/common/opencode-plugin.js
+++ b/PluginBase/common/opencode-plugin.js
@@ -86,6 +86,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       sessionParents: new Map(),
       freeSandboxes: [],
       lastSessionSandbox: new Map(),
+      activeBashCounts: new Map(),
       sandboxSweepDone: false,
       disposed: false,
     };
@@ -118,6 +119,11 @@ export function createOpenCodePlugin(pluginRootUrl) {
       "tool.execute.before": async (input, output) => {
         loadMetadata(pluginRoot, state);
         applyPreToolUseRules(state, input, output);
+        trackBashStart(state, input);
+      },
+
+      "tool.execute.after": async (input) => {
+        trackBashEnd(state, input);
       },
 
       "shell.env": async (input, output) => {
@@ -1132,6 +1138,7 @@ function releaseSandboxOwnerLock(ownerLock) {
 
 async function handlePluginEvent(state, event) {
   if (event?.type === "session.created" || event?.type === "session.updated") {
+    if (state.disposed) return;
     recordSessionParent(state, event.properties?.info);
     return;
   }
@@ -1140,6 +1147,11 @@ async function handlePluginEvent(state, event) {
     const rawSessionID = event.properties?.sessionID;
     if (state.disposed || typeof rawSessionID !== "string" || !rawSessionID) return;
     const safeID = safeSessionID(rawSessionID);
+    // A stale idle — delivered after the session was already re-prompted —
+    // must not pool a sandbox an in-flight bash command is still writing to.
+    // Skipping is safe: the re-prompted turn ends with its own idle, which
+    // performs the release once no command is running.
+    if ((state.activeBashCounts.get(safeID) ?? 0) > 0) return;
     // Only subagent (child) sessions release on idle. A main session going
     // idle is just the end of a turn; it keeps its sandbox for the next one.
     if (state.sessionParents.get(safeID)) releaseSandboxToPool(state, safeID);
@@ -1154,9 +1166,15 @@ async function handlePluginEvent(state, event) {
   const safeID = safeSessionID(sessionID);
   const parentID =
     event.properties?.info?.parentID ?? state.sessionParents.get(safeID);
+  // Only a session this instance actually observed as parentless counts as a
+  // main session. A deletion for a session we never tracked (created before
+  // the plugin loaded) proves nothing about the pool, so it must not drain
+  // warm caches that may belong to a still-live main.
+  const knownMain = !parentID && state.sessionParents.has(safeID);
   state.deletedSandboxSessions.add(safeID);
   state.sessionParents.delete(safeID);
   state.lastSessionSandbox.delete(safeID);
+  state.activeBashCounts.delete(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
   const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
@@ -1165,7 +1183,7 @@ async function handlePluginEvent(state, event) {
   // A deleted main session drains the free pool: pooled sandboxes existed to
   // serve its subagents, so reclaim the disk now rather than at dispose.
   // Sandboxes still leased by live sessions are untouched.
-  if (!parentID) await drainFreeSandboxes(state);
+  if (knownMain) await drainFreeSandboxes(state);
 }
 
 // Leasing order: the sandbox this session already holds, then the sandbox it
@@ -1188,6 +1206,10 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
       return entry.path;
     }
+    // Discarded entries stay marked pending: this instance's sweep already
+    // ran, so without the marker a transient inspect failure would orphan
+    // the directory until another process claims the sandbox root.
+    markPendingSandboxCleanup(entry.path);
   }
 
   while (state.freeSandboxes.length > 0) {
@@ -1195,6 +1217,7 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
       return entry.path;
     }
+    markPendingSandboxCleanup(entry.path);
   }
 
   // Plugin instances never create a sandbox path used by another instance, so
@@ -1212,9 +1235,33 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
 function recordSessionParent(state, info) {
   const id = info?.id;
   if (typeof id !== "string" || !id) return;
+  const safeID = safeSessionID(id);
   const parentID =
     typeof info.parentID === "string" && info.parentID ? info.parentID : null;
-  state.sessionParents.set(safeSessionID(id), parentID);
+  // A payload without parentID normally means "main session", but never let
+  // it downgrade a session we already classified: a partial update would
+  // otherwise stop a known child from releasing on idle and let its
+  // deletion drain the pool.
+  if (parentID === null && state.sessionParents.has(safeID)) return;
+  state.sessionParents.set(safeID, parentID);
+}
+
+// In-flight bash tracking exists solely to gate the idle-release against
+// stale events. Counts only ever prevent a release, so a missed
+// tool.execute.after degrades to "the sandbox stays leased" — the pre-pool
+// behavior, reclaimed on deletion/dispose — never to a premature release.
+function trackBashStart(state, input) {
+  if (String(input?.tool ?? "").toLowerCase() !== "bash") return;
+  const safeID = safeSessionID(input?.sessionID ?? "global");
+  state.activeBashCounts.set(safeID, (state.activeBashCounts.get(safeID) ?? 0) + 1);
+}
+
+function trackBashEnd(state, input) {
+  if (String(input?.tool ?? "").toLowerCase() !== "bash") return;
+  const safeID = safeSessionID(input?.sessionID ?? "global");
+  const count = state.activeBashCounts.get(safeID) ?? 0;
+  if (count <= 1) state.activeBashCounts.delete(safeID);
+  else state.activeBashCounts.set(safeID, count - 1);
 }
 
 function releaseSandboxToPool(state, sessionID) {
@@ -1251,15 +1298,25 @@ async function drainFreeSandboxes(state) {
   }
   if (!state.sandboxRoot) return;
 
+  // Removal is detached (/bin/rm) rather than awaited: draining several
+  // multi-GB trees in-process would stall serialized event delivery — the
+  // very lag that turns a delayed session.idle stale.
   await Promise.all(
     entries.map(async ({ path: sandboxPath, identity }) => {
       markPendingSandboxCleanup(sandboxPath);
-      await quarantineAndRemoveSandbox(state, sandboxPath, identity);
+      await quarantineAndRemoveSandbox(state, sandboxPath, identity, {
+        detach: true,
+      });
     }),
   );
 }
 
-async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
+async function quarantineAndRemoveSandbox(
+  state,
+  sandboxPath,
+  sandboxIdentity,
+  { detach = false } = {},
+) {
   const quarantinedPath = await quarantineOwnedSandbox(
     sandboxPath,
     state.instanceID,
@@ -1269,9 +1326,20 @@ async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
   const cleanupIdentity = quarantinedPath
     ? relocatedSandboxIdentity(sandboxIdentity, quarantinedPath)
     : sandboxIdentity;
+  const removalPath = quarantinedPath || sandboxPath;
+  const expectedInstanceID = quarantinedPath ? "" : state.instanceID;
+  if (detach) {
+    await detachManagedSandbox(
+      removalPath,
+      expectedInstanceID,
+      state.sandboxRoot,
+      cleanupIdentity,
+    );
+    return;
+  }
   await removeManagedSandbox(
-    quarantinedPath || sandboxPath,
-    quarantinedPath ? "" : state.instanceID,
+    removalPath,
+    expectedInstanceID,
     state.sandboxRoot,
     cleanupIdentity,
   );
@@ -1298,6 +1366,7 @@ async function detachOwnedSandboxes(state) {
   state.freeSandboxes.length = 0;
   state.sessionParents.clear();
   state.lastSessionSandbox.clear();
+  state.activeBashCounts.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
   state.xcodeMcpApprovalHelpers.clear();

--- a/PluginBase/common/opencode-plugin.js
+++ b/PluginBase/common/opencode-plugin.js
@@ -54,6 +54,7 @@ const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
 const XCODE_SANDBOX_MODE = 0o700;
 const XCODE_SANDBOX_OWNER_GRACE_MS = 60_000;
 const XCODE_SANDBOX_OWNER_LOCK = ".owner.lock";
+const XCODE_SANDBOX_CREATION_TOKEN = ".creation-token";
 const XCODE_SANDBOX_QUARANTINE_RE =
   /^\.quarantine-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const XCODE_SANDBOX_PENDING_CLEANUPS_KEY = Symbol.for(
@@ -764,6 +765,7 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   const packagesDir = path.join(sandboxBase, "packages");
 
   const sandboxIdentity = secureSandboxDirectory(sandboxBase, sandboxRoot);
+  sandboxIdentity.creationToken = ensureSandboxCreationToken(sandboxBase);
   state.ownedSandboxIdentities.set(sessionID, sandboxIdentity);
   if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
   secureSandboxDirectory(buildDir, sandboxIdentity);
@@ -829,6 +831,32 @@ function createDirectoryNonRecursively(directoryPath) {
     fs.mkdirSync(directoryPath, { mode: XCODE_SANDBOX_MODE });
   } catch (error) {
     if (error?.code !== "EEXIST") throw error;
+  }
+}
+
+// Written once, the first time a sandbox directory is created, and never
+// rewritten. dev+ino+uid alone can't distinguish "still the sandbox we
+// leased" from "something recreated this exact path" on filesystems that
+// recycle inode numbers quickly (tmpfs, the common $TMPDIR backing on Linux
+// CI runners) — a same-path replacement can't reproduce this token's
+// content by coincidence the way it can reproduce a recycled inode number.
+function ensureSandboxCreationToken(sandboxBase) {
+  const tokenPath = path.join(sandboxBase, XCODE_SANDBOX_CREATION_TOKEN);
+  try {
+    const token = randomUUID();
+    fs.writeFileSync(tokenPath, token, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    return token;
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+  return readSandboxCreationToken(sandboxBase);
+}
+
+function readSandboxCreationToken(sandboxBase) {
+  try {
+    return fs.readFileSync(path.join(sandboxBase, XCODE_SANDBOX_CREATION_TOKEN), "utf8");
+  } catch {
+    return null;
   }
 }
 
@@ -1895,6 +1923,19 @@ function secureExistingManagedSandbox(
     ) {
       return null;
     }
+    // dev+ino+uid alone can't tell "still the sandbox we handed out" from
+    // "something recreated this exact path": tmpfs (the common $TMPDIR
+    // backing on Linux CI runners) can hand a freshly created directory the
+    // same inode a just-removed directory held. The creation token is
+    // content written once when the directory was first made, so a
+    // same-path replacement can't produce a match by coincidence.
+    if (
+      expectedSandboxIdentity?.creationToken &&
+      readSandboxCreationToken(candidate) !== expectedSandboxIdentity.creationToken
+    ) {
+      return null;
+    }
+    current.creationToken = expectedSandboxIdentity?.creationToken;
     return current;
   } catch {
     return null;

--- a/PluginBase/common/opencode-plugin.js
+++ b/PluginBase/common/opencode-plugin.js
@@ -1136,6 +1136,19 @@ function releaseSandboxOwnerLock(ownerLock) {
   }
 }
 
+// Field-diagnosable pool decisions: when $TMPDIR/xbt-sandbox-debug exists,
+// every lease/release decision (and every refusal, with its reason) is
+// appended to $TMPDIR/xbt-sandbox-debug.log. Inert without the flag file.
+function sandboxDebugLog(message) {
+  try {
+    const flag = path.join(os.tmpdir(), "xbt-sandbox-debug");
+    if (!fs.existsSync(flag)) return;
+    fs.appendFileSync(`${flag}.log`, `${new Date().toISOString()} ${message}\n`);
+  } catch {
+    // Diagnostics must never interfere with sandbox management.
+  }
+}
+
 async function handlePluginEvent(state, event) {
   if (event?.type === "session.created" || event?.type === "session.updated") {
     if (state.disposed) return;
@@ -1151,10 +1164,21 @@ async function handlePluginEvent(state, event) {
     // must not pool a sandbox an in-flight bash command is still writing to.
     // Skipping is safe: the re-prompted turn ends with its own idle, which
     // performs the release once no command is running.
-    if ((state.activeBashCounts.get(safeID) ?? 0) > 0) return;
+    if ((state.activeBashCounts.get(safeID) ?? 0) > 0) {
+      sandboxDebugLog(
+        `idle ${safeID}: release refused, ${state.activeBashCounts.get(safeID)} bash in flight`,
+      );
+      return;
+    }
     // Only subagent (child) sessions release on idle. A main session going
     // idle is just the end of a turn; it keeps its sandbox for the next one.
-    if (state.sessionParents.get(safeID)) releaseSandboxToPool(state, safeID);
+    if (state.sessionParents.get(safeID)) {
+      releaseSandboxToPool(state, safeID);
+    } else {
+      sandboxDebugLog(
+        `idle ${safeID}: release refused, parent=${JSON.stringify(state.sessionParents.get(safeID) ?? null)} known=${state.sessionParents.has(safeID)}`,
+      );
+    }
     return;
   }
 
@@ -1183,6 +1207,9 @@ async function handlePluginEvent(state, event) {
   // A deleted main session drains the free pool: pooled sandboxes existed to
   // serve its subagents, so reclaim the disk now rather than at dispose.
   // Sandboxes still leased by live sessions are untouched.
+  sandboxDebugLog(
+    `deleted ${safeID}: knownMain=${knownMain} drain=${knownMain ? state.freeSandboxes.length : 0} pooled`,
+  );
   if (knownMain) await drainFreeSandboxes(state);
 }
 
@@ -1204,20 +1231,24 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
   if (preferredIndex !== -1) {
     const [entry] = state.freeSandboxes.splice(preferredIndex, 1);
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      sandboxDebugLog(`lease ${sessionID}: reused previous ${path.basename(entry.path)}`);
       return entry.path;
     }
     // Discarded entries stay marked pending: this instance's sweep already
     // ran, so without the marker a transient inspect failure would orphan
     // the directory until another process claims the sandbox root.
     markPendingSandboxCleanup(entry.path);
+    sandboxDebugLog(`lease ${sessionID}: discarded invalid ${path.basename(entry.path)}`);
   }
 
   while (state.freeSandboxes.length > 0) {
     const entry = state.freeSandboxes.pop();
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      sandboxDebugLog(`lease ${sessionID}: reused pooled ${path.basename(entry.path)}`);
       return entry.path;
     }
     markPendingSandboxCleanup(entry.path);
+    sandboxDebugLog(`lease ${sessionID}: discarded invalid ${path.basename(entry.path)}`);
   }
 
   // Plugin instances never create a sandbox path used by another instance, so
@@ -1228,8 +1259,13 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
   // share a live sandbox — fall back to a unique suffix instead.
   const fresh = path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
   const leasedPaths = new Set(state.ownedSandboxes.values());
-  if (!leasedPaths.has(fresh)) return fresh;
-  return path.join(sandboxRootIdentity.path, `${sessionID}-${randomUUID()}`);
+  if (!leasedPaths.has(fresh)) {
+    sandboxDebugLog(`lease ${sessionID}: fresh ${path.basename(fresh)}`);
+    return fresh;
+  }
+  const disambiguated = path.join(sandboxRootIdentity.path, `${sessionID}-${randomUUID()}`);
+  sandboxDebugLog(`lease ${sessionID}: fresh (collision) ${path.basename(disambiguated)}`);
+  return disambiguated;
 }
 
 function recordSessionParent(state, info) {
@@ -1273,6 +1309,7 @@ function releaseSandboxToPool(state, sessionID) {
   state.ownedSandboxIdentities.delete(sessionID);
   state.lastSessionSandbox.set(sessionID, sandboxPath);
   state.freeSandboxes.push({ path: sandboxPath, identity });
+  sandboxDebugLog(`release ${sessionID}: pooled ${path.basename(sandboxPath)}`);
 }
 
 async function removeOwnedSandbox(state, sessionID) {

--- a/PluginBase/common/opencode-plugin.js
+++ b/PluginBase/common/opencode-plugin.js
@@ -1273,14 +1273,23 @@ async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
 
 async function detachOwnedSandboxes(state) {
   state.disposed = true;
-  const sandboxes = [...state.ownedSandboxes.entries()].map(([sessionID, sandboxPath]) => ({
-    sandboxPath,
-    sandboxIdentity: state.ownedSandboxIdentities.get(sessionID),
-  }));
+  const sandboxes = [
+    ...[...state.ownedSandboxes.entries()].map(([sessionID, sandboxPath]) => ({
+      sandboxPath,
+      sandboxIdentity: state.ownedSandboxIdentities.get(sessionID),
+    })),
+    ...state.freeSandboxes.map((entry) => ({
+      sandboxPath: entry.path,
+      sandboxIdentity: entry.identity,
+    })),
+  ];
   const sandboxPaths = [...new Set(sandboxes.map(({ sandboxPath }) => sandboxPath))];
   for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
   state.ownedSandboxIdentities.clear();
+  state.freeSandboxes.length = 0;
+  state.sessionParents.clear();
+  state.lastSessionSandbox.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
   state.xcodeMcpApprovalHelpers.clear();

--- a/PluginBase/common/opencode-plugin.js
+++ b/PluginBase/common/opencode-plugin.js
@@ -83,6 +83,9 @@ export function createOpenCodePlugin(pluginRootUrl) {
       ownedSandboxes: new Map(),
       ownedSandboxIdentities: new Map(),
       deletedSandboxSessions: new Set(),
+      sessionParents: new Map(),
+      freeSandboxes: [],
+      lastSessionSandbox: new Map(),
       sandboxSweepDone: false,
       disposed: false,
     };
@@ -737,9 +740,7 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
   if (state.disposed || state.deletedSandboxSessions.has(sessionID)) return;
   const sandboxRoot = secureSandboxRoot(state);
-  // Plugin instances never reuse a sandbox path, so an older instance cannot
-  // delete a replacement instance's active sandbox after an ownership check.
-  const sandboxBase = path.join(sandboxRoot.path, `${sessionID}-${state.instanceID}`);
+  const sandboxBase = leaseSandboxPath(state, sandboxRoot, sessionID);
   state.ownedSandboxes.set(sessionID, sandboxBase);
 
   if (!state.processStartToken) {
@@ -1130,6 +1131,21 @@ function releaseSandboxOwnerLock(ownerLock) {
 }
 
 async function handlePluginEvent(state, event) {
+  if (event?.type === "session.created" || event?.type === "session.updated") {
+    recordSessionParent(state, event.properties?.info);
+    return;
+  }
+
+  if (event?.type === "session.idle") {
+    const rawSessionID = event.properties?.sessionID;
+    if (state.disposed || typeof rawSessionID !== "string" || !rawSessionID) return;
+    const safeID = safeSessionID(rawSessionID);
+    // Only subagent (child) sessions release on idle. A main session going
+    // idle is just the end of a turn; it keeps its sandbox for the next one.
+    if (state.sessionParents.get(safeID)) releaseSandboxToPool(state, safeID);
+    return;
+  }
+
   if (event?.type !== "session.deleted") return;
 
   const sessionID = event.properties?.info?.id;
@@ -1137,11 +1153,67 @@ async function handlePluginEvent(state, event) {
 
   const safeID = safeSessionID(sessionID);
   state.deletedSandboxSessions.add(safeID);
+  state.sessionParents.delete(safeID);
+  state.lastSessionSandbox.delete(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
   const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
   await stopXcodeMcpApproval(activeApproval);
   await removeOwnedSandbox(state, safeID);
+}
+
+// Leasing order: the sandbox this session already holds, then the sandbox it
+// held before releasing (warm caches for a re-prompted subagent), then the
+// most recently freed pool entry, then a fresh directory. Pool entries are
+// revalidated before reuse and dropped if they fail the identity checks.
+// Reused directories keep their original <sessionID>-<instanceID> name and
+// are never renamed — SPM and Xcode state files embed absolute paths.
+function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
+  const existing = state.ownedSandboxes.get(sessionID);
+  if (existing) return existing;
+
+  const preferred = state.lastSessionSandbox.get(sessionID);
+  const preferredIndex =
+    typeof preferred === "string"
+      ? state.freeSandboxes.findIndex((entry) => entry.path === preferred)
+      : -1;
+  if (preferredIndex !== -1) {
+    const [entry] = state.freeSandboxes.splice(preferredIndex, 1);
+    if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      return entry.path;
+    }
+  }
+
+  while (state.freeSandboxes.length > 0) {
+    const entry = state.freeSandboxes.pop();
+    if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      return entry.path;
+    }
+  }
+
+  // Plugin instances never create a sandbox path used by another instance, so
+  // an older instance cannot delete a replacement instance's active sandbox
+  // after an ownership check.
+  return path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
+}
+
+function recordSessionParent(state, info) {
+  const id = info?.id;
+  if (typeof id !== "string" || !id) return;
+  const parentID =
+    typeof info.parentID === "string" && info.parentID ? info.parentID : null;
+  state.sessionParents.set(safeSessionID(id), parentID);
+}
+
+function releaseSandboxToPool(state, sessionID) {
+  const sandboxPath = state.ownedSandboxes.get(sessionID);
+  const identity = state.ownedSandboxIdentities.get(sessionID);
+  if (!sandboxPath || !identity) return;
+
+  state.ownedSandboxes.delete(sessionID);
+  state.ownedSandboxIdentities.delete(sessionID);
+  state.lastSessionSandbox.set(sessionID, sandboxPath);
+  state.freeSandboxes.push({ path: sandboxPath, identity });
 }
 
 async function removeOwnedSandbox(state, sessionID) {

--- a/SwiftScaffolding/common/opencode-plugin.js
+++ b/SwiftScaffolding/common/opencode-plugin.js
@@ -1199,8 +1199,14 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
 
   // Plugin instances never create a sandbox path used by another instance, so
   // an older instance cannot delete a replacement instance's active sandbox
-  // after an ownership check.
-  return path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
+  // after an ownership check. Within this instance the deterministic name can
+  // collide: pooling decouples directory names from sessions, so a sandbox
+  // named after this session may now be leased by a different session. Never
+  // share a live sandbox — fall back to a unique suffix instead.
+  const fresh = path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
+  const leasedPaths = new Set(state.ownedSandboxes.values());
+  if (!leasedPaths.has(fresh)) return fresh;
+  return path.join(sandboxRootIdentity.path, `${sessionID}-${randomUUID()}`);
 }
 
 function recordSessionParent(state, info) {
@@ -1287,6 +1293,8 @@ async function detachOwnedSandboxes(state) {
   for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
   state.ownedSandboxIdentities.clear();
+  // Pooled entries were folded into `sandboxes` above; clear the pool and
+  // session-tracking state so a disposed instance can never lease or release.
   state.freeSandboxes.length = 0;
   state.sessionParents.clear();
   state.lastSessionSandbox.clear();

--- a/SwiftScaffolding/common/opencode-plugin.js
+++ b/SwiftScaffolding/common/opencode-plugin.js
@@ -1152,6 +1152,8 @@ async function handlePluginEvent(state, event) {
   if (typeof sessionID !== "string" || !sessionID) return;
 
   const safeID = safeSessionID(sessionID);
+  const parentID =
+    event.properties?.info?.parentID ?? state.sessionParents.get(safeID);
   state.deletedSandboxSessions.add(safeID);
   state.sessionParents.delete(safeID);
   state.lastSessionSandbox.delete(safeID);
@@ -1160,6 +1162,10 @@ async function handlePluginEvent(state, event) {
   const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
   await stopXcodeMcpApproval(activeApproval);
   await removeOwnedSandbox(state, safeID);
+  // A deleted main session drains the free pool: pooled sandboxes existed to
+  // serve its subagents, so reclaim the disk now rather than at dispose.
+  // Sandboxes still leased by live sessions are untouched.
+  if (!parentID) await drainFreeSandboxes(state);
 }
 
 // Leasing order: the sandbox this session already holds, then the sandbox it
@@ -1226,6 +1232,28 @@ async function removeOwnedSandbox(state, sessionID) {
   state.ownedSandboxIdentities.delete(sessionID);
   if (!state.sandboxRoot || !sandboxIdentity) return;
 
+  await quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity);
+}
+
+async function drainFreeSandboxes(state) {
+  const entries = state.freeSandboxes.splice(0, state.freeSandboxes.length);
+  if (entries.length === 0) return;
+
+  const drainedPaths = new Set(entries.map((entry) => entry.path));
+  for (const [sessionID, sandboxPath] of state.lastSessionSandbox) {
+    if (drainedPaths.has(sandboxPath)) state.lastSessionSandbox.delete(sessionID);
+  }
+  if (!state.sandboxRoot) return;
+
+  await Promise.all(
+    entries.map(async ({ path: sandboxPath, identity }) => {
+      markPendingSandboxCleanup(sandboxPath);
+      await quarantineAndRemoveSandbox(state, sandboxPath, identity);
+    }),
+  );
+}
+
+async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
   const quarantinedPath = await quarantineOwnedSandbox(
     sandboxPath,
     state.instanceID,

--- a/SwiftScaffolding/common/opencode-plugin.js
+++ b/SwiftScaffolding/common/opencode-plugin.js
@@ -86,6 +86,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       sessionParents: new Map(),
       freeSandboxes: [],
       lastSessionSandbox: new Map(),
+      activeBashCounts: new Map(),
       sandboxSweepDone: false,
       disposed: false,
     };
@@ -118,6 +119,11 @@ export function createOpenCodePlugin(pluginRootUrl) {
       "tool.execute.before": async (input, output) => {
         loadMetadata(pluginRoot, state);
         applyPreToolUseRules(state, input, output);
+        trackBashStart(state, input);
+      },
+
+      "tool.execute.after": async (input) => {
+        trackBashEnd(state, input);
       },
 
       "shell.env": async (input, output) => {
@@ -1132,6 +1138,7 @@ function releaseSandboxOwnerLock(ownerLock) {
 
 async function handlePluginEvent(state, event) {
   if (event?.type === "session.created" || event?.type === "session.updated") {
+    if (state.disposed) return;
     recordSessionParent(state, event.properties?.info);
     return;
   }
@@ -1140,6 +1147,11 @@ async function handlePluginEvent(state, event) {
     const rawSessionID = event.properties?.sessionID;
     if (state.disposed || typeof rawSessionID !== "string" || !rawSessionID) return;
     const safeID = safeSessionID(rawSessionID);
+    // A stale idle — delivered after the session was already re-prompted —
+    // must not pool a sandbox an in-flight bash command is still writing to.
+    // Skipping is safe: the re-prompted turn ends with its own idle, which
+    // performs the release once no command is running.
+    if ((state.activeBashCounts.get(safeID) ?? 0) > 0) return;
     // Only subagent (child) sessions release on idle. A main session going
     // idle is just the end of a turn; it keeps its sandbox for the next one.
     if (state.sessionParents.get(safeID)) releaseSandboxToPool(state, safeID);
@@ -1154,9 +1166,15 @@ async function handlePluginEvent(state, event) {
   const safeID = safeSessionID(sessionID);
   const parentID =
     event.properties?.info?.parentID ?? state.sessionParents.get(safeID);
+  // Only a session this instance actually observed as parentless counts as a
+  // main session. A deletion for a session we never tracked (created before
+  // the plugin loaded) proves nothing about the pool, so it must not drain
+  // warm caches that may belong to a still-live main.
+  const knownMain = !parentID && state.sessionParents.has(safeID);
   state.deletedSandboxSessions.add(safeID);
   state.sessionParents.delete(safeID);
   state.lastSessionSandbox.delete(safeID);
+  state.activeBashCounts.delete(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
   const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
@@ -1165,7 +1183,7 @@ async function handlePluginEvent(state, event) {
   // A deleted main session drains the free pool: pooled sandboxes existed to
   // serve its subagents, so reclaim the disk now rather than at dispose.
   // Sandboxes still leased by live sessions are untouched.
-  if (!parentID) await drainFreeSandboxes(state);
+  if (knownMain) await drainFreeSandboxes(state);
 }
 
 // Leasing order: the sandbox this session already holds, then the sandbox it
@@ -1188,6 +1206,10 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
       return entry.path;
     }
+    // Discarded entries stay marked pending: this instance's sweep already
+    // ran, so without the marker a transient inspect failure would orphan
+    // the directory until another process claims the sandbox root.
+    markPendingSandboxCleanup(entry.path);
   }
 
   while (state.freeSandboxes.length > 0) {
@@ -1195,6 +1217,7 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
       return entry.path;
     }
+    markPendingSandboxCleanup(entry.path);
   }
 
   // Plugin instances never create a sandbox path used by another instance, so
@@ -1212,9 +1235,33 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
 function recordSessionParent(state, info) {
   const id = info?.id;
   if (typeof id !== "string" || !id) return;
+  const safeID = safeSessionID(id);
   const parentID =
     typeof info.parentID === "string" && info.parentID ? info.parentID : null;
-  state.sessionParents.set(safeSessionID(id), parentID);
+  // A payload without parentID normally means "main session", but never let
+  // it downgrade a session we already classified: a partial update would
+  // otherwise stop a known child from releasing on idle and let its
+  // deletion drain the pool.
+  if (parentID === null && state.sessionParents.has(safeID)) return;
+  state.sessionParents.set(safeID, parentID);
+}
+
+// In-flight bash tracking exists solely to gate the idle-release against
+// stale events. Counts only ever prevent a release, so a missed
+// tool.execute.after degrades to "the sandbox stays leased" — the pre-pool
+// behavior, reclaimed on deletion/dispose — never to a premature release.
+function trackBashStart(state, input) {
+  if (String(input?.tool ?? "").toLowerCase() !== "bash") return;
+  const safeID = safeSessionID(input?.sessionID ?? "global");
+  state.activeBashCounts.set(safeID, (state.activeBashCounts.get(safeID) ?? 0) + 1);
+}
+
+function trackBashEnd(state, input) {
+  if (String(input?.tool ?? "").toLowerCase() !== "bash") return;
+  const safeID = safeSessionID(input?.sessionID ?? "global");
+  const count = state.activeBashCounts.get(safeID) ?? 0;
+  if (count <= 1) state.activeBashCounts.delete(safeID);
+  else state.activeBashCounts.set(safeID, count - 1);
 }
 
 function releaseSandboxToPool(state, sessionID) {
@@ -1251,15 +1298,25 @@ async function drainFreeSandboxes(state) {
   }
   if (!state.sandboxRoot) return;
 
+  // Removal is detached (/bin/rm) rather than awaited: draining several
+  // multi-GB trees in-process would stall serialized event delivery — the
+  // very lag that turns a delayed session.idle stale.
   await Promise.all(
     entries.map(async ({ path: sandboxPath, identity }) => {
       markPendingSandboxCleanup(sandboxPath);
-      await quarantineAndRemoveSandbox(state, sandboxPath, identity);
+      await quarantineAndRemoveSandbox(state, sandboxPath, identity, {
+        detach: true,
+      });
     }),
   );
 }
 
-async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
+async function quarantineAndRemoveSandbox(
+  state,
+  sandboxPath,
+  sandboxIdentity,
+  { detach = false } = {},
+) {
   const quarantinedPath = await quarantineOwnedSandbox(
     sandboxPath,
     state.instanceID,
@@ -1269,9 +1326,20 @@ async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
   const cleanupIdentity = quarantinedPath
     ? relocatedSandboxIdentity(sandboxIdentity, quarantinedPath)
     : sandboxIdentity;
+  const removalPath = quarantinedPath || sandboxPath;
+  const expectedInstanceID = quarantinedPath ? "" : state.instanceID;
+  if (detach) {
+    await detachManagedSandbox(
+      removalPath,
+      expectedInstanceID,
+      state.sandboxRoot,
+      cleanupIdentity,
+    );
+    return;
+  }
   await removeManagedSandbox(
-    quarantinedPath || sandboxPath,
-    quarantinedPath ? "" : state.instanceID,
+    removalPath,
+    expectedInstanceID,
     state.sandboxRoot,
     cleanupIdentity,
   );
@@ -1298,6 +1366,7 @@ async function detachOwnedSandboxes(state) {
   state.freeSandboxes.length = 0;
   state.sessionParents.clear();
   state.lastSessionSandbox.clear();
+  state.activeBashCounts.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
   state.xcodeMcpApprovalHelpers.clear();

--- a/SwiftScaffolding/common/opencode-plugin.js
+++ b/SwiftScaffolding/common/opencode-plugin.js
@@ -54,6 +54,7 @@ const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
 const XCODE_SANDBOX_MODE = 0o700;
 const XCODE_SANDBOX_OWNER_GRACE_MS = 60_000;
 const XCODE_SANDBOX_OWNER_LOCK = ".owner.lock";
+const XCODE_SANDBOX_CREATION_TOKEN = ".creation-token";
 const XCODE_SANDBOX_QUARANTINE_RE =
   /^\.quarantine-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const XCODE_SANDBOX_PENDING_CLEANUPS_KEY = Symbol.for(
@@ -764,6 +765,7 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   const packagesDir = path.join(sandboxBase, "packages");
 
   const sandboxIdentity = secureSandboxDirectory(sandboxBase, sandboxRoot);
+  sandboxIdentity.creationToken = ensureSandboxCreationToken(sandboxBase);
   state.ownedSandboxIdentities.set(sessionID, sandboxIdentity);
   if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
   secureSandboxDirectory(buildDir, sandboxIdentity);
@@ -829,6 +831,32 @@ function createDirectoryNonRecursively(directoryPath) {
     fs.mkdirSync(directoryPath, { mode: XCODE_SANDBOX_MODE });
   } catch (error) {
     if (error?.code !== "EEXIST") throw error;
+  }
+}
+
+// Written once, the first time a sandbox directory is created, and never
+// rewritten. dev+ino+uid alone can't distinguish "still the sandbox we
+// leased" from "something recreated this exact path" on filesystems that
+// recycle inode numbers quickly (tmpfs, the common $TMPDIR backing on Linux
+// CI runners) — a same-path replacement can't reproduce this token's
+// content by coincidence the way it can reproduce a recycled inode number.
+function ensureSandboxCreationToken(sandboxBase) {
+  const tokenPath = path.join(sandboxBase, XCODE_SANDBOX_CREATION_TOKEN);
+  try {
+    const token = randomUUID();
+    fs.writeFileSync(tokenPath, token, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    return token;
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+  return readSandboxCreationToken(sandboxBase);
+}
+
+function readSandboxCreationToken(sandboxBase) {
+  try {
+    return fs.readFileSync(path.join(sandboxBase, XCODE_SANDBOX_CREATION_TOKEN), "utf8");
+  } catch {
+    return null;
   }
 }
 
@@ -1895,6 +1923,19 @@ function secureExistingManagedSandbox(
     ) {
       return null;
     }
+    // dev+ino+uid alone can't tell "still the sandbox we handed out" from
+    // "something recreated this exact path": tmpfs (the common $TMPDIR
+    // backing on Linux CI runners) can hand a freshly created directory the
+    // same inode a just-removed directory held. The creation token is
+    // content written once when the directory was first made, so a
+    // same-path replacement can't produce a match by coincidence.
+    if (
+      expectedSandboxIdentity?.creationToken &&
+      readSandboxCreationToken(candidate) !== expectedSandboxIdentity.creationToken
+    ) {
+      return null;
+    }
+    current.creationToken = expectedSandboxIdentity?.creationToken;
     return current;
   } catch {
     return null;

--- a/SwiftScaffolding/common/opencode-plugin.js
+++ b/SwiftScaffolding/common/opencode-plugin.js
@@ -1136,6 +1136,19 @@ function releaseSandboxOwnerLock(ownerLock) {
   }
 }
 
+// Field-diagnosable pool decisions: when $TMPDIR/xbt-sandbox-debug exists,
+// every lease/release decision (and every refusal, with its reason) is
+// appended to $TMPDIR/xbt-sandbox-debug.log. Inert without the flag file.
+function sandboxDebugLog(message) {
+  try {
+    const flag = path.join(os.tmpdir(), "xbt-sandbox-debug");
+    if (!fs.existsSync(flag)) return;
+    fs.appendFileSync(`${flag}.log`, `${new Date().toISOString()} ${message}\n`);
+  } catch {
+    // Diagnostics must never interfere with sandbox management.
+  }
+}
+
 async function handlePluginEvent(state, event) {
   if (event?.type === "session.created" || event?.type === "session.updated") {
     if (state.disposed) return;
@@ -1151,10 +1164,21 @@ async function handlePluginEvent(state, event) {
     // must not pool a sandbox an in-flight bash command is still writing to.
     // Skipping is safe: the re-prompted turn ends with its own idle, which
     // performs the release once no command is running.
-    if ((state.activeBashCounts.get(safeID) ?? 0) > 0) return;
+    if ((state.activeBashCounts.get(safeID) ?? 0) > 0) {
+      sandboxDebugLog(
+        `idle ${safeID}: release refused, ${state.activeBashCounts.get(safeID)} bash in flight`,
+      );
+      return;
+    }
     // Only subagent (child) sessions release on idle. A main session going
     // idle is just the end of a turn; it keeps its sandbox for the next one.
-    if (state.sessionParents.get(safeID)) releaseSandboxToPool(state, safeID);
+    if (state.sessionParents.get(safeID)) {
+      releaseSandboxToPool(state, safeID);
+    } else {
+      sandboxDebugLog(
+        `idle ${safeID}: release refused, parent=${JSON.stringify(state.sessionParents.get(safeID) ?? null)} known=${state.sessionParents.has(safeID)}`,
+      );
+    }
     return;
   }
 
@@ -1183,6 +1207,9 @@ async function handlePluginEvent(state, event) {
   // A deleted main session drains the free pool: pooled sandboxes existed to
   // serve its subagents, so reclaim the disk now rather than at dispose.
   // Sandboxes still leased by live sessions are untouched.
+  sandboxDebugLog(
+    `deleted ${safeID}: knownMain=${knownMain} drain=${knownMain ? state.freeSandboxes.length : 0} pooled`,
+  );
   if (knownMain) await drainFreeSandboxes(state);
 }
 
@@ -1204,20 +1231,24 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
   if (preferredIndex !== -1) {
     const [entry] = state.freeSandboxes.splice(preferredIndex, 1);
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      sandboxDebugLog(`lease ${sessionID}: reused previous ${path.basename(entry.path)}`);
       return entry.path;
     }
     // Discarded entries stay marked pending: this instance's sweep already
     // ran, so without the marker a transient inspect failure would orphan
     // the directory until another process claims the sandbox root.
     markPendingSandboxCleanup(entry.path);
+    sandboxDebugLog(`lease ${sessionID}: discarded invalid ${path.basename(entry.path)}`);
   }
 
   while (state.freeSandboxes.length > 0) {
     const entry = state.freeSandboxes.pop();
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      sandboxDebugLog(`lease ${sessionID}: reused pooled ${path.basename(entry.path)}`);
       return entry.path;
     }
     markPendingSandboxCleanup(entry.path);
+    sandboxDebugLog(`lease ${sessionID}: discarded invalid ${path.basename(entry.path)}`);
   }
 
   // Plugin instances never create a sandbox path used by another instance, so
@@ -1228,8 +1259,13 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
   // share a live sandbox — fall back to a unique suffix instead.
   const fresh = path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
   const leasedPaths = new Set(state.ownedSandboxes.values());
-  if (!leasedPaths.has(fresh)) return fresh;
-  return path.join(sandboxRootIdentity.path, `${sessionID}-${randomUUID()}`);
+  if (!leasedPaths.has(fresh)) {
+    sandboxDebugLog(`lease ${sessionID}: fresh ${path.basename(fresh)}`);
+    return fresh;
+  }
+  const disambiguated = path.join(sandboxRootIdentity.path, `${sessionID}-${randomUUID()}`);
+  sandboxDebugLog(`lease ${sessionID}: fresh (collision) ${path.basename(disambiguated)}`);
+  return disambiguated;
 }
 
 function recordSessionParent(state, info) {
@@ -1273,6 +1309,7 @@ function releaseSandboxToPool(state, sessionID) {
   state.ownedSandboxIdentities.delete(sessionID);
   state.lastSessionSandbox.set(sessionID, sandboxPath);
   state.freeSandboxes.push({ path: sandboxPath, identity });
+  sandboxDebugLog(`release ${sessionID}: pooled ${path.basename(sandboxPath)}`);
 }
 
 async function removeOwnedSandbox(state, sessionID) {

--- a/SwiftScaffolding/common/opencode-plugin.js
+++ b/SwiftScaffolding/common/opencode-plugin.js
@@ -1273,14 +1273,23 @@ async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
 
 async function detachOwnedSandboxes(state) {
   state.disposed = true;
-  const sandboxes = [...state.ownedSandboxes.entries()].map(([sessionID, sandboxPath]) => ({
-    sandboxPath,
-    sandboxIdentity: state.ownedSandboxIdentities.get(sessionID),
-  }));
+  const sandboxes = [
+    ...[...state.ownedSandboxes.entries()].map(([sessionID, sandboxPath]) => ({
+      sandboxPath,
+      sandboxIdentity: state.ownedSandboxIdentities.get(sessionID),
+    })),
+    ...state.freeSandboxes.map((entry) => ({
+      sandboxPath: entry.path,
+      sandboxIdentity: entry.identity,
+    })),
+  ];
   const sandboxPaths = [...new Set(sandboxes.map(({ sandboxPath }) => sandboxPath))];
   for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
   state.ownedSandboxIdentities.clear();
+  state.freeSandboxes.length = 0;
+  state.sessionParents.clear();
+  state.lastSessionSandbox.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
   state.xcodeMcpApprovalHelpers.clear();

--- a/SwiftScaffolding/common/opencode-plugin.js
+++ b/SwiftScaffolding/common/opencode-plugin.js
@@ -83,6 +83,9 @@ export function createOpenCodePlugin(pluginRootUrl) {
       ownedSandboxes: new Map(),
       ownedSandboxIdentities: new Map(),
       deletedSandboxSessions: new Set(),
+      sessionParents: new Map(),
+      freeSandboxes: [],
+      lastSessionSandbox: new Map(),
       sandboxSweepDone: false,
       disposed: false,
     };
@@ -737,9 +740,7 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
   if (state.disposed || state.deletedSandboxSessions.has(sessionID)) return;
   const sandboxRoot = secureSandboxRoot(state);
-  // Plugin instances never reuse a sandbox path, so an older instance cannot
-  // delete a replacement instance's active sandbox after an ownership check.
-  const sandboxBase = path.join(sandboxRoot.path, `${sessionID}-${state.instanceID}`);
+  const sandboxBase = leaseSandboxPath(state, sandboxRoot, sessionID);
   state.ownedSandboxes.set(sessionID, sandboxBase);
 
   if (!state.processStartToken) {
@@ -1130,6 +1131,21 @@ function releaseSandboxOwnerLock(ownerLock) {
 }
 
 async function handlePluginEvent(state, event) {
+  if (event?.type === "session.created" || event?.type === "session.updated") {
+    recordSessionParent(state, event.properties?.info);
+    return;
+  }
+
+  if (event?.type === "session.idle") {
+    const rawSessionID = event.properties?.sessionID;
+    if (state.disposed || typeof rawSessionID !== "string" || !rawSessionID) return;
+    const safeID = safeSessionID(rawSessionID);
+    // Only subagent (child) sessions release on idle. A main session going
+    // idle is just the end of a turn; it keeps its sandbox for the next one.
+    if (state.sessionParents.get(safeID)) releaseSandboxToPool(state, safeID);
+    return;
+  }
+
   if (event?.type !== "session.deleted") return;
 
   const sessionID = event.properties?.info?.id;
@@ -1137,11 +1153,67 @@ async function handlePluginEvent(state, event) {
 
   const safeID = safeSessionID(sessionID);
   state.deletedSandboxSessions.add(safeID);
+  state.sessionParents.delete(safeID);
+  state.lastSessionSandbox.delete(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
   const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
   await stopXcodeMcpApproval(activeApproval);
   await removeOwnedSandbox(state, safeID);
+}
+
+// Leasing order: the sandbox this session already holds, then the sandbox it
+// held before releasing (warm caches for a re-prompted subagent), then the
+// most recently freed pool entry, then a fresh directory. Pool entries are
+// revalidated before reuse and dropped if they fail the identity checks.
+// Reused directories keep their original <sessionID>-<instanceID> name and
+// are never renamed — SPM and Xcode state files embed absolute paths.
+function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
+  const existing = state.ownedSandboxes.get(sessionID);
+  if (existing) return existing;
+
+  const preferred = state.lastSessionSandbox.get(sessionID);
+  const preferredIndex =
+    typeof preferred === "string"
+      ? state.freeSandboxes.findIndex((entry) => entry.path === preferred)
+      : -1;
+  if (preferredIndex !== -1) {
+    const [entry] = state.freeSandboxes.splice(preferredIndex, 1);
+    if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      return entry.path;
+    }
+  }
+
+  while (state.freeSandboxes.length > 0) {
+    const entry = state.freeSandboxes.pop();
+    if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      return entry.path;
+    }
+  }
+
+  // Plugin instances never create a sandbox path used by another instance, so
+  // an older instance cannot delete a replacement instance's active sandbox
+  // after an ownership check.
+  return path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
+}
+
+function recordSessionParent(state, info) {
+  const id = info?.id;
+  if (typeof id !== "string" || !id) return;
+  const parentID =
+    typeof info.parentID === "string" && info.parentID ? info.parentID : null;
+  state.sessionParents.set(safeSessionID(id), parentID);
+}
+
+function releaseSandboxToPool(state, sessionID) {
+  const sandboxPath = state.ownedSandboxes.get(sessionID);
+  const identity = state.ownedSandboxIdentities.get(sessionID);
+  if (!sandboxPath || !identity) return;
+
+  state.ownedSandboxes.delete(sessionID);
+  state.ownedSandboxIdentities.delete(sessionID);
+  state.lastSessionSandbox.set(sessionID, sandboxPath);
+  state.freeSandboxes.push({ path: sandboxPath, identity });
 }
 
 async function removeOwnedSandbox(state, sessionID) {

--- a/XcodeBuildTools/common/opencode-plugin.js
+++ b/XcodeBuildTools/common/opencode-plugin.js
@@ -1199,8 +1199,14 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
 
   // Plugin instances never create a sandbox path used by another instance, so
   // an older instance cannot delete a replacement instance's active sandbox
-  // after an ownership check.
-  return path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
+  // after an ownership check. Within this instance the deterministic name can
+  // collide: pooling decouples directory names from sessions, so a sandbox
+  // named after this session may now be leased by a different session. Never
+  // share a live sandbox — fall back to a unique suffix instead.
+  const fresh = path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
+  const leasedPaths = new Set(state.ownedSandboxes.values());
+  if (!leasedPaths.has(fresh)) return fresh;
+  return path.join(sandboxRootIdentity.path, `${sessionID}-${randomUUID()}`);
 }
 
 function recordSessionParent(state, info) {
@@ -1287,6 +1293,8 @@ async function detachOwnedSandboxes(state) {
   for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
   state.ownedSandboxIdentities.clear();
+  // Pooled entries were folded into `sandboxes` above; clear the pool and
+  // session-tracking state so a disposed instance can never lease or release.
   state.freeSandboxes.length = 0;
   state.sessionParents.clear();
   state.lastSessionSandbox.clear();

--- a/XcodeBuildTools/common/opencode-plugin.js
+++ b/XcodeBuildTools/common/opencode-plugin.js
@@ -1152,6 +1152,8 @@ async function handlePluginEvent(state, event) {
   if (typeof sessionID !== "string" || !sessionID) return;
 
   const safeID = safeSessionID(sessionID);
+  const parentID =
+    event.properties?.info?.parentID ?? state.sessionParents.get(safeID);
   state.deletedSandboxSessions.add(safeID);
   state.sessionParents.delete(safeID);
   state.lastSessionSandbox.delete(safeID);
@@ -1160,6 +1162,10 @@ async function handlePluginEvent(state, event) {
   const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
   await stopXcodeMcpApproval(activeApproval);
   await removeOwnedSandbox(state, safeID);
+  // A deleted main session drains the free pool: pooled sandboxes existed to
+  // serve its subagents, so reclaim the disk now rather than at dispose.
+  // Sandboxes still leased by live sessions are untouched.
+  if (!parentID) await drainFreeSandboxes(state);
 }
 
 // Leasing order: the sandbox this session already holds, then the sandbox it
@@ -1226,6 +1232,28 @@ async function removeOwnedSandbox(state, sessionID) {
   state.ownedSandboxIdentities.delete(sessionID);
   if (!state.sandboxRoot || !sandboxIdentity) return;
 
+  await quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity);
+}
+
+async function drainFreeSandboxes(state) {
+  const entries = state.freeSandboxes.splice(0, state.freeSandboxes.length);
+  if (entries.length === 0) return;
+
+  const drainedPaths = new Set(entries.map((entry) => entry.path));
+  for (const [sessionID, sandboxPath] of state.lastSessionSandbox) {
+    if (drainedPaths.has(sandboxPath)) state.lastSessionSandbox.delete(sessionID);
+  }
+  if (!state.sandboxRoot) return;
+
+  await Promise.all(
+    entries.map(async ({ path: sandboxPath, identity }) => {
+      markPendingSandboxCleanup(sandboxPath);
+      await quarantineAndRemoveSandbox(state, sandboxPath, identity);
+    }),
+  );
+}
+
+async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
   const quarantinedPath = await quarantineOwnedSandbox(
     sandboxPath,
     state.instanceID,

--- a/XcodeBuildTools/common/opencode-plugin.js
+++ b/XcodeBuildTools/common/opencode-plugin.js
@@ -86,6 +86,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       sessionParents: new Map(),
       freeSandboxes: [],
       lastSessionSandbox: new Map(),
+      activeBashCounts: new Map(),
       sandboxSweepDone: false,
       disposed: false,
     };
@@ -118,6 +119,11 @@ export function createOpenCodePlugin(pluginRootUrl) {
       "tool.execute.before": async (input, output) => {
         loadMetadata(pluginRoot, state);
         applyPreToolUseRules(state, input, output);
+        trackBashStart(state, input);
+      },
+
+      "tool.execute.after": async (input) => {
+        trackBashEnd(state, input);
       },
 
       "shell.env": async (input, output) => {
@@ -1132,6 +1138,7 @@ function releaseSandboxOwnerLock(ownerLock) {
 
 async function handlePluginEvent(state, event) {
   if (event?.type === "session.created" || event?.type === "session.updated") {
+    if (state.disposed) return;
     recordSessionParent(state, event.properties?.info);
     return;
   }
@@ -1140,6 +1147,11 @@ async function handlePluginEvent(state, event) {
     const rawSessionID = event.properties?.sessionID;
     if (state.disposed || typeof rawSessionID !== "string" || !rawSessionID) return;
     const safeID = safeSessionID(rawSessionID);
+    // A stale idle — delivered after the session was already re-prompted —
+    // must not pool a sandbox an in-flight bash command is still writing to.
+    // Skipping is safe: the re-prompted turn ends with its own idle, which
+    // performs the release once no command is running.
+    if ((state.activeBashCounts.get(safeID) ?? 0) > 0) return;
     // Only subagent (child) sessions release on idle. A main session going
     // idle is just the end of a turn; it keeps its sandbox for the next one.
     if (state.sessionParents.get(safeID)) releaseSandboxToPool(state, safeID);
@@ -1154,9 +1166,15 @@ async function handlePluginEvent(state, event) {
   const safeID = safeSessionID(sessionID);
   const parentID =
     event.properties?.info?.parentID ?? state.sessionParents.get(safeID);
+  // Only a session this instance actually observed as parentless counts as a
+  // main session. A deletion for a session we never tracked (created before
+  // the plugin loaded) proves nothing about the pool, so it must not drain
+  // warm caches that may belong to a still-live main.
+  const knownMain = !parentID && state.sessionParents.has(safeID);
   state.deletedSandboxSessions.add(safeID);
   state.sessionParents.delete(safeID);
   state.lastSessionSandbox.delete(safeID);
+  state.activeBashCounts.delete(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
   const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
@@ -1165,7 +1183,7 @@ async function handlePluginEvent(state, event) {
   // A deleted main session drains the free pool: pooled sandboxes existed to
   // serve its subagents, so reclaim the disk now rather than at dispose.
   // Sandboxes still leased by live sessions are untouched.
-  if (!parentID) await drainFreeSandboxes(state);
+  if (knownMain) await drainFreeSandboxes(state);
 }
 
 // Leasing order: the sandbox this session already holds, then the sandbox it
@@ -1188,6 +1206,10 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
       return entry.path;
     }
+    // Discarded entries stay marked pending: this instance's sweep already
+    // ran, so without the marker a transient inspect failure would orphan
+    // the directory until another process claims the sandbox root.
+    markPendingSandboxCleanup(entry.path);
   }
 
   while (state.freeSandboxes.length > 0) {
@@ -1195,6 +1217,7 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
       return entry.path;
     }
+    markPendingSandboxCleanup(entry.path);
   }
 
   // Plugin instances never create a sandbox path used by another instance, so
@@ -1212,9 +1235,33 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
 function recordSessionParent(state, info) {
   const id = info?.id;
   if (typeof id !== "string" || !id) return;
+  const safeID = safeSessionID(id);
   const parentID =
     typeof info.parentID === "string" && info.parentID ? info.parentID : null;
-  state.sessionParents.set(safeSessionID(id), parentID);
+  // A payload without parentID normally means "main session", but never let
+  // it downgrade a session we already classified: a partial update would
+  // otherwise stop a known child from releasing on idle and let its
+  // deletion drain the pool.
+  if (parentID === null && state.sessionParents.has(safeID)) return;
+  state.sessionParents.set(safeID, parentID);
+}
+
+// In-flight bash tracking exists solely to gate the idle-release against
+// stale events. Counts only ever prevent a release, so a missed
+// tool.execute.after degrades to "the sandbox stays leased" — the pre-pool
+// behavior, reclaimed on deletion/dispose — never to a premature release.
+function trackBashStart(state, input) {
+  if (String(input?.tool ?? "").toLowerCase() !== "bash") return;
+  const safeID = safeSessionID(input?.sessionID ?? "global");
+  state.activeBashCounts.set(safeID, (state.activeBashCounts.get(safeID) ?? 0) + 1);
+}
+
+function trackBashEnd(state, input) {
+  if (String(input?.tool ?? "").toLowerCase() !== "bash") return;
+  const safeID = safeSessionID(input?.sessionID ?? "global");
+  const count = state.activeBashCounts.get(safeID) ?? 0;
+  if (count <= 1) state.activeBashCounts.delete(safeID);
+  else state.activeBashCounts.set(safeID, count - 1);
 }
 
 function releaseSandboxToPool(state, sessionID) {
@@ -1251,15 +1298,25 @@ async function drainFreeSandboxes(state) {
   }
   if (!state.sandboxRoot) return;
 
+  // Removal is detached (/bin/rm) rather than awaited: draining several
+  // multi-GB trees in-process would stall serialized event delivery — the
+  // very lag that turns a delayed session.idle stale.
   await Promise.all(
     entries.map(async ({ path: sandboxPath, identity }) => {
       markPendingSandboxCleanup(sandboxPath);
-      await quarantineAndRemoveSandbox(state, sandboxPath, identity);
+      await quarantineAndRemoveSandbox(state, sandboxPath, identity, {
+        detach: true,
+      });
     }),
   );
 }
 
-async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
+async function quarantineAndRemoveSandbox(
+  state,
+  sandboxPath,
+  sandboxIdentity,
+  { detach = false } = {},
+) {
   const quarantinedPath = await quarantineOwnedSandbox(
     sandboxPath,
     state.instanceID,
@@ -1269,9 +1326,20 @@ async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
   const cleanupIdentity = quarantinedPath
     ? relocatedSandboxIdentity(sandboxIdentity, quarantinedPath)
     : sandboxIdentity;
+  const removalPath = quarantinedPath || sandboxPath;
+  const expectedInstanceID = quarantinedPath ? "" : state.instanceID;
+  if (detach) {
+    await detachManagedSandbox(
+      removalPath,
+      expectedInstanceID,
+      state.sandboxRoot,
+      cleanupIdentity,
+    );
+    return;
+  }
   await removeManagedSandbox(
-    quarantinedPath || sandboxPath,
-    quarantinedPath ? "" : state.instanceID,
+    removalPath,
+    expectedInstanceID,
     state.sandboxRoot,
     cleanupIdentity,
   );
@@ -1298,6 +1366,7 @@ async function detachOwnedSandboxes(state) {
   state.freeSandboxes.length = 0;
   state.sessionParents.clear();
   state.lastSessionSandbox.clear();
+  state.activeBashCounts.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
   state.xcodeMcpApprovalHelpers.clear();

--- a/XcodeBuildTools/common/opencode-plugin.js
+++ b/XcodeBuildTools/common/opencode-plugin.js
@@ -54,6 +54,7 @@ const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
 const XCODE_SANDBOX_MODE = 0o700;
 const XCODE_SANDBOX_OWNER_GRACE_MS = 60_000;
 const XCODE_SANDBOX_OWNER_LOCK = ".owner.lock";
+const XCODE_SANDBOX_CREATION_TOKEN = ".creation-token";
 const XCODE_SANDBOX_QUARANTINE_RE =
   /^\.quarantine-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const XCODE_SANDBOX_PENDING_CLEANUPS_KEY = Symbol.for(
@@ -764,6 +765,7 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   const packagesDir = path.join(sandboxBase, "packages");
 
   const sandboxIdentity = secureSandboxDirectory(sandboxBase, sandboxRoot);
+  sandboxIdentity.creationToken = ensureSandboxCreationToken(sandboxBase);
   state.ownedSandboxIdentities.set(sessionID, sandboxIdentity);
   if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
   secureSandboxDirectory(buildDir, sandboxIdentity);
@@ -829,6 +831,32 @@ function createDirectoryNonRecursively(directoryPath) {
     fs.mkdirSync(directoryPath, { mode: XCODE_SANDBOX_MODE });
   } catch (error) {
     if (error?.code !== "EEXIST") throw error;
+  }
+}
+
+// Written once, the first time a sandbox directory is created, and never
+// rewritten. dev+ino+uid alone can't distinguish "still the sandbox we
+// leased" from "something recreated this exact path" on filesystems that
+// recycle inode numbers quickly (tmpfs, the common $TMPDIR backing on Linux
+// CI runners) — a same-path replacement can't reproduce this token's
+// content by coincidence the way it can reproduce a recycled inode number.
+function ensureSandboxCreationToken(sandboxBase) {
+  const tokenPath = path.join(sandboxBase, XCODE_SANDBOX_CREATION_TOKEN);
+  try {
+    const token = randomUUID();
+    fs.writeFileSync(tokenPath, token, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    return token;
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+  return readSandboxCreationToken(sandboxBase);
+}
+
+function readSandboxCreationToken(sandboxBase) {
+  try {
+    return fs.readFileSync(path.join(sandboxBase, XCODE_SANDBOX_CREATION_TOKEN), "utf8");
+  } catch {
+    return null;
   }
 }
 
@@ -1895,6 +1923,19 @@ function secureExistingManagedSandbox(
     ) {
       return null;
     }
+    // dev+ino+uid alone can't tell "still the sandbox we handed out" from
+    // "something recreated this exact path": tmpfs (the common $TMPDIR
+    // backing on Linux CI runners) can hand a freshly created directory the
+    // same inode a just-removed directory held. The creation token is
+    // content written once when the directory was first made, so a
+    // same-path replacement can't produce a match by coincidence.
+    if (
+      expectedSandboxIdentity?.creationToken &&
+      readSandboxCreationToken(candidate) !== expectedSandboxIdentity.creationToken
+    ) {
+      return null;
+    }
+    current.creationToken = expectedSandboxIdentity?.creationToken;
     return current;
   } catch {
     return null;

--- a/XcodeBuildTools/common/opencode-plugin.js
+++ b/XcodeBuildTools/common/opencode-plugin.js
@@ -1136,6 +1136,19 @@ function releaseSandboxOwnerLock(ownerLock) {
   }
 }
 
+// Field-diagnosable pool decisions: when $TMPDIR/xbt-sandbox-debug exists,
+// every lease/release decision (and every refusal, with its reason) is
+// appended to $TMPDIR/xbt-sandbox-debug.log. Inert without the flag file.
+function sandboxDebugLog(message) {
+  try {
+    const flag = path.join(os.tmpdir(), "xbt-sandbox-debug");
+    if (!fs.existsSync(flag)) return;
+    fs.appendFileSync(`${flag}.log`, `${new Date().toISOString()} ${message}\n`);
+  } catch {
+    // Diagnostics must never interfere with sandbox management.
+  }
+}
+
 async function handlePluginEvent(state, event) {
   if (event?.type === "session.created" || event?.type === "session.updated") {
     if (state.disposed) return;
@@ -1151,10 +1164,21 @@ async function handlePluginEvent(state, event) {
     // must not pool a sandbox an in-flight bash command is still writing to.
     // Skipping is safe: the re-prompted turn ends with its own idle, which
     // performs the release once no command is running.
-    if ((state.activeBashCounts.get(safeID) ?? 0) > 0) return;
+    if ((state.activeBashCounts.get(safeID) ?? 0) > 0) {
+      sandboxDebugLog(
+        `idle ${safeID}: release refused, ${state.activeBashCounts.get(safeID)} bash in flight`,
+      );
+      return;
+    }
     // Only subagent (child) sessions release on idle. A main session going
     // idle is just the end of a turn; it keeps its sandbox for the next one.
-    if (state.sessionParents.get(safeID)) releaseSandboxToPool(state, safeID);
+    if (state.sessionParents.get(safeID)) {
+      releaseSandboxToPool(state, safeID);
+    } else {
+      sandboxDebugLog(
+        `idle ${safeID}: release refused, parent=${JSON.stringify(state.sessionParents.get(safeID) ?? null)} known=${state.sessionParents.has(safeID)}`,
+      );
+    }
     return;
   }
 
@@ -1183,6 +1207,9 @@ async function handlePluginEvent(state, event) {
   // A deleted main session drains the free pool: pooled sandboxes existed to
   // serve its subagents, so reclaim the disk now rather than at dispose.
   // Sandboxes still leased by live sessions are untouched.
+  sandboxDebugLog(
+    `deleted ${safeID}: knownMain=${knownMain} drain=${knownMain ? state.freeSandboxes.length : 0} pooled`,
+  );
   if (knownMain) await drainFreeSandboxes(state);
 }
 
@@ -1204,20 +1231,24 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
   if (preferredIndex !== -1) {
     const [entry] = state.freeSandboxes.splice(preferredIndex, 1);
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      sandboxDebugLog(`lease ${sessionID}: reused previous ${path.basename(entry.path)}`);
       return entry.path;
     }
     // Discarded entries stay marked pending: this instance's sweep already
     // ran, so without the marker a transient inspect failure would orphan
     // the directory until another process claims the sandbox root.
     markPendingSandboxCleanup(entry.path);
+    sandboxDebugLog(`lease ${sessionID}: discarded invalid ${path.basename(entry.path)}`);
   }
 
   while (state.freeSandboxes.length > 0) {
     const entry = state.freeSandboxes.pop();
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      sandboxDebugLog(`lease ${sessionID}: reused pooled ${path.basename(entry.path)}`);
       return entry.path;
     }
     markPendingSandboxCleanup(entry.path);
+    sandboxDebugLog(`lease ${sessionID}: discarded invalid ${path.basename(entry.path)}`);
   }
 
   // Plugin instances never create a sandbox path used by another instance, so
@@ -1228,8 +1259,13 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
   // share a live sandbox — fall back to a unique suffix instead.
   const fresh = path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
   const leasedPaths = new Set(state.ownedSandboxes.values());
-  if (!leasedPaths.has(fresh)) return fresh;
-  return path.join(sandboxRootIdentity.path, `${sessionID}-${randomUUID()}`);
+  if (!leasedPaths.has(fresh)) {
+    sandboxDebugLog(`lease ${sessionID}: fresh ${path.basename(fresh)}`);
+    return fresh;
+  }
+  const disambiguated = path.join(sandboxRootIdentity.path, `${sessionID}-${randomUUID()}`);
+  sandboxDebugLog(`lease ${sessionID}: fresh (collision) ${path.basename(disambiguated)}`);
+  return disambiguated;
 }
 
 function recordSessionParent(state, info) {
@@ -1273,6 +1309,7 @@ function releaseSandboxToPool(state, sessionID) {
   state.ownedSandboxIdentities.delete(sessionID);
   state.lastSessionSandbox.set(sessionID, sandboxPath);
   state.freeSandboxes.push({ path: sandboxPath, identity });
+  sandboxDebugLog(`release ${sessionID}: pooled ${path.basename(sandboxPath)}`);
 }
 
 async function removeOwnedSandbox(state, sessionID) {

--- a/XcodeBuildTools/common/opencode-plugin.js
+++ b/XcodeBuildTools/common/opencode-plugin.js
@@ -1273,14 +1273,23 @@ async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
 
 async function detachOwnedSandboxes(state) {
   state.disposed = true;
-  const sandboxes = [...state.ownedSandboxes.entries()].map(([sessionID, sandboxPath]) => ({
-    sandboxPath,
-    sandboxIdentity: state.ownedSandboxIdentities.get(sessionID),
-  }));
+  const sandboxes = [
+    ...[...state.ownedSandboxes.entries()].map(([sessionID, sandboxPath]) => ({
+      sandboxPath,
+      sandboxIdentity: state.ownedSandboxIdentities.get(sessionID),
+    })),
+    ...state.freeSandboxes.map((entry) => ({
+      sandboxPath: entry.path,
+      sandboxIdentity: entry.identity,
+    })),
+  ];
   const sandboxPaths = [...new Set(sandboxes.map(({ sandboxPath }) => sandboxPath))];
   for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
   state.ownedSandboxIdentities.clear();
+  state.freeSandboxes.length = 0;
+  state.sessionParents.clear();
+  state.lastSessionSandbox.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
   state.xcodeMcpApprovalHelpers.clear();

--- a/XcodeBuildTools/common/opencode-plugin.js
+++ b/XcodeBuildTools/common/opencode-plugin.js
@@ -83,6 +83,9 @@ export function createOpenCodePlugin(pluginRootUrl) {
       ownedSandboxes: new Map(),
       ownedSandboxIdentities: new Map(),
       deletedSandboxSessions: new Set(),
+      sessionParents: new Map(),
+      freeSandboxes: [],
+      lastSessionSandbox: new Map(),
       sandboxSweepDone: false,
       disposed: false,
     };
@@ -737,9 +740,7 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
   if (state.disposed || state.deletedSandboxSessions.has(sessionID)) return;
   const sandboxRoot = secureSandboxRoot(state);
-  // Plugin instances never reuse a sandbox path, so an older instance cannot
-  // delete a replacement instance's active sandbox after an ownership check.
-  const sandboxBase = path.join(sandboxRoot.path, `${sessionID}-${state.instanceID}`);
+  const sandboxBase = leaseSandboxPath(state, sandboxRoot, sessionID);
   state.ownedSandboxes.set(sessionID, sandboxBase);
 
   if (!state.processStartToken) {
@@ -1130,6 +1131,21 @@ function releaseSandboxOwnerLock(ownerLock) {
 }
 
 async function handlePluginEvent(state, event) {
+  if (event?.type === "session.created" || event?.type === "session.updated") {
+    recordSessionParent(state, event.properties?.info);
+    return;
+  }
+
+  if (event?.type === "session.idle") {
+    const rawSessionID = event.properties?.sessionID;
+    if (state.disposed || typeof rawSessionID !== "string" || !rawSessionID) return;
+    const safeID = safeSessionID(rawSessionID);
+    // Only subagent (child) sessions release on idle. A main session going
+    // idle is just the end of a turn; it keeps its sandbox for the next one.
+    if (state.sessionParents.get(safeID)) releaseSandboxToPool(state, safeID);
+    return;
+  }
+
   if (event?.type !== "session.deleted") return;
 
   const sessionID = event.properties?.info?.id;
@@ -1137,11 +1153,67 @@ async function handlePluginEvent(state, event) {
 
   const safeID = safeSessionID(sessionID);
   state.deletedSandboxSessions.add(safeID);
+  state.sessionParents.delete(safeID);
+  state.lastSessionSandbox.delete(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
   const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
   await stopXcodeMcpApproval(activeApproval);
   await removeOwnedSandbox(state, safeID);
+}
+
+// Leasing order: the sandbox this session already holds, then the sandbox it
+// held before releasing (warm caches for a re-prompted subagent), then the
+// most recently freed pool entry, then a fresh directory. Pool entries are
+// revalidated before reuse and dropped if they fail the identity checks.
+// Reused directories keep their original <sessionID>-<instanceID> name and
+// are never renamed — SPM and Xcode state files embed absolute paths.
+function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
+  const existing = state.ownedSandboxes.get(sessionID);
+  if (existing) return existing;
+
+  const preferred = state.lastSessionSandbox.get(sessionID);
+  const preferredIndex =
+    typeof preferred === "string"
+      ? state.freeSandboxes.findIndex((entry) => entry.path === preferred)
+      : -1;
+  if (preferredIndex !== -1) {
+    const [entry] = state.freeSandboxes.splice(preferredIndex, 1);
+    if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      return entry.path;
+    }
+  }
+
+  while (state.freeSandboxes.length > 0) {
+    const entry = state.freeSandboxes.pop();
+    if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      return entry.path;
+    }
+  }
+
+  // Plugin instances never create a sandbox path used by another instance, so
+  // an older instance cannot delete a replacement instance's active sandbox
+  // after an ownership check.
+  return path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
+}
+
+function recordSessionParent(state, info) {
+  const id = info?.id;
+  if (typeof id !== "string" || !id) return;
+  const parentID =
+    typeof info.parentID === "string" && info.parentID ? info.parentID : null;
+  state.sessionParents.set(safeSessionID(id), parentID);
+}
+
+function releaseSandboxToPool(state, sessionID) {
+  const sandboxPath = state.ownedSandboxes.get(sessionID);
+  const identity = state.ownedSandboxIdentities.get(sessionID);
+  if (!sandboxPath || !identity) return;
+
+  state.ownedSandboxes.delete(sessionID);
+  state.ownedSandboxIdentities.delete(sessionID);
+  state.lastSessionSandbox.set(sessionID, sandboxPath);
+  state.freeSandboxes.push({ path: sandboxPath, identity });
 }
 
 async function removeOwnedSandbox(state, sessionID) {

--- a/common/opencode-plugin.js
+++ b/common/opencode-plugin.js
@@ -1135,6 +1135,19 @@ function releaseSandboxOwnerLock(ownerLock) {
   }
 }
 
+// Field-diagnosable pool decisions: when $TMPDIR/xbt-sandbox-debug exists,
+// every lease/release decision (and every refusal, with its reason) is
+// appended to $TMPDIR/xbt-sandbox-debug.log. Inert without the flag file.
+function sandboxDebugLog(message) {
+  try {
+    const flag = path.join(os.tmpdir(), "xbt-sandbox-debug");
+    if (!fs.existsSync(flag)) return;
+    fs.appendFileSync(`${flag}.log`, `${new Date().toISOString()} ${message}\n`);
+  } catch {
+    // Diagnostics must never interfere with sandbox management.
+  }
+}
+
 async function handlePluginEvent(state, event) {
   if (event?.type === "session.created" || event?.type === "session.updated") {
     if (state.disposed) return;
@@ -1150,10 +1163,21 @@ async function handlePluginEvent(state, event) {
     // must not pool a sandbox an in-flight bash command is still writing to.
     // Skipping is safe: the re-prompted turn ends with its own idle, which
     // performs the release once no command is running.
-    if ((state.activeBashCounts.get(safeID) ?? 0) > 0) return;
+    if ((state.activeBashCounts.get(safeID) ?? 0) > 0) {
+      sandboxDebugLog(
+        `idle ${safeID}: release refused, ${state.activeBashCounts.get(safeID)} bash in flight`,
+      );
+      return;
+    }
     // Only subagent (child) sessions release on idle. A main session going
     // idle is just the end of a turn; it keeps its sandbox for the next one.
-    if (state.sessionParents.get(safeID)) releaseSandboxToPool(state, safeID);
+    if (state.sessionParents.get(safeID)) {
+      releaseSandboxToPool(state, safeID);
+    } else {
+      sandboxDebugLog(
+        `idle ${safeID}: release refused, parent=${JSON.stringify(state.sessionParents.get(safeID) ?? null)} known=${state.sessionParents.has(safeID)}`,
+      );
+    }
     return;
   }
 
@@ -1182,6 +1206,9 @@ async function handlePluginEvent(state, event) {
   // A deleted main session drains the free pool: pooled sandboxes existed to
   // serve its subagents, so reclaim the disk now rather than at dispose.
   // Sandboxes still leased by live sessions are untouched.
+  sandboxDebugLog(
+    `deleted ${safeID}: knownMain=${knownMain} drain=${knownMain ? state.freeSandboxes.length : 0} pooled`,
+  );
   if (knownMain) await drainFreeSandboxes(state);
 }
 
@@ -1203,20 +1230,24 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
   if (preferredIndex !== -1) {
     const [entry] = state.freeSandboxes.splice(preferredIndex, 1);
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      sandboxDebugLog(`lease ${sessionID}: reused previous ${path.basename(entry.path)}`);
       return entry.path;
     }
     // Discarded entries stay marked pending: this instance's sweep already
     // ran, so without the marker a transient inspect failure would orphan
     // the directory until another process claims the sandbox root.
     markPendingSandboxCleanup(entry.path);
+    sandboxDebugLog(`lease ${sessionID}: discarded invalid ${path.basename(entry.path)}`);
   }
 
   while (state.freeSandboxes.length > 0) {
     const entry = state.freeSandboxes.pop();
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      sandboxDebugLog(`lease ${sessionID}: reused pooled ${path.basename(entry.path)}`);
       return entry.path;
     }
     markPendingSandboxCleanup(entry.path);
+    sandboxDebugLog(`lease ${sessionID}: discarded invalid ${path.basename(entry.path)}`);
   }
 
   // Plugin instances never create a sandbox path used by another instance, so
@@ -1227,8 +1258,13 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
   // share a live sandbox — fall back to a unique suffix instead.
   const fresh = path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
   const leasedPaths = new Set(state.ownedSandboxes.values());
-  if (!leasedPaths.has(fresh)) return fresh;
-  return path.join(sandboxRootIdentity.path, `${sessionID}-${randomUUID()}`);
+  if (!leasedPaths.has(fresh)) {
+    sandboxDebugLog(`lease ${sessionID}: fresh ${path.basename(fresh)}`);
+    return fresh;
+  }
+  const disambiguated = path.join(sandboxRootIdentity.path, `${sessionID}-${randomUUID()}`);
+  sandboxDebugLog(`lease ${sessionID}: fresh (collision) ${path.basename(disambiguated)}`);
+  return disambiguated;
 }
 
 function recordSessionParent(state, info) {
@@ -1272,6 +1308,7 @@ function releaseSandboxToPool(state, sessionID) {
   state.ownedSandboxIdentities.delete(sessionID);
   state.lastSessionSandbox.set(sessionID, sandboxPath);
   state.freeSandboxes.push({ path: sandboxPath, identity });
+  sandboxDebugLog(`release ${sessionID}: pooled ${path.basename(sandboxPath)}`);
 }
 
 async function removeOwnedSandbox(state, sessionID) {

--- a/common/opencode-plugin.js
+++ b/common/opencode-plugin.js
@@ -1198,8 +1198,14 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
 
   // Plugin instances never create a sandbox path used by another instance, so
   // an older instance cannot delete a replacement instance's active sandbox
-  // after an ownership check.
-  return path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
+  // after an ownership check. Within this instance the deterministic name can
+  // collide: pooling decouples directory names from sessions, so a sandbox
+  // named after this session may now be leased by a different session. Never
+  // share a live sandbox — fall back to a unique suffix instead.
+  const fresh = path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
+  const leasedPaths = new Set(state.ownedSandboxes.values());
+  if (!leasedPaths.has(fresh)) return fresh;
+  return path.join(sandboxRootIdentity.path, `${sessionID}-${randomUUID()}`);
 }
 
 function recordSessionParent(state, info) {
@@ -1286,6 +1292,8 @@ async function detachOwnedSandboxes(state) {
   for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
   state.ownedSandboxIdentities.clear();
+  // Pooled entries were folded into `sandboxes` above; clear the pool and
+  // session-tracking state so a disposed instance can never lease or release.
   state.freeSandboxes.length = 0;
   state.sessionParents.clear();
   state.lastSessionSandbox.clear();

--- a/common/opencode-plugin.js
+++ b/common/opencode-plugin.js
@@ -53,6 +53,7 @@ const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
 const XCODE_SANDBOX_MODE = 0o700;
 const XCODE_SANDBOX_OWNER_GRACE_MS = 60_000;
 const XCODE_SANDBOX_OWNER_LOCK = ".owner.lock";
+const XCODE_SANDBOX_CREATION_TOKEN = ".creation-token";
 const XCODE_SANDBOX_QUARANTINE_RE =
   /^\.quarantine-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const XCODE_SANDBOX_PENDING_CLEANUPS_KEY = Symbol.for(
@@ -763,6 +764,7 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   const packagesDir = path.join(sandboxBase, "packages");
 
   const sandboxIdentity = secureSandboxDirectory(sandboxBase, sandboxRoot);
+  sandboxIdentity.creationToken = ensureSandboxCreationToken(sandboxBase);
   state.ownedSandboxIdentities.set(sessionID, sandboxIdentity);
   if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
   secureSandboxDirectory(buildDir, sandboxIdentity);
@@ -828,6 +830,32 @@ function createDirectoryNonRecursively(directoryPath) {
     fs.mkdirSync(directoryPath, { mode: XCODE_SANDBOX_MODE });
   } catch (error) {
     if (error?.code !== "EEXIST") throw error;
+  }
+}
+
+// Written once, the first time a sandbox directory is created, and never
+// rewritten. dev+ino+uid alone can't distinguish "still the sandbox we
+// leased" from "something recreated this exact path" on filesystems that
+// recycle inode numbers quickly (tmpfs, the common $TMPDIR backing on Linux
+// CI runners) — a same-path replacement can't reproduce this token's
+// content by coincidence the way it can reproduce a recycled inode number.
+function ensureSandboxCreationToken(sandboxBase) {
+  const tokenPath = path.join(sandboxBase, XCODE_SANDBOX_CREATION_TOKEN);
+  try {
+    const token = randomUUID();
+    fs.writeFileSync(tokenPath, token, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    return token;
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+  return readSandboxCreationToken(sandboxBase);
+}
+
+function readSandboxCreationToken(sandboxBase) {
+  try {
+    return fs.readFileSync(path.join(sandboxBase, XCODE_SANDBOX_CREATION_TOKEN), "utf8");
+  } catch {
+    return null;
   }
 }
 
@@ -1894,6 +1922,19 @@ function secureExistingManagedSandbox(
     ) {
       return null;
     }
+    // dev+ino+uid alone can't tell "still the sandbox we handed out" from
+    // "something recreated this exact path": tmpfs (the common $TMPDIR
+    // backing on Linux CI runners) can hand a freshly created directory the
+    // same inode a just-removed directory held. The creation token is
+    // content written once when the directory was first made, so a
+    // same-path replacement can't produce a match by coincidence.
+    if (
+      expectedSandboxIdentity?.creationToken &&
+      readSandboxCreationToken(candidate) !== expectedSandboxIdentity.creationToken
+    ) {
+      return null;
+    }
+    current.creationToken = expectedSandboxIdentity?.creationToken;
     return current;
   } catch {
     return null;

--- a/common/opencode-plugin.js
+++ b/common/opencode-plugin.js
@@ -1272,14 +1272,23 @@ async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
 
 async function detachOwnedSandboxes(state) {
   state.disposed = true;
-  const sandboxes = [...state.ownedSandboxes.entries()].map(([sessionID, sandboxPath]) => ({
-    sandboxPath,
-    sandboxIdentity: state.ownedSandboxIdentities.get(sessionID),
-  }));
+  const sandboxes = [
+    ...[...state.ownedSandboxes.entries()].map(([sessionID, sandboxPath]) => ({
+      sandboxPath,
+      sandboxIdentity: state.ownedSandboxIdentities.get(sessionID),
+    })),
+    ...state.freeSandboxes.map((entry) => ({
+      sandboxPath: entry.path,
+      sandboxIdentity: entry.identity,
+    })),
+  ];
   const sandboxPaths = [...new Set(sandboxes.map(({ sandboxPath }) => sandboxPath))];
   for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
   state.ownedSandboxIdentities.clear();
+  state.freeSandboxes.length = 0;
+  state.sessionParents.clear();
+  state.lastSessionSandbox.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
   state.xcodeMcpApprovalHelpers.clear();

--- a/common/opencode-plugin.js
+++ b/common/opencode-plugin.js
@@ -85,6 +85,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       sessionParents: new Map(),
       freeSandboxes: [],
       lastSessionSandbox: new Map(),
+      activeBashCounts: new Map(),
       sandboxSweepDone: false,
       disposed: false,
     };
@@ -117,6 +118,11 @@ export function createOpenCodePlugin(pluginRootUrl) {
       "tool.execute.before": async (input, output) => {
         loadMetadata(pluginRoot, state);
         applyPreToolUseRules(state, input, output);
+        trackBashStart(state, input);
+      },
+
+      "tool.execute.after": async (input) => {
+        trackBashEnd(state, input);
       },
 
       "shell.env": async (input, output) => {
@@ -1131,6 +1137,7 @@ function releaseSandboxOwnerLock(ownerLock) {
 
 async function handlePluginEvent(state, event) {
   if (event?.type === "session.created" || event?.type === "session.updated") {
+    if (state.disposed) return;
     recordSessionParent(state, event.properties?.info);
     return;
   }
@@ -1139,6 +1146,11 @@ async function handlePluginEvent(state, event) {
     const rawSessionID = event.properties?.sessionID;
     if (state.disposed || typeof rawSessionID !== "string" || !rawSessionID) return;
     const safeID = safeSessionID(rawSessionID);
+    // A stale idle — delivered after the session was already re-prompted —
+    // must not pool a sandbox an in-flight bash command is still writing to.
+    // Skipping is safe: the re-prompted turn ends with its own idle, which
+    // performs the release once no command is running.
+    if ((state.activeBashCounts.get(safeID) ?? 0) > 0) return;
     // Only subagent (child) sessions release on idle. A main session going
     // idle is just the end of a turn; it keeps its sandbox for the next one.
     if (state.sessionParents.get(safeID)) releaseSandboxToPool(state, safeID);
@@ -1153,9 +1165,15 @@ async function handlePluginEvent(state, event) {
   const safeID = safeSessionID(sessionID);
   const parentID =
     event.properties?.info?.parentID ?? state.sessionParents.get(safeID);
+  // Only a session this instance actually observed as parentless counts as a
+  // main session. A deletion for a session we never tracked (created before
+  // the plugin loaded) proves nothing about the pool, so it must not drain
+  // warm caches that may belong to a still-live main.
+  const knownMain = !parentID && state.sessionParents.has(safeID);
   state.deletedSandboxSessions.add(safeID);
   state.sessionParents.delete(safeID);
   state.lastSessionSandbox.delete(safeID);
+  state.activeBashCounts.delete(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
   const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
@@ -1164,7 +1182,7 @@ async function handlePluginEvent(state, event) {
   // A deleted main session drains the free pool: pooled sandboxes existed to
   // serve its subagents, so reclaim the disk now rather than at dispose.
   // Sandboxes still leased by live sessions are untouched.
-  if (!parentID) await drainFreeSandboxes(state);
+  if (knownMain) await drainFreeSandboxes(state);
 }
 
 // Leasing order: the sandbox this session already holds, then the sandbox it
@@ -1187,6 +1205,10 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
       return entry.path;
     }
+    // Discarded entries stay marked pending: this instance's sweep already
+    // ran, so without the marker a transient inspect failure would orphan
+    // the directory until another process claims the sandbox root.
+    markPendingSandboxCleanup(entry.path);
   }
 
   while (state.freeSandboxes.length > 0) {
@@ -1194,6 +1216,7 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
       return entry.path;
     }
+    markPendingSandboxCleanup(entry.path);
   }
 
   // Plugin instances never create a sandbox path used by another instance, so
@@ -1211,9 +1234,33 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
 function recordSessionParent(state, info) {
   const id = info?.id;
   if (typeof id !== "string" || !id) return;
+  const safeID = safeSessionID(id);
   const parentID =
     typeof info.parentID === "string" && info.parentID ? info.parentID : null;
-  state.sessionParents.set(safeSessionID(id), parentID);
+  // A payload without parentID normally means "main session", but never let
+  // it downgrade a session we already classified: a partial update would
+  // otherwise stop a known child from releasing on idle and let its
+  // deletion drain the pool.
+  if (parentID === null && state.sessionParents.has(safeID)) return;
+  state.sessionParents.set(safeID, parentID);
+}
+
+// In-flight bash tracking exists solely to gate the idle-release against
+// stale events. Counts only ever prevent a release, so a missed
+// tool.execute.after degrades to "the sandbox stays leased" — the pre-pool
+// behavior, reclaimed on deletion/dispose — never to a premature release.
+function trackBashStart(state, input) {
+  if (String(input?.tool ?? "").toLowerCase() !== "bash") return;
+  const safeID = safeSessionID(input?.sessionID ?? "global");
+  state.activeBashCounts.set(safeID, (state.activeBashCounts.get(safeID) ?? 0) + 1);
+}
+
+function trackBashEnd(state, input) {
+  if (String(input?.tool ?? "").toLowerCase() !== "bash") return;
+  const safeID = safeSessionID(input?.sessionID ?? "global");
+  const count = state.activeBashCounts.get(safeID) ?? 0;
+  if (count <= 1) state.activeBashCounts.delete(safeID);
+  else state.activeBashCounts.set(safeID, count - 1);
 }
 
 function releaseSandboxToPool(state, sessionID) {
@@ -1250,15 +1297,25 @@ async function drainFreeSandboxes(state) {
   }
   if (!state.sandboxRoot) return;
 
+  // Removal is detached (/bin/rm) rather than awaited: draining several
+  // multi-GB trees in-process would stall serialized event delivery — the
+  // very lag that turns a delayed session.idle stale.
   await Promise.all(
     entries.map(async ({ path: sandboxPath, identity }) => {
       markPendingSandboxCleanup(sandboxPath);
-      await quarantineAndRemoveSandbox(state, sandboxPath, identity);
+      await quarantineAndRemoveSandbox(state, sandboxPath, identity, {
+        detach: true,
+      });
     }),
   );
 }
 
-async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
+async function quarantineAndRemoveSandbox(
+  state,
+  sandboxPath,
+  sandboxIdentity,
+  { detach = false } = {},
+) {
   const quarantinedPath = await quarantineOwnedSandbox(
     sandboxPath,
     state.instanceID,
@@ -1268,9 +1325,20 @@ async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
   const cleanupIdentity = quarantinedPath
     ? relocatedSandboxIdentity(sandboxIdentity, quarantinedPath)
     : sandboxIdentity;
+  const removalPath = quarantinedPath || sandboxPath;
+  const expectedInstanceID = quarantinedPath ? "" : state.instanceID;
+  if (detach) {
+    await detachManagedSandbox(
+      removalPath,
+      expectedInstanceID,
+      state.sandboxRoot,
+      cleanupIdentity,
+    );
+    return;
+  }
   await removeManagedSandbox(
-    quarantinedPath || sandboxPath,
-    quarantinedPath ? "" : state.instanceID,
+    removalPath,
+    expectedInstanceID,
     state.sandboxRoot,
     cleanupIdentity,
   );
@@ -1297,6 +1365,7 @@ async function detachOwnedSandboxes(state) {
   state.freeSandboxes.length = 0;
   state.sessionParents.clear();
   state.lastSessionSandbox.clear();
+  state.activeBashCounts.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
   state.xcodeMcpApprovalHelpers.clear();

--- a/common/opencode-plugin.js
+++ b/common/opencode-plugin.js
@@ -82,6 +82,9 @@ export function createOpenCodePlugin(pluginRootUrl) {
       ownedSandboxes: new Map(),
       ownedSandboxIdentities: new Map(),
       deletedSandboxSessions: new Set(),
+      sessionParents: new Map(),
+      freeSandboxes: [],
+      lastSessionSandbox: new Map(),
       sandboxSweepDone: false,
       disposed: false,
     };
@@ -736,9 +739,7 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
   if (state.disposed || state.deletedSandboxSessions.has(sessionID)) return;
   const sandboxRoot = secureSandboxRoot(state);
-  // Plugin instances never reuse a sandbox path, so an older instance cannot
-  // delete a replacement instance's active sandbox after an ownership check.
-  const sandboxBase = path.join(sandboxRoot.path, `${sessionID}-${state.instanceID}`);
+  const sandboxBase = leaseSandboxPath(state, sandboxRoot, sessionID);
   state.ownedSandboxes.set(sessionID, sandboxBase);
 
   if (!state.processStartToken) {
@@ -1129,6 +1130,21 @@ function releaseSandboxOwnerLock(ownerLock) {
 }
 
 async function handlePluginEvent(state, event) {
+  if (event?.type === "session.created" || event?.type === "session.updated") {
+    recordSessionParent(state, event.properties?.info);
+    return;
+  }
+
+  if (event?.type === "session.idle") {
+    const rawSessionID = event.properties?.sessionID;
+    if (state.disposed || typeof rawSessionID !== "string" || !rawSessionID) return;
+    const safeID = safeSessionID(rawSessionID);
+    // Only subagent (child) sessions release on idle. A main session going
+    // idle is just the end of a turn; it keeps its sandbox for the next one.
+    if (state.sessionParents.get(safeID)) releaseSandboxToPool(state, safeID);
+    return;
+  }
+
   if (event?.type !== "session.deleted") return;
 
   const sessionID = event.properties?.info?.id;
@@ -1136,11 +1152,67 @@ async function handlePluginEvent(state, event) {
 
   const safeID = safeSessionID(sessionID);
   state.deletedSandboxSessions.add(safeID);
+  state.sessionParents.delete(safeID);
+  state.lastSessionSandbox.delete(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
   const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
   await stopXcodeMcpApproval(activeApproval);
   await removeOwnedSandbox(state, safeID);
+}
+
+// Leasing order: the sandbox this session already holds, then the sandbox it
+// held before releasing (warm caches for a re-prompted subagent), then the
+// most recently freed pool entry, then a fresh directory. Pool entries are
+// revalidated before reuse and dropped if they fail the identity checks.
+// Reused directories keep their original <sessionID>-<instanceID> name and
+// are never renamed — SPM and Xcode state files embed absolute paths.
+function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
+  const existing = state.ownedSandboxes.get(sessionID);
+  if (existing) return existing;
+
+  const preferred = state.lastSessionSandbox.get(sessionID);
+  const preferredIndex =
+    typeof preferred === "string"
+      ? state.freeSandboxes.findIndex((entry) => entry.path === preferred)
+      : -1;
+  if (preferredIndex !== -1) {
+    const [entry] = state.freeSandboxes.splice(preferredIndex, 1);
+    if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      return entry.path;
+    }
+  }
+
+  while (state.freeSandboxes.length > 0) {
+    const entry = state.freeSandboxes.pop();
+    if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      return entry.path;
+    }
+  }
+
+  // Plugin instances never create a sandbox path used by another instance, so
+  // an older instance cannot delete a replacement instance's active sandbox
+  // after an ownership check.
+  return path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
+}
+
+function recordSessionParent(state, info) {
+  const id = info?.id;
+  if (typeof id !== "string" || !id) return;
+  const parentID =
+    typeof info.parentID === "string" && info.parentID ? info.parentID : null;
+  state.sessionParents.set(safeSessionID(id), parentID);
+}
+
+function releaseSandboxToPool(state, sessionID) {
+  const sandboxPath = state.ownedSandboxes.get(sessionID);
+  const identity = state.ownedSandboxIdentities.get(sessionID);
+  if (!sandboxPath || !identity) return;
+
+  state.ownedSandboxes.delete(sessionID);
+  state.ownedSandboxIdentities.delete(sessionID);
+  state.lastSessionSandbox.set(sessionID, sandboxPath);
+  state.freeSandboxes.push({ path: sandboxPath, identity });
 }
 
 async function removeOwnedSandbox(state, sessionID) {

--- a/common/opencode-plugin.js
+++ b/common/opencode-plugin.js
@@ -1151,6 +1151,8 @@ async function handlePluginEvent(state, event) {
   if (typeof sessionID !== "string" || !sessionID) return;
 
   const safeID = safeSessionID(sessionID);
+  const parentID =
+    event.properties?.info?.parentID ?? state.sessionParents.get(safeID);
   state.deletedSandboxSessions.add(safeID);
   state.sessionParents.delete(safeID);
   state.lastSessionSandbox.delete(safeID);
@@ -1159,6 +1161,10 @@ async function handlePluginEvent(state, event) {
   const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
   await stopXcodeMcpApproval(activeApproval);
   await removeOwnedSandbox(state, safeID);
+  // A deleted main session drains the free pool: pooled sandboxes existed to
+  // serve its subagents, so reclaim the disk now rather than at dispose.
+  // Sandboxes still leased by live sessions are untouched.
+  if (!parentID) await drainFreeSandboxes(state);
 }
 
 // Leasing order: the sandbox this session already holds, then the sandbox it
@@ -1225,6 +1231,28 @@ async function removeOwnedSandbox(state, sessionID) {
   state.ownedSandboxIdentities.delete(sessionID);
   if (!state.sandboxRoot || !sandboxIdentity) return;
 
+  await quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity);
+}
+
+async function drainFreeSandboxes(state) {
+  const entries = state.freeSandboxes.splice(0, state.freeSandboxes.length);
+  if (entries.length === 0) return;
+
+  const drainedPaths = new Set(entries.map((entry) => entry.path));
+  for (const [sessionID, sandboxPath] of state.lastSessionSandbox) {
+    if (drainedPaths.has(sandboxPath)) state.lastSessionSandbox.delete(sessionID);
+  }
+  if (!state.sandboxRoot) return;
+
+  await Promise.all(
+    entries.map(async ({ path: sandboxPath, identity }) => {
+      markPendingSandboxCleanup(sandboxPath);
+      await quarantineAndRemoveSandbox(state, sandboxPath, identity);
+    }),
+  );
+}
+
+async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
   const quarantinedPath = await quarantineOwnedSandbox(
     sandboxPath,
     state.instanceID,

--- a/iOSSimulator/common/opencode-plugin.js
+++ b/iOSSimulator/common/opencode-plugin.js
@@ -1199,8 +1199,14 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
 
   // Plugin instances never create a sandbox path used by another instance, so
   // an older instance cannot delete a replacement instance's active sandbox
-  // after an ownership check.
-  return path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
+  // after an ownership check. Within this instance the deterministic name can
+  // collide: pooling decouples directory names from sessions, so a sandbox
+  // named after this session may now be leased by a different session. Never
+  // share a live sandbox — fall back to a unique suffix instead.
+  const fresh = path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
+  const leasedPaths = new Set(state.ownedSandboxes.values());
+  if (!leasedPaths.has(fresh)) return fresh;
+  return path.join(sandboxRootIdentity.path, `${sessionID}-${randomUUID()}`);
 }
 
 function recordSessionParent(state, info) {
@@ -1287,6 +1293,8 @@ async function detachOwnedSandboxes(state) {
   for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
   state.ownedSandboxIdentities.clear();
+  // Pooled entries were folded into `sandboxes` above; clear the pool and
+  // session-tracking state so a disposed instance can never lease or release.
   state.freeSandboxes.length = 0;
   state.sessionParents.clear();
   state.lastSessionSandbox.clear();

--- a/iOSSimulator/common/opencode-plugin.js
+++ b/iOSSimulator/common/opencode-plugin.js
@@ -1152,6 +1152,8 @@ async function handlePluginEvent(state, event) {
   if (typeof sessionID !== "string" || !sessionID) return;
 
   const safeID = safeSessionID(sessionID);
+  const parentID =
+    event.properties?.info?.parentID ?? state.sessionParents.get(safeID);
   state.deletedSandboxSessions.add(safeID);
   state.sessionParents.delete(safeID);
   state.lastSessionSandbox.delete(safeID);
@@ -1160,6 +1162,10 @@ async function handlePluginEvent(state, event) {
   const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
   await stopXcodeMcpApproval(activeApproval);
   await removeOwnedSandbox(state, safeID);
+  // A deleted main session drains the free pool: pooled sandboxes existed to
+  // serve its subagents, so reclaim the disk now rather than at dispose.
+  // Sandboxes still leased by live sessions are untouched.
+  if (!parentID) await drainFreeSandboxes(state);
 }
 
 // Leasing order: the sandbox this session already holds, then the sandbox it
@@ -1226,6 +1232,28 @@ async function removeOwnedSandbox(state, sessionID) {
   state.ownedSandboxIdentities.delete(sessionID);
   if (!state.sandboxRoot || !sandboxIdentity) return;
 
+  await quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity);
+}
+
+async function drainFreeSandboxes(state) {
+  const entries = state.freeSandboxes.splice(0, state.freeSandboxes.length);
+  if (entries.length === 0) return;
+
+  const drainedPaths = new Set(entries.map((entry) => entry.path));
+  for (const [sessionID, sandboxPath] of state.lastSessionSandbox) {
+    if (drainedPaths.has(sandboxPath)) state.lastSessionSandbox.delete(sessionID);
+  }
+  if (!state.sandboxRoot) return;
+
+  await Promise.all(
+    entries.map(async ({ path: sandboxPath, identity }) => {
+      markPendingSandboxCleanup(sandboxPath);
+      await quarantineAndRemoveSandbox(state, sandboxPath, identity);
+    }),
+  );
+}
+
+async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
   const quarantinedPath = await quarantineOwnedSandbox(
     sandboxPath,
     state.instanceID,

--- a/iOSSimulator/common/opencode-plugin.js
+++ b/iOSSimulator/common/opencode-plugin.js
@@ -86,6 +86,7 @@ export function createOpenCodePlugin(pluginRootUrl) {
       sessionParents: new Map(),
       freeSandboxes: [],
       lastSessionSandbox: new Map(),
+      activeBashCounts: new Map(),
       sandboxSweepDone: false,
       disposed: false,
     };
@@ -118,6 +119,11 @@ export function createOpenCodePlugin(pluginRootUrl) {
       "tool.execute.before": async (input, output) => {
         loadMetadata(pluginRoot, state);
         applyPreToolUseRules(state, input, output);
+        trackBashStart(state, input);
+      },
+
+      "tool.execute.after": async (input) => {
+        trackBashEnd(state, input);
       },
 
       "shell.env": async (input, output) => {
@@ -1132,6 +1138,7 @@ function releaseSandboxOwnerLock(ownerLock) {
 
 async function handlePluginEvent(state, event) {
   if (event?.type === "session.created" || event?.type === "session.updated") {
+    if (state.disposed) return;
     recordSessionParent(state, event.properties?.info);
     return;
   }
@@ -1140,6 +1147,11 @@ async function handlePluginEvent(state, event) {
     const rawSessionID = event.properties?.sessionID;
     if (state.disposed || typeof rawSessionID !== "string" || !rawSessionID) return;
     const safeID = safeSessionID(rawSessionID);
+    // A stale idle — delivered after the session was already re-prompted —
+    // must not pool a sandbox an in-flight bash command is still writing to.
+    // Skipping is safe: the re-prompted turn ends with its own idle, which
+    // performs the release once no command is running.
+    if ((state.activeBashCounts.get(safeID) ?? 0) > 0) return;
     // Only subagent (child) sessions release on idle. A main session going
     // idle is just the end of a turn; it keeps its sandbox for the next one.
     if (state.sessionParents.get(safeID)) releaseSandboxToPool(state, safeID);
@@ -1154,9 +1166,15 @@ async function handlePluginEvent(state, event) {
   const safeID = safeSessionID(sessionID);
   const parentID =
     event.properties?.info?.parentID ?? state.sessionParents.get(safeID);
+  // Only a session this instance actually observed as parentless counts as a
+  // main session. A deletion for a session we never tracked (created before
+  // the plugin loaded) proves nothing about the pool, so it must not drain
+  // warm caches that may belong to a still-live main.
+  const knownMain = !parentID && state.sessionParents.has(safeID);
   state.deletedSandboxSessions.add(safeID);
   state.sessionParents.delete(safeID);
   state.lastSessionSandbox.delete(safeID);
+  state.activeBashCounts.delete(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
   const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
@@ -1165,7 +1183,7 @@ async function handlePluginEvent(state, event) {
   // A deleted main session drains the free pool: pooled sandboxes existed to
   // serve its subagents, so reclaim the disk now rather than at dispose.
   // Sandboxes still leased by live sessions are untouched.
-  if (!parentID) await drainFreeSandboxes(state);
+  if (knownMain) await drainFreeSandboxes(state);
 }
 
 // Leasing order: the sandbox this session already holds, then the sandbox it
@@ -1188,6 +1206,10 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
       return entry.path;
     }
+    // Discarded entries stay marked pending: this instance's sweep already
+    // ran, so without the marker a transient inspect failure would orphan
+    // the directory until another process claims the sandbox root.
+    markPendingSandboxCleanup(entry.path);
   }
 
   while (state.freeSandboxes.length > 0) {
@@ -1195,6 +1217,7 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
       return entry.path;
     }
+    markPendingSandboxCleanup(entry.path);
   }
 
   // Plugin instances never create a sandbox path used by another instance, so
@@ -1212,9 +1235,33 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
 function recordSessionParent(state, info) {
   const id = info?.id;
   if (typeof id !== "string" || !id) return;
+  const safeID = safeSessionID(id);
   const parentID =
     typeof info.parentID === "string" && info.parentID ? info.parentID : null;
-  state.sessionParents.set(safeSessionID(id), parentID);
+  // A payload without parentID normally means "main session", but never let
+  // it downgrade a session we already classified: a partial update would
+  // otherwise stop a known child from releasing on idle and let its
+  // deletion drain the pool.
+  if (parentID === null && state.sessionParents.has(safeID)) return;
+  state.sessionParents.set(safeID, parentID);
+}
+
+// In-flight bash tracking exists solely to gate the idle-release against
+// stale events. Counts only ever prevent a release, so a missed
+// tool.execute.after degrades to "the sandbox stays leased" — the pre-pool
+// behavior, reclaimed on deletion/dispose — never to a premature release.
+function trackBashStart(state, input) {
+  if (String(input?.tool ?? "").toLowerCase() !== "bash") return;
+  const safeID = safeSessionID(input?.sessionID ?? "global");
+  state.activeBashCounts.set(safeID, (state.activeBashCounts.get(safeID) ?? 0) + 1);
+}
+
+function trackBashEnd(state, input) {
+  if (String(input?.tool ?? "").toLowerCase() !== "bash") return;
+  const safeID = safeSessionID(input?.sessionID ?? "global");
+  const count = state.activeBashCounts.get(safeID) ?? 0;
+  if (count <= 1) state.activeBashCounts.delete(safeID);
+  else state.activeBashCounts.set(safeID, count - 1);
 }
 
 function releaseSandboxToPool(state, sessionID) {
@@ -1251,15 +1298,25 @@ async function drainFreeSandboxes(state) {
   }
   if (!state.sandboxRoot) return;
 
+  // Removal is detached (/bin/rm) rather than awaited: draining several
+  // multi-GB trees in-process would stall serialized event delivery — the
+  // very lag that turns a delayed session.idle stale.
   await Promise.all(
     entries.map(async ({ path: sandboxPath, identity }) => {
       markPendingSandboxCleanup(sandboxPath);
-      await quarantineAndRemoveSandbox(state, sandboxPath, identity);
+      await quarantineAndRemoveSandbox(state, sandboxPath, identity, {
+        detach: true,
+      });
     }),
   );
 }
 
-async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
+async function quarantineAndRemoveSandbox(
+  state,
+  sandboxPath,
+  sandboxIdentity,
+  { detach = false } = {},
+) {
   const quarantinedPath = await quarantineOwnedSandbox(
     sandboxPath,
     state.instanceID,
@@ -1269,9 +1326,20 @@ async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
   const cleanupIdentity = quarantinedPath
     ? relocatedSandboxIdentity(sandboxIdentity, quarantinedPath)
     : sandboxIdentity;
+  const removalPath = quarantinedPath || sandboxPath;
+  const expectedInstanceID = quarantinedPath ? "" : state.instanceID;
+  if (detach) {
+    await detachManagedSandbox(
+      removalPath,
+      expectedInstanceID,
+      state.sandboxRoot,
+      cleanupIdentity,
+    );
+    return;
+  }
   await removeManagedSandbox(
-    quarantinedPath || sandboxPath,
-    quarantinedPath ? "" : state.instanceID,
+    removalPath,
+    expectedInstanceID,
     state.sandboxRoot,
     cleanupIdentity,
   );
@@ -1298,6 +1366,7 @@ async function detachOwnedSandboxes(state) {
   state.freeSandboxes.length = 0;
   state.sessionParents.clear();
   state.lastSessionSandbox.clear();
+  state.activeBashCounts.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
   state.xcodeMcpApprovalHelpers.clear();

--- a/iOSSimulator/common/opencode-plugin.js
+++ b/iOSSimulator/common/opencode-plugin.js
@@ -54,6 +54,7 @@ const XCODE_SANDBOX_DIR = "opencode-xcodebuildtools-sandbox";
 const XCODE_SANDBOX_MODE = 0o700;
 const XCODE_SANDBOX_OWNER_GRACE_MS = 60_000;
 const XCODE_SANDBOX_OWNER_LOCK = ".owner.lock";
+const XCODE_SANDBOX_CREATION_TOKEN = ".creation-token";
 const XCODE_SANDBOX_QUARANTINE_RE =
   /^\.quarantine-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const XCODE_SANDBOX_PENDING_CLEANUPS_KEY = Symbol.for(
@@ -764,6 +765,7 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   const packagesDir = path.join(sandboxBase, "packages");
 
   const sandboxIdentity = secureSandboxDirectory(sandboxBase, sandboxRoot);
+  sandboxIdentity.creationToken = ensureSandboxCreationToken(sandboxBase);
   state.ownedSandboxIdentities.set(sessionID, sandboxIdentity);
   if (sandboxSetupIsCancelled(state, sessionID, sandboxBase)) return;
   secureSandboxDirectory(buildDir, sandboxIdentity);
@@ -829,6 +831,32 @@ function createDirectoryNonRecursively(directoryPath) {
     fs.mkdirSync(directoryPath, { mode: XCODE_SANDBOX_MODE });
   } catch (error) {
     if (error?.code !== "EEXIST") throw error;
+  }
+}
+
+// Written once, the first time a sandbox directory is created, and never
+// rewritten. dev+ino+uid alone can't distinguish "still the sandbox we
+// leased" from "something recreated this exact path" on filesystems that
+// recycle inode numbers quickly (tmpfs, the common $TMPDIR backing on Linux
+// CI runners) — a same-path replacement can't reproduce this token's
+// content by coincidence the way it can reproduce a recycled inode number.
+function ensureSandboxCreationToken(sandboxBase) {
+  const tokenPath = path.join(sandboxBase, XCODE_SANDBOX_CREATION_TOKEN);
+  try {
+    const token = randomUUID();
+    fs.writeFileSync(tokenPath, token, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    return token;
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+  return readSandboxCreationToken(sandboxBase);
+}
+
+function readSandboxCreationToken(sandboxBase) {
+  try {
+    return fs.readFileSync(path.join(sandboxBase, XCODE_SANDBOX_CREATION_TOKEN), "utf8");
+  } catch {
+    return null;
   }
 }
 
@@ -1895,6 +1923,19 @@ function secureExistingManagedSandbox(
     ) {
       return null;
     }
+    // dev+ino+uid alone can't tell "still the sandbox we handed out" from
+    // "something recreated this exact path": tmpfs (the common $TMPDIR
+    // backing on Linux CI runners) can hand a freshly created directory the
+    // same inode a just-removed directory held. The creation token is
+    // content written once when the directory was first made, so a
+    // same-path replacement can't produce a match by coincidence.
+    if (
+      expectedSandboxIdentity?.creationToken &&
+      readSandboxCreationToken(candidate) !== expectedSandboxIdentity.creationToken
+    ) {
+      return null;
+    }
+    current.creationToken = expectedSandboxIdentity?.creationToken;
     return current;
   } catch {
     return null;

--- a/iOSSimulator/common/opencode-plugin.js
+++ b/iOSSimulator/common/opencode-plugin.js
@@ -1136,6 +1136,19 @@ function releaseSandboxOwnerLock(ownerLock) {
   }
 }
 
+// Field-diagnosable pool decisions: when $TMPDIR/xbt-sandbox-debug exists,
+// every lease/release decision (and every refusal, with its reason) is
+// appended to $TMPDIR/xbt-sandbox-debug.log. Inert without the flag file.
+function sandboxDebugLog(message) {
+  try {
+    const flag = path.join(os.tmpdir(), "xbt-sandbox-debug");
+    if (!fs.existsSync(flag)) return;
+    fs.appendFileSync(`${flag}.log`, `${new Date().toISOString()} ${message}\n`);
+  } catch {
+    // Diagnostics must never interfere with sandbox management.
+  }
+}
+
 async function handlePluginEvent(state, event) {
   if (event?.type === "session.created" || event?.type === "session.updated") {
     if (state.disposed) return;
@@ -1151,10 +1164,21 @@ async function handlePluginEvent(state, event) {
     // must not pool a sandbox an in-flight bash command is still writing to.
     // Skipping is safe: the re-prompted turn ends with its own idle, which
     // performs the release once no command is running.
-    if ((state.activeBashCounts.get(safeID) ?? 0) > 0) return;
+    if ((state.activeBashCounts.get(safeID) ?? 0) > 0) {
+      sandboxDebugLog(
+        `idle ${safeID}: release refused, ${state.activeBashCounts.get(safeID)} bash in flight`,
+      );
+      return;
+    }
     // Only subagent (child) sessions release on idle. A main session going
     // idle is just the end of a turn; it keeps its sandbox for the next one.
-    if (state.sessionParents.get(safeID)) releaseSandboxToPool(state, safeID);
+    if (state.sessionParents.get(safeID)) {
+      releaseSandboxToPool(state, safeID);
+    } else {
+      sandboxDebugLog(
+        `idle ${safeID}: release refused, parent=${JSON.stringify(state.sessionParents.get(safeID) ?? null)} known=${state.sessionParents.has(safeID)}`,
+      );
+    }
     return;
   }
 
@@ -1183,6 +1207,9 @@ async function handlePluginEvent(state, event) {
   // A deleted main session drains the free pool: pooled sandboxes existed to
   // serve its subagents, so reclaim the disk now rather than at dispose.
   // Sandboxes still leased by live sessions are untouched.
+  sandboxDebugLog(
+    `deleted ${safeID}: knownMain=${knownMain} drain=${knownMain ? state.freeSandboxes.length : 0} pooled`,
+  );
   if (knownMain) await drainFreeSandboxes(state);
 }
 
@@ -1204,20 +1231,24 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
   if (preferredIndex !== -1) {
     const [entry] = state.freeSandboxes.splice(preferredIndex, 1);
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      sandboxDebugLog(`lease ${sessionID}: reused previous ${path.basename(entry.path)}`);
       return entry.path;
     }
     // Discarded entries stay marked pending: this instance's sweep already
     // ran, so without the marker a transient inspect failure would orphan
     // the directory until another process claims the sandbox root.
     markPendingSandboxCleanup(entry.path);
+    sandboxDebugLog(`lease ${sessionID}: discarded invalid ${path.basename(entry.path)}`);
   }
 
   while (state.freeSandboxes.length > 0) {
     const entry = state.freeSandboxes.pop();
     if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      sandboxDebugLog(`lease ${sessionID}: reused pooled ${path.basename(entry.path)}`);
       return entry.path;
     }
     markPendingSandboxCleanup(entry.path);
+    sandboxDebugLog(`lease ${sessionID}: discarded invalid ${path.basename(entry.path)}`);
   }
 
   // Plugin instances never create a sandbox path used by another instance, so
@@ -1228,8 +1259,13 @@ function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
   // share a live sandbox — fall back to a unique suffix instead.
   const fresh = path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
   const leasedPaths = new Set(state.ownedSandboxes.values());
-  if (!leasedPaths.has(fresh)) return fresh;
-  return path.join(sandboxRootIdentity.path, `${sessionID}-${randomUUID()}`);
+  if (!leasedPaths.has(fresh)) {
+    sandboxDebugLog(`lease ${sessionID}: fresh ${path.basename(fresh)}`);
+    return fresh;
+  }
+  const disambiguated = path.join(sandboxRootIdentity.path, `${sessionID}-${randomUUID()}`);
+  sandboxDebugLog(`lease ${sessionID}: fresh (collision) ${path.basename(disambiguated)}`);
+  return disambiguated;
 }
 
 function recordSessionParent(state, info) {
@@ -1273,6 +1309,7 @@ function releaseSandboxToPool(state, sessionID) {
   state.ownedSandboxIdentities.delete(sessionID);
   state.lastSessionSandbox.set(sessionID, sandboxPath);
   state.freeSandboxes.push({ path: sandboxPath, identity });
+  sandboxDebugLog(`release ${sessionID}: pooled ${path.basename(sandboxPath)}`);
 }
 
 async function removeOwnedSandbox(state, sessionID) {

--- a/iOSSimulator/common/opencode-plugin.js
+++ b/iOSSimulator/common/opencode-plugin.js
@@ -1273,14 +1273,23 @@ async function quarantineAndRemoveSandbox(state, sandboxPath, sandboxIdentity) {
 
 async function detachOwnedSandboxes(state) {
   state.disposed = true;
-  const sandboxes = [...state.ownedSandboxes.entries()].map(([sessionID, sandboxPath]) => ({
-    sandboxPath,
-    sandboxIdentity: state.ownedSandboxIdentities.get(sessionID),
-  }));
+  const sandboxes = [
+    ...[...state.ownedSandboxes.entries()].map(([sessionID, sandboxPath]) => ({
+      sandboxPath,
+      sandboxIdentity: state.ownedSandboxIdentities.get(sessionID),
+    })),
+    ...state.freeSandboxes.map((entry) => ({
+      sandboxPath: entry.path,
+      sandboxIdentity: entry.identity,
+    })),
+  ];
   const sandboxPaths = [...new Set(sandboxes.map(({ sandboxPath }) => sandboxPath))];
   for (const sandboxPath of sandboxPaths) markPendingSandboxCleanup(sandboxPath);
   state.ownedSandboxes.clear();
   state.ownedSandboxIdentities.clear();
+  state.freeSandboxes.length = 0;
+  state.sessionParents.clear();
+  state.lastSessionSandbox.clear();
   state.xcodeMcpCache.clear();
   state.xcodeMcpApprovalSessions.clear();
   state.xcodeMcpApprovalHelpers.clear();

--- a/iOSSimulator/common/opencode-plugin.js
+++ b/iOSSimulator/common/opencode-plugin.js
@@ -83,6 +83,9 @@ export function createOpenCodePlugin(pluginRootUrl) {
       ownedSandboxes: new Map(),
       ownedSandboxIdentities: new Map(),
       deletedSandboxSessions: new Set(),
+      sessionParents: new Map(),
+      freeSandboxes: [],
+      lastSessionSandbox: new Map(),
       sandboxSweepDone: false,
       disposed: false,
     };
@@ -737,9 +740,7 @@ async function configureShellEnvironment(pluginRoot, state, input, output) {
   const sessionID = safeSessionID(input.sessionID ?? input.cwd ?? "default");
   if (state.disposed || state.deletedSandboxSessions.has(sessionID)) return;
   const sandboxRoot = secureSandboxRoot(state);
-  // Plugin instances never reuse a sandbox path, so an older instance cannot
-  // delete a replacement instance's active sandbox after an ownership check.
-  const sandboxBase = path.join(sandboxRoot.path, `${sessionID}-${state.instanceID}`);
+  const sandboxBase = leaseSandboxPath(state, sandboxRoot, sessionID);
   state.ownedSandboxes.set(sessionID, sandboxBase);
 
   if (!state.processStartToken) {
@@ -1130,6 +1131,21 @@ function releaseSandboxOwnerLock(ownerLock) {
 }
 
 async function handlePluginEvent(state, event) {
+  if (event?.type === "session.created" || event?.type === "session.updated") {
+    recordSessionParent(state, event.properties?.info);
+    return;
+  }
+
+  if (event?.type === "session.idle") {
+    const rawSessionID = event.properties?.sessionID;
+    if (state.disposed || typeof rawSessionID !== "string" || !rawSessionID) return;
+    const safeID = safeSessionID(rawSessionID);
+    // Only subagent (child) sessions release on idle. A main session going
+    // idle is just the end of a turn; it keeps its sandbox for the next one.
+    if (state.sessionParents.get(safeID)) releaseSandboxToPool(state, safeID);
+    return;
+  }
+
   if (event?.type !== "session.deleted") return;
 
   const sessionID = event.properties?.info?.id;
@@ -1137,11 +1153,67 @@ async function handlePluginEvent(state, event) {
 
   const safeID = safeSessionID(sessionID);
   state.deletedSandboxSessions.add(safeID);
+  state.sessionParents.delete(safeID);
+  state.lastSessionSandbox.delete(safeID);
   state.xcodeMcpCache.delete(safeID);
   state.xcodeMcpApprovalSessions.delete(safeID);
   const activeApproval = state.xcodeMcpApprovalHelpers.get(safeID);
   await stopXcodeMcpApproval(activeApproval);
   await removeOwnedSandbox(state, safeID);
+}
+
+// Leasing order: the sandbox this session already holds, then the sandbox it
+// held before releasing (warm caches for a re-prompted subagent), then the
+// most recently freed pool entry, then a fresh directory. Pool entries are
+// revalidated before reuse and dropped if they fail the identity checks.
+// Reused directories keep their original <sessionID>-<instanceID> name and
+// are never renamed — SPM and Xcode state files embed absolute paths.
+function leaseSandboxPath(state, sandboxRootIdentity, sessionID) {
+  const existing = state.ownedSandboxes.get(sessionID);
+  if (existing) return existing;
+
+  const preferred = state.lastSessionSandbox.get(sessionID);
+  const preferredIndex =
+    typeof preferred === "string"
+      ? state.freeSandboxes.findIndex((entry) => entry.path === preferred)
+      : -1;
+  if (preferredIndex !== -1) {
+    const [entry] = state.freeSandboxes.splice(preferredIndex, 1);
+    if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      return entry.path;
+    }
+  }
+
+  while (state.freeSandboxes.length > 0) {
+    const entry = state.freeSandboxes.pop();
+    if (secureExistingManagedSandbox(entry.path, sandboxRootIdentity, entry.identity)) {
+      return entry.path;
+    }
+  }
+
+  // Plugin instances never create a sandbox path used by another instance, so
+  // an older instance cannot delete a replacement instance's active sandbox
+  // after an ownership check.
+  return path.join(sandboxRootIdentity.path, `${sessionID}-${state.instanceID}`);
+}
+
+function recordSessionParent(state, info) {
+  const id = info?.id;
+  if (typeof id !== "string" || !id) return;
+  const parentID =
+    typeof info.parentID === "string" && info.parentID ? info.parentID : null;
+  state.sessionParents.set(safeSessionID(id), parentID);
+}
+
+function releaseSandboxToPool(state, sessionID) {
+  const sandboxPath = state.ownedSandboxes.get(sessionID);
+  const identity = state.ownedSandboxIdentities.get(sessionID);
+  if (!sandboxPath || !identity) return;
+
+  state.ownedSandboxes.delete(sessionID);
+  state.ownedSandboxIdentities.delete(sessionID);
+  state.lastSessionSandbox.set(sessionID, sandboxPath);
+  state.freeSandboxes.push({ path: sandboxPath, identity });
 }
 
 async function removeOwnedSandbox(state, sessionID) {

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -3483,6 +3483,15 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
                 const hooks = await plugin.server({});
                 await hooks.config({});
 
+                // Register main-1 so the deletion handler can classify it as
+                // a KNOWN main session — unknown deletions must not drain.
+                await hooks.event({
+                  event: {
+                    type: "session.updated",
+                    properties: { info: { id: "main-1" } },
+                  },
+                });
+
                 const leases = {};
                 for (const sessionID of ["child-1", "child-2"]) {
                   await hooks.event({
@@ -3513,6 +3522,12 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
                     properties: { info: { id: "main-1" } },
                   },
                 });
+
+                // Drain removal is detached (/bin/rm), so poll for it.
+                for (let attempt = 0; attempt < 200; attempt += 1) {
+                  if (!fs.existsSync(leases["child-1"])) break;
+                  await new Promise((resolve) => setTimeout(resolve, 25));
+                }
 
                 console.log(JSON.stringify({
                   pooledExists: fs.existsSync(leases["child-1"]),
@@ -3775,6 +3790,208 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
 
         self.assertTrue(result["pooledExists"])
         self.assertFalse(result["deletedExists"])
+
+    def test_stale_idle_with_inflight_bash_does_not_pool_the_sandbox(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=pool-stale-idle"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                await hooks.event({
+                  event: {
+                    type: "session.updated",
+                    properties: { info: { id: "child-1", parentID: "main-1" } },
+                  },
+                });
+                const first = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-1" },
+                  first,
+                );
+                const firstSandbox = path.dirname(first.env.SANDBOX_DERIVED_DATA);
+
+                // A command is in flight when a delayed (stale) idle for the
+                // re-prompted session is finally processed: the release must
+                // be skipped, or another session could lease a sandbox the
+                // running build is writing to.
+                await hooks["tool.execute.before"](
+                  { tool: "bash", sessionID: "child-1" },
+                  { args: { command: "true" } },
+                );
+                await hooks.event({
+                  event: {
+                    type: "session.idle",
+                    properties: { sessionID: "child-1" },
+                  },
+                });
+
+                await hooks.event({
+                  event: {
+                    type: "session.updated",
+                    properties: { info: { id: "child-2", parentID: "main-1" } },
+                  },
+                });
+                const second = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-2" },
+                  second,
+                );
+                const secondSandbox = path.dirname(second.env.SANDBOX_DERIVED_DATA);
+
+                // Once the command completes, the next idle releases as usual.
+                await hooks["tool.execute.after"](
+                  { tool: "bash", sessionID: "child-1" },
+                );
+                await hooks.event({
+                  event: {
+                    type: "session.idle",
+                    properties: { sessionID: "child-1" },
+                  },
+                });
+                await hooks.event({
+                  event: {
+                    type: "session.updated",
+                    properties: { info: { id: "child-3", parentID: "main-1" } },
+                  },
+                });
+                const third = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-3" },
+                  third,
+                );
+                const thirdSandbox = path.dirname(third.env.SANDBOX_DERIVED_DATA);
+
+                console.log(JSON.stringify({
+                  pooledWhileInflight: secondSandbox === firstSandbox,
+                  pooledAfterCompletion: thirdSandbox === firstSandbox,
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertFalse(result["pooledWhileInflight"])
+        self.assertTrue(result["pooledAfterCompletion"])
+
+    def test_session_created_event_registers_parentage(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=pool-created"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                const sandboxes = {};
+                for (const sessionID of ["child-1", "child-2"]) {
+                  await hooks.event({
+                    event: {
+                      type: "session.created",
+                      properties: { info: { id: sessionID, parentID: "main-1" } },
+                    },
+                  });
+                }
+
+                const first = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-1" },
+                  first,
+                );
+                sandboxes["child-1"] = path.dirname(first.env.SANDBOX_DERIVED_DATA);
+
+                await hooks.event({
+                  event: {
+                    type: "session.idle",
+                    properties: { sessionID: "child-1" },
+                  },
+                });
+
+                const second = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-2" },
+                  second,
+                );
+                sandboxes["child-2"] = path.dirname(second.env.SANDBOX_DERIVED_DATA);
+
+                console.log(JSON.stringify({
+                  reused: sandboxes["child-1"] === sandboxes["child-2"],
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertTrue(result["reused"])
+
+    def test_partial_session_update_keeps_child_parentage(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=pool-partial-update"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                await hooks.event({
+                  event: {
+                    type: "session.updated",
+                    properties: { info: { id: "child-1", parentID: "main-1" } },
+                  },
+                });
+                // A later payload without parentID must not downgrade the
+                // known child to a main session.
+                await hooks.event({
+                  event: {
+                    type: "session.updated",
+                    properties: { info: { id: "child-1" } },
+                  },
+                });
+
+                const first = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-1" },
+                  first,
+                );
+                const firstSandbox = path.dirname(first.env.SANDBOX_DERIVED_DATA);
+
+                await hooks.event({
+                  event: {
+                    type: "session.idle",
+                    properties: { sessionID: "child-1" },
+                  },
+                });
+
+                await hooks.event({
+                  event: {
+                    type: "session.updated",
+                    properties: { info: { id: "child-2", parentID: "main-1" } },
+                  },
+                });
+                const second = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-2" },
+                  second,
+                );
+                const secondSandbox = path.dirname(second.env.SANDBOX_DERIVED_DATA);
+
+                console.log(JSON.stringify({
+                  released: secondSandbox === firstSandbox,
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertTrue(result["released"])
 
 
 if __name__ == "__main__":

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -3411,6 +3411,65 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
 
         self.assertEqual(result["previous"], result["returningSandbox"])
 
+    def test_invalid_pool_entries_are_discarded_on_lease(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=pool-discard"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                await hooks.event({
+                  event: {
+                    type: "session.updated",
+                    properties: { info: { id: "child-1", parentID: "main-1" } },
+                  },
+                });
+                const first = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-1" },
+                  first,
+                );
+                const firstSandbox = path.dirname(first.env.SANDBOX_DERIVED_DATA);
+
+                await hooks.event({
+                  event: {
+                    type: "session.idle",
+                    properties: { sessionID: "child-1" },
+                  },
+                });
+
+                // Replace the pooled directory behind the pool's back: same
+                // path, new inode. Identity revalidation must reject it and
+                // the next lease must fall through to a fresh directory.
+                fs.rmSync(firstSandbox, { recursive: true, force: true });
+                fs.mkdirSync(firstSandbox, { mode: 0o700 });
+
+                await hooks.event({
+                  event: {
+                    type: "session.updated",
+                    properties: { info: { id: "child-2", parentID: "main-1" } },
+                  },
+                });
+                const second = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-2" },
+                  second,
+                );
+                const secondSandbox = path.dirname(second.env.SANDBOX_DERIVED_DATA);
+
+                console.log(JSON.stringify({ firstSandbox, secondSandbox }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertNotEqual(result["firstSandbox"], result["secondSandbox"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -3588,6 +3588,56 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
 
         self.assertTrue(result["reusedExists"])
 
+    def test_plugin_dispose_removes_pooled_sandboxes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=pool-dispose"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                await hooks.event({
+                  event: {
+                    type: "session.updated",
+                    properties: { info: { id: "child-1", parentID: "main-1" } },
+                  },
+                });
+                const output = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-1" },
+                  output,
+                );
+                const sandbox = path.dirname(output.env.SANDBOX_DERIVED_DATA);
+
+                // Release to the pool, then dispose: the pooled sandbox must
+                // be cleaned up even though no session owns it anymore.
+                await hooks.event({
+                  event: {
+                    type: "session.idle",
+                    properties: { sessionID: "child-1" },
+                  },
+                });
+                await hooks.dispose();
+
+                for (let attempt = 0; attempt < 100; attempt += 1) {
+                  if (!fs.existsSync(sandbox)) break;
+                  await new Promise((resolve) => setTimeout(resolve, 5));
+                }
+
+                console.log(JSON.stringify({
+                  sandboxExists: fs.existsSync(sandbox),
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertFalse(result["sandboxExists"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -3203,6 +3203,214 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
 
         self.assertFalse(result["staleExists"])
 
+    def test_subagent_sandbox_is_reused_after_idle(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=pool-reuse"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                await hooks.event({
+                  event: {
+                    type: "session.updated",
+                    properties: { info: { id: "child-1", parentID: "main-1" } },
+                  },
+                });
+                const first = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-1" },
+                  first,
+                );
+                const firstSandbox = path.dirname(first.env.SANDBOX_DERIVED_DATA);
+
+                await hooks.event({
+                  event: {
+                    type: "session.idle",
+                    properties: { sessionID: "child-1" },
+                  },
+                });
+
+                await hooks.event({
+                  event: {
+                    type: "session.updated",
+                    properties: { info: { id: "child-2", parentID: "main-1" } },
+                  },
+                });
+                const second = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-2" },
+                  second,
+                );
+                const secondSandbox = path.dirname(second.env.SANDBOX_DERIVED_DATA);
+
+                const root = path.dirname(firstSandbox);
+                const entries = fs
+                  .readdirSync(root)
+                  .filter((name) => !name.startsWith("."));
+
+                console.log(JSON.stringify({
+                  firstSandbox,
+                  secondSandbox,
+                  entries,
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertEqual(result["firstSandbox"], result["secondSandbox"])
+        self.assertEqual(len(result["entries"]), 1)
+
+    def test_parallel_subagents_get_distinct_sandboxes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=pool-parallel"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                const sandboxes = [];
+                for (const sessionID of ["child-1", "child-2"]) {
+                  await hooks.event({
+                    event: {
+                      type: "session.updated",
+                      properties: { info: { id: sessionID, parentID: "main-1" } },
+                    },
+                  });
+                  const output = { env: {} };
+                  await hooks["shell.env"](
+                    { cwd: process.cwd(), sessionID },
+                    output,
+                  );
+                  sandboxes.push(path.dirname(output.env.SANDBOX_DERIVED_DATA));
+                }
+
+                console.log(JSON.stringify({ sandboxes }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertNotEqual(result["sandboxes"][0], result["sandboxes"][1])
+
+    def test_main_session_idle_does_not_release_its_sandbox(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=pool-main-idle"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                await hooks.event({
+                  event: {
+                    type: "session.updated",
+                    properties: { info: { id: "main-1" } },
+                  },
+                });
+                const main = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "main-1" },
+                  main,
+                );
+                const mainSandbox = path.dirname(main.env.SANDBOX_DERIVED_DATA);
+
+                await hooks.event({
+                  event: {
+                    type: "session.idle",
+                    properties: { sessionID: "main-1" },
+                  },
+                });
+
+                await hooks.event({
+                  event: {
+                    type: "session.updated",
+                    properties: { info: { id: "child-1", parentID: "main-1" } },
+                  },
+                });
+                const child = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-1" },
+                  child,
+                );
+                const childSandbox = path.dirname(child.env.SANDBOX_DERIVED_DATA);
+
+                console.log(JSON.stringify({ mainSandbox, childSandbox }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertNotEqual(result["mainSandbox"], result["childSandbox"])
+
+    def test_returning_subagent_prefers_its_previous_sandbox(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=pool-prefer"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                const leases = {};
+                for (const sessionID of ["child-1", "child-2"]) {
+                  await hooks.event({
+                    event: {
+                      type: "session.updated",
+                      properties: { info: { id: sessionID, parentID: "main-1" } },
+                    },
+                  });
+                  const output = { env: {} };
+                  await hooks["shell.env"](
+                    { cwd: process.cwd(), sessionID },
+                    output,
+                  );
+                  leases[sessionID] = path.dirname(output.env.SANDBOX_DERIVED_DATA);
+                }
+
+                // Release child-2 first, then child-1, so child-1's sandbox
+                // sits on top of the LIFO stack when child-2 returns.
+                for (const sessionID of ["child-2", "child-1"]) {
+                  await hooks.event({
+                    event: {
+                      type: "session.idle",
+                      properties: { sessionID },
+                    },
+                  });
+                }
+
+                const returning = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-2" },
+                  returning,
+                );
+                const returningSandbox = path.dirname(
+                  returning.env.SANDBOX_DERIVED_DATA,
+                );
+
+                console.log(JSON.stringify({
+                  previous: leases["child-2"],
+                  returningSandbox,
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertEqual(result["previous"], result["returningSandbox"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -3638,6 +3638,144 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
 
         self.assertFalse(result["sandboxExists"])
 
+    def test_reprompted_subagent_does_not_share_a_taken_sandbox(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=pool-reprompt"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                await hooks.event({
+                  event: {
+                    type: "session.updated",
+                    properties: { info: { id: "child-1", parentID: "main-1" } },
+                  },
+                });
+                const first = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-1" },
+                  first,
+                );
+                const firstSandbox = path.dirname(first.env.SANDBOX_DERIVED_DATA);
+
+                await hooks.event({
+                  event: {
+                    type: "session.idle",
+                    properties: { sessionID: "child-1" },
+                  },
+                });
+
+                await hooks.event({
+                  event: {
+                    type: "session.updated",
+                    properties: { info: { id: "child-2", parentID: "main-1" } },
+                  },
+                });
+                const second = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-2" },
+                  second,
+                );
+                const secondSandbox = path.dirname(second.env.SANDBOX_DERIVED_DATA);
+
+                // child-2 took child-1's pooled sandbox. A re-prompted
+                // child-1 hits the fresh-path fallback with an empty pool
+                // and must NOT be handed the sandbox child-2 is leasing.
+                const reprompted = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-1" },
+                  reprompted,
+                );
+                const repromptedSandbox = path.dirname(
+                  reprompted.env.SANDBOX_DERIVED_DATA,
+                );
+
+                // Deleting child-1 must remove only child-1's own sandbox,
+                // never the one child-2 is leasing.
+                await hooks.event({
+                  event: {
+                    type: "session.deleted",
+                    properties: { info: { id: "child-1", parentID: "main-1" } },
+                  },
+                });
+
+                console.log(JSON.stringify({
+                  reused: secondSandbox === firstSandbox,
+                  shared: repromptedSandbox === secondSandbox,
+                  child2SandboxExists: fs.existsSync(secondSandbox),
+                  repromptedSandboxExists: fs.existsSync(repromptedSandbox),
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertTrue(result["reused"])
+        self.assertFalse(result["shared"])
+        self.assertTrue(result["child2SandboxExists"])
+        self.assertFalse(result["repromptedSandboxExists"])
+
+    def test_subagent_deletion_does_not_drain_the_free_pool(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=pool-child-delete"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                const leases = {};
+                for (const sessionID of ["child-1", "child-2"]) {
+                  await hooks.event({
+                    event: {
+                      type: "session.updated",
+                      properties: { info: { id: sessionID, parentID: "main-1" } },
+                    },
+                  });
+                  const output = { env: {} };
+                  await hooks["shell.env"](
+                    { cwd: process.cwd(), sessionID },
+                    output,
+                  );
+                  leases[sessionID] = path.dirname(output.env.SANDBOX_DERIVED_DATA);
+                }
+
+                // child-1's sandbox sits in the free pool when the OTHER
+                // subagent is deleted: only a MAIN session's deletion may
+                // drain the pool.
+                await hooks.event({
+                  event: {
+                    type: "session.idle",
+                    properties: { sessionID: "child-1" },
+                  },
+                });
+                await hooks.event({
+                  event: {
+                    type: "session.deleted",
+                    properties: { info: { id: "child-2", parentID: "main-1" } },
+                  },
+                });
+
+                console.log(JSON.stringify({
+                  pooledExists: fs.existsSync(leases["child-1"]),
+                  deletedExists: fs.existsSync(leases["child-2"]),
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertTrue(result["pooledExists"])
+        self.assertFalse(result["deletedExists"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -3470,6 +3470,124 @@ class OpenCodePluginRuntimeTests(unittest.TestCase):
 
         self.assertNotEqual(result["firstSandbox"], result["secondSandbox"])
 
+    def test_main_session_deletion_drains_the_free_pool(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=pool-drain"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                const leases = {};
+                for (const sessionID of ["child-1", "child-2"]) {
+                  await hooks.event({
+                    event: {
+                      type: "session.updated",
+                      properties: { info: { id: sessionID, parentID: "main-1" } },
+                    },
+                  });
+                  const output = { env: {} };
+                  await hooks["shell.env"](
+                    { cwd: process.cwd(), sessionID },
+                    output,
+                  );
+                  leases[sessionID] = path.dirname(output.env.SANDBOX_DERIVED_DATA);
+                }
+
+                // child-1 finishes (its sandbox is pooled); child-2 stays live.
+                await hooks.event({
+                  event: {
+                    type: "session.idle",
+                    properties: { sessionID: "child-1" },
+                  },
+                });
+
+                await hooks.event({
+                  event: {
+                    type: "session.deleted",
+                    properties: { info: { id: "main-1" } },
+                  },
+                });
+
+                console.log(JSON.stringify({
+                  pooledExists: fs.existsSync(leases["child-1"]),
+                  leasedExists: fs.existsSync(leases["child-2"]),
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertFalse(result["pooledExists"])
+        self.assertTrue(result["leasedExists"])
+
+    def test_deleting_a_finished_subagent_keeps_the_reused_sandbox(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_node(
+                """
+                import fs from "node:fs";
+                import path from "node:path";
+
+                const plugin = (await import(
+                  "./XcodeBuildTools/opencode-plugin.js?test=pool-no-double-free"
+                )).default;
+                const hooks = await plugin.server({});
+                await hooks.config({});
+
+                await hooks.event({
+                  event: {
+                    type: "session.updated",
+                    properties: { info: { id: "child-1", parentID: "main-1" } },
+                  },
+                });
+                const first = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-1" },
+                  first,
+                );
+
+                await hooks.event({
+                  event: {
+                    type: "session.idle",
+                    properties: { sessionID: "child-1" },
+                  },
+                });
+
+                await hooks.event({
+                  event: {
+                    type: "session.updated",
+                    properties: { info: { id: "child-2", parentID: "main-1" } },
+                  },
+                });
+                const second = { env: {} };
+                await hooks["shell.env"](
+                  { cwd: process.cwd(), sessionID: "child-2" },
+                  second,
+                );
+                const reused = path.dirname(second.env.SANDBOX_DERIVED_DATA);
+
+                // Deleting the finished child must not touch the sandbox that
+                // child-2 is now leasing.
+                await hooks.event({
+                  event: {
+                    type: "session.deleted",
+                    properties: { info: { id: "child-1", parentID: "main-1" } },
+                  },
+                });
+
+                console.log(JSON.stringify({
+                  reusedExists: fs.existsSync(reused),
+                }));
+                """,
+                {"TMPDIR": tmpdir},
+            )
+
+        self.assertTrue(result["reusedExists"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

In the OpenCode plugin path, every session that runs a shell command gets its own Xcode build sandbox — and OpenCode subagents are child sessions with fresh session IDs. Each subagent that compiled created a new multi-GB DerivedData/SPM sandbox that was only removed at plugin dispose, so disk usage grew monotonically with the number of subagents spawned.

## Solution

A per-plugin-instance lease pool in `common/opencode-plugin.js` (synced to all plugin packages):

- **Release:** child (subagent) sessions — identified via `parentID` tracked from `session.created`/`session.updated` events — release their sandbox to a free pool on `session.idle`. Main sessions never release on idle.
- **Lease:** sessions lease in `shell.env`, preferring the sandbox they held before, then the most recently freed pool entry (revalidated with the existing identity checks; invalid entries discarded), then a fresh directory. The fresh-path fallback disambiguates with a random suffix if the deterministic name is another session's live sandbox — pooling decouples directory names from sessions, so the old deterministic name is no longer collision-free.
- **Reclaim:** deleting a main session drains the free pool from disk (via the existing quarantine + remove machinery, extracted into a shared `quarantineAndRemoveSandbox` helper); plugin dispose also removes pooled sandboxes.

Disk usage is now bounded by peak subagent concurrency instead of total subagent count, and reused sandboxes keep warm DerivedData/SPM caches (directories are never renamed, so embedded absolute paths stay valid).

## Testing

Seven new integration tests in `tests/test_opencode_plugin.py` (reuse-after-idle, parallel isolation, main-idle no-release, previous-sandbox preference, invalid-entry discard, drain-on-main-deletion with live-lease survival, subagent-deletion drain-gate pin, no-double-free, dispose pool cleanup, re-prompted-subagent collision regression). Full suite: 97/97 passing; `scripts/sync-plugin-common.py --check` clean.

No version bumps in this PR — release bumps/tags follow the `update-plugin` flow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)